### PR TITLE
Cursor/supabase integration phase 1 bdc7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist
 .env.production
 .env.staging
 .env*.local
+
+# Embedded / local clone (do not commit)
+cursor-default/

--- a/GITHUB_PAGES_DEPLOY.md
+++ b/GITHUB_PAGES_DEPLOY.md
@@ -1,0 +1,195 @@
+## StatKeeper – GitHub Pages Deployment
+
+This guide shows how to deploy StatKeeper to **GitHub Pages** as a project site at `https://username.github.io/cursor-default/` using **GitHub Actions**.
+
+Replace `username` with your actual GitHub username.
+
+---
+
+## 1. One‑time project configuration
+
+### 1.1 Ensure Vite base path is set
+
+In `vite.config.ts`, Vite should build with the project path `/cursor-default/`, and the PWA `scope` / `start_url` should also use `/cursor-default/`:
+
+```ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { VitePWA } from 'vite-plugin-pwa'
+
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/cursor-default/' : '/',
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['vite.svg'],
+      manifest: {
+        name: 'StatKeeper',
+        short_name: 'StatKeeper',
+        description: 'Track sports game stats in real time',
+        theme_color: '#1e293b',
+        background_color: '#f8fafc',
+        display: 'standalone',
+        orientation: 'portrait',
+        scope: '/cursor-default/',
+        start_url: '/cursor-default/',
+        icons: [
+          {
+            src: 'pwa-192x192.png',
+            sizes: '192x192',
+            type: 'image/png',
+          },
+          {
+            src: 'pwa-512x512.png',
+            sizes: '512x512',
+            type: 'image/png',
+          },
+          {
+            src: 'pwa-512x512.png',
+            sizes: '512x512',
+            type: 'image/png',
+            purpose: 'any maskable',
+          },
+        ],
+      },
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'google-fonts-cache',
+              expiration: { maxEntries: 10, maxAgeSeconds: 60 * 60 * 24 * 365 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+        ],
+      },
+    }),
+  ],
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+  },
+}))
+```
+
+> If your repo name is not `cursor-default`, change `/cursor-default/` to `/<your-repo-name>/` everywhere above.
+
+### 1.2 Add the GitHub Actions workflow
+
+Create `.github/workflows/deploy.yml` with the following contents:
+
+```yaml
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+Commit and push:
+
+```bash
+git add vite.config.ts .github/workflows/deploy.yml GITHUB_PAGES_DEPLOY.md
+git commit -m "Set up GitHub Pages deployment"
+git push
+```
+
+---
+
+## 2. Configure GitHub Pages in the repo
+
+1. Go to your GitHub repo in the browser.
+2. Navigate to **Settings → Pages**.
+3. Under **Source**, choose **GitHub Actions** (not a branch).
+4. Save the settings.
+
+GitHub will now expect a workflow (like `deploy.yml`) to publish the site.
+
+---
+
+## 3. Trigger a deployment
+
+1. Push to the `main` branch (or use **Actions → Deploy to GitHub Pages → Run workflow**).
+2. Open the **Actions** tab and wait for the **Deploy to GitHub Pages** workflow to finish successfully.
+3. Return to **Settings → Pages** to see the published URL.
+
+For a project site it will be:
+
+- `https://username.github.io/cursor-default/`
+
+---
+
+## 4. Test the deployed app
+
+1. Open the Pages URL in your browser.
+2. Confirm:
+   - The app loads and routes work (URLs like `https://username.github.io/cursor-default/#/game`).
+   - Assets (JS/CSS) load without 404s.
+3. On your phone:
+   - Open the same URL.
+   - Use **Add to Home Screen** / **Install app** in the browser menu to install the PWA.
+
+After this, every push to `main` will automatically rebuild and redeploy StatKeeper to GitHub Pages.
+
+---
+
+## Notes about local URLs
+
+- `pnpm dev` will run at `http://localhost:5173/` (no `/cursor-default/` prefix).
+- `pnpm preview` serves the production build, so open `http://localhost:4173/cursor-default/`.
+

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ The dev server starts at `http://localhost:5173`.
    - `supabase/migrations/005_team_members_rls_recursion_cycle_fix.sql`
    - `supabase/migrations/006_teams_insert_policy_fix.sql`
    - `supabase/migrations/007_games_last_opened_preference.sql`
-   > If you already applied `001` through `006`, do **not** rerun them — only run `007` to enable cross-device deterministic active-game resume preference.
+   - `supabase/migrations/008_player_checkouts.sql`
+   - `supabase/migrations/009_stat_corrections.sql`
+   - `supabase/migrations/010_resolved_stats_rpcs.sql`
+   > If you already applied earlier migrations, run only the new ones (e.g. only `008`–`010` for Phase 3 player checkout and resolved stats).
    > If migrations are missing or outdated, the in-app scoreboard will show a cloud sync warning/error status.
 4. Restart the dev server — the auth page will appear
 
@@ -133,7 +136,11 @@ supabase/
     ├── 003_games_stats.sql
     ├── 004_team_members_rls_fix.sql
     ├── 005_team_members_rls_recursion_cycle_fix.sql
-    └── 006_teams_insert_policy_fix.sql
+    ├── 006_teams_insert_policy_fix.sql
+    ├── 007_games_last_opened_preference.sql
+    ├── 008_player_checkouts.sql
+    ├── 009_stat_corrections.sql
+    └── 010_resolved_stats_rpcs.sql
 
 docs/
 └── INTEGRATION_PLAN.md    # Full architecture, data model, and phased roadmap
@@ -147,7 +154,7 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 |---|---|---|
 | 1 | **Supabase Foundation** — auth, cloud DB, RLS, migrations, auth UI | In Progress |
 | 2 | **Cloud Stat Tracking** — persistent teams/rosters, games saved to cloud | Planned |
-| 3 | **Season Stats + Multi-Parent** — player checkout, admin corrections, leaderboards | Planned |
+| 3 | **Season Stats + Multi-Parent** — player checkout, admin corrections, leaderboards | In Progress |
 | 4 | **Capacitor + Polish** — native Android/iOS builds, push notifications, exports | Planned |
 | 5 | **Sports Engine** — API integration (deferred; requires developer access) | Deferred |
 
@@ -167,12 +174,13 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 - [x] Cloud game history page with finalize flow and final-game read-only summary behavior
 - [x] Snapshot-based offline queue with reconnect-triggered cloud sync replay
 - [x] Integration plan with multi-parent checkout model and admin corrections
+- [x] Phase 3 DB: `player_checkouts`, `stat_corrections`, `get_game_stats_resolved`, `get_season_stats_resolved` (migrations 008–010)
 
 ### What's Next
 
-- [ ] Complete cloud-first GameContext flows (broader history hydration policies)
-- [ ] Expand offline queueing to durable/background sync beyond in-session snapshot replay
-- [ ] Team collaboration roles/invites and multi-parent workflows
+- [ ] Player checkout UI (pre-game claim players) and Game Summary use of resolved stats RPC
+- [ ] Admin stat review/corrections UI and review queue for averaged stats
+- [ ] Team collaboration invites and multi-parent workflows
 - [ ] Per-sport stat refinements and additional stats
 
 ### Mobile Native (Capacitor)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import SportSelect from './pages/SportSelect'
 import GameSetup from './pages/GameSetup'
 import PlayerSetup from './pages/PlayerSetup'
 import GameTracker from './pages/GameTracker'
+import GameCheckout from './pages/GameCheckout'
 import GameSummary from './pages/GameSummary'
 import Admin from './pages/Admin'
 import Teams from './pages/Teams'
@@ -37,6 +38,7 @@ function AppRoutes() {
           <Route path="/" element={<SportSelect />} />
           <Route path="/setup" element={<GameSetup />} />
           <Route path="/players" element={<PlayerSetup />} />
+          <Route path="/checkout" element={<GameCheckout />} />
           <Route path="/game" element={<GameTracker />} />
           <Route path="/summary" element={<GameSummary />} />
           <Route path="/admin" element={<Admin />} />

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -382,6 +382,8 @@ function loadState(): GameState {
 interface GameContextType {
   state: GameState
   dispatch: React.Dispatch<GameAction>
+  /** Trigger an immediate cloud sync (e.g. when leaving Game Tracker). */
+  flushCloudSync: () => void
 }
 
 const GameContext = createContext<GameContextType | null>(null)
@@ -609,6 +611,14 @@ export function GameProvider({ children }: { children: ReactNode }) {
     }
   }, [isConfigured, isOnline, userId])
 
+  const flushCloudSync = useCallback(() => {
+    if (debounceTimerRef.current !== null) {
+      window.clearTimeout(debounceTimerRef.current)
+      debounceTimerRef.current = null
+    }
+    void runCloudSync()
+  }, [runCloudSync])
+
   const syncFingerprint = buildSyncFingerprint(state)
   const shouldSync = canSyncState(state, isConfigured, userId, isOnline)
 
@@ -633,7 +643,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
 
     debounceTimerRef.current = window.setTimeout(() => {
       void runCloudSync()
-    }, 300)
+    }, 150)
 
     return () => {
       if (debounceTimerRef.current !== null) {
@@ -644,7 +654,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
   }, [runCloudSync, shouldSync, syncFingerprint])
 
   return (
-    <GameContext.Provider value={{ state, dispatch }}>
+    <GameContext.Provider value={{ state, dispatch, flushCloudSync }}>
       {children}
     </GameContext.Provider>
   )

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -27,6 +27,27 @@ import { sports } from '../config/sports'
 
 const STORAGE_KEY = 'statkeeper_game'
 const CLOUD_RESUME_TARGETS_KEY = 'statkeeper_cloud_resume_targets'
+const PENDING_SYNC_KEY = 'statkeeper_pending_sync'
+
+function getPendingSyncFlag(): boolean {
+  try {
+    return localStorage.getItem(PENDING_SYNC_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function setPendingSyncFlag(pending: boolean): void {
+  try {
+    if (pending) {
+      localStorage.setItem(PENDING_SYNC_KEY, '1')
+    } else {
+      localStorage.removeItem(PENDING_SYNC_KEY)
+    }
+  } catch {
+    // ignore
+  }
+}
 
 const CLOUD_SYNC_STATUSES: CloudSyncStatus[] = [
   'offline',
@@ -526,6 +547,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
     if (!canSyncState(stateRef.current, isConfigured, userId, isOnline)) {
       if (!isOnline && hasSyncPrereqs(stateRef.current, isConfigured, userId)) {
         pendingSyncRef.current = true
+        setPendingSyncFlag(true)
       }
       return
     }
@@ -553,6 +575,7 @@ export function GameProvider({ children }: { children: ReactNode }) {
           })
           if (!isOnline && hasSyncPrereqs(snapshot, isConfigured, snapshotUserId)) {
             pendingSyncRef.current = true
+            setPendingSyncFlag(true)
           }
           break
         }
@@ -592,10 +615,12 @@ export function GameProvider({ children }: { children: ReactNode }) {
           setResumeTarget(snapshotUserId, synced.gameId)
         }
         pendingSyncRef.current = false
+        setPendingSyncFlag(false)
       } while (queueAnotherSyncRef.current)
     } catch (error) {
       if (isLikelyNetworkError(error)) {
         pendingSyncRef.current = true
+        setPendingSyncFlag(true)
         dispatch({
           type: 'SET_CLOUD_SYNC_STATE',
           cloudSync: {
@@ -631,8 +656,16 @@ export function GameProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!isOnline && hasSyncPrereqs(stateRef.current, isConfigured, userId)) {
       pendingSyncRef.current = true
+      setPendingSyncFlag(true)
     }
   }, [isConfigured, isOnline, syncFingerprint, userId])
+
+  // Restore durable pending-sync flag on load so we sync after reopen when user had been offline
+  useEffect(() => {
+    if (isConfigured && userId && isOnline && getPendingSyncFlag()) {
+      pendingSyncRef.current = true
+    }
+  }, [isConfigured, isOnline, userId])
 
   useEffect(() => {
     if (!isOnline || !pendingSyncRef.current) return

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -438,7 +438,13 @@ export function GameProvider({ children }: { children: ReactNode }) {
 
     let cancelled = false
     const hydrateFromCloud = async () => {
-      if (stateRef.current.sport && stateRef.current.gameInfo) {
+      // Cloud-first: only skip hydration when there is unsynced local progress
+      // (game in progress that has never been synced - no gameId yet).
+      const hasUnsyncedLocal =
+        stateRef.current.sport &&
+        stateRef.current.gameInfo &&
+        !stateRef.current.cloudSync.gameId
+      if (hasUnsyncedLocal) {
         hydratedUserRef.current = userId
         return
       }

--- a/src/pages/GameCheckout.tsx
+++ b/src/pages/GameCheckout.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useState, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useGame } from '../context/GameContext'
+import { useAuth } from '../context/AuthContext'
+import { supabase } from '../lib/supabase'
+
+interface CheckoutRow {
+  player_id: string
+  user_id: string
+  is_primary: boolean
+}
+
+export default function GameCheckout() {
+  const navigate = useNavigate()
+  const { state, flushCloudSync } = useGame()
+  const { user, isConfigured } = useAuth()
+  const gameId = state.cloudSync.gameId
+  const playerIdMap = state.cloudSync.playerIdMap
+  const { sport, gameInfo, players } = state
+  const syncTriggeredRef = useRef(false)
+
+  const [checkouts, setCheckouts] = useState<CheckoutRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [toggling, setToggling] = useState<string | null>(null)
+
+  const myId = user?.id ?? null
+
+  // If we have no gameId yet (first time), trigger sync so game is created
+  useEffect(() => {
+    if (!isConfigured || !user || gameId) return
+    if (syncTriggeredRef.current) return
+    if (!gameInfo || players.length === 0) return
+    syncTriggeredRef.current = true
+    flushCloudSync()
+  }, [isConfigured, user, gameId, gameInfo, players.length, flushCloudSync])
+
+  useEffect(() => {
+    const client = supabase
+    if (!isConfigured || !gameId || !client) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    const load = async () => {
+      setError(null)
+      const { data, error: e } = await client
+        .from('player_checkouts')
+        .select('player_id, user_id, is_primary')
+        .eq('game_id', gameId)
+
+      if (cancelled) return
+      if (e) {
+        setError(e.message)
+        setLoading(false)
+        return
+      }
+      setCheckouts((data ?? []) as CheckoutRow[])
+      setLoading(false)
+    }
+
+    void load()
+    return () => { cancelled = true }
+  }, [isConfigured, gameId])
+
+  const isCheckedOutByMe = (remotePlayerId: string) =>
+    checkouts.some(c => c.player_id === remotePlayerId && c.user_id === myId)
+
+  const claimedByOther = (remotePlayerId: string) => {
+    const c = checkouts.find(x => x.player_id === remotePlayerId && x.is_primary && x.user_id !== myId)
+    return c ? 'Someone else' : null
+  }
+
+  const handleToggle = async (localPlayerId: string) => {
+    if (!supabase || !gameId || !myId) return
+    const remotePlayerId = playerIdMap[localPlayerId] ?? localPlayerId
+
+    setToggling(localPlayerId)
+    setError(null)
+
+    const checked = isCheckedOutByMe(remotePlayerId)
+
+    if (checked) {
+      const { error: e } = await supabase
+        .from('player_checkouts')
+        .delete()
+        .eq('game_id', gameId)
+        .eq('player_id', remotePlayerId)
+        .eq('user_id', myId)
+
+      if (!e) {
+        setCheckouts(prev => prev.filter(c => !(c.player_id === remotePlayerId && c.user_id === myId)))
+      } else {
+        setError(e.message)
+      }
+    } else {
+      const existing = checkouts.some(c => c.player_id === remotePlayerId)
+      const { error: e } = await supabase
+        .from('player_checkouts')
+        .insert({
+          game_id: gameId,
+          player_id: remotePlayerId,
+          user_id: myId,
+          is_primary: !existing,
+        })
+
+      if (!e) {
+        setCheckouts(prev => [...prev, { player_id: remotePlayerId, user_id: myId, is_primary: !existing }])
+      } else {
+        setError(e.message)
+      }
+    }
+
+    setToggling(null)
+  }
+
+  const handleStartTracking = () => {
+    navigate('/game')
+  }
+
+  if (!sport || !gameInfo || players.length === 0) {
+    navigate('/')
+    return null
+  }
+
+  if (!isConfigured) {
+    navigate('/game')
+    return null
+  }
+
+  if (!gameId) {
+    return (
+      <div className="min-h-screen flex flex-col bg-slate-50 items-center justify-center px-4">
+        <p className="text-slate-500 animate-pulse">Preparing game…</p>
+        <p className="text-xs text-slate-400 mt-2">Sync in progress</p>
+        <button
+          type="button"
+          onClick={() => navigate('/game')}
+          className="mt-4 text-sm text-blue-600"
+        >
+          Skip to Game →
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-slate-50">
+      <header className={`bg-gradient-to-r ${sport.theme.gradient} text-white px-4 py-4`}>
+        <div className="max-w-lg mx-auto">
+          <button
+            onClick={() => navigate('/players')}
+            className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center mb-3
+                       active:scale-90 transition-transform"
+          >
+            ←
+          </button>
+          <h1 className="text-lg font-bold">Who are you tracking?</h1>
+          <p className="text-sm opacity-80 mt-1">
+            {gameInfo.teamName} vs {gameInfo.opponentName}
+          </p>
+          <p className="text-xs opacity-60 mt-1">
+            Select the players you will record stats for. Others can track the same game.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex-1 px-4 py-6 max-w-lg mx-auto w-full">
+        {error && (
+          <div className="card bg-red-50 border-red-200 text-red-700 text-sm mb-4">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="card text-slate-500 animate-pulse">Loading...</div>
+        ) : (
+          <div className="space-y-2 mb-6">
+            {players.map(player => {
+              const remoteId = playerIdMap[player.id] ?? player.id
+              const mine = isCheckedOutByMe(remoteId)
+              const other = claimedByOther(remoteId)
+
+              return (
+                <button
+                  key={player.id}
+                  type="button"
+                  onClick={() => { void handleToggle(player.id) }}
+                  disabled={toggling === player.id}
+                  className={`card w-full flex items-center justify-between py-3 text-left transition-colors
+                    ${mine ? 'ring-2 ring-blue-400 bg-blue-50/50' : 'hover:bg-slate-50'}`}
+                >
+                  <div className="flex items-center gap-3">
+                    <span className={`
+                      ${sport.theme.bg} text-white w-10 h-10 rounded-full
+                      flex items-center justify-center font-bold text-sm
+                    `}>
+                      {player.number || '—'}
+                    </span>
+                    <div>
+                      <p className="font-medium text-slate-700">{player.name}</p>
+                      {other && (
+                        <p className="text-xs text-slate-500">Primary: {other}</p>
+                      )}
+                    </div>
+                  </div>
+                  <span className="text-2xl">{mine ? '✓' : '○'}</span>
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        <button
+          onClick={handleStartTracking}
+          className="btn-primary w-full"
+        >
+          Start Tracking →
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/GameSummary.tsx
+++ b/src/pages/GameSummary.tsx
@@ -1,9 +1,12 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGame } from '../context/GameContext'
 import { computePlayerScore, computeCategoryTotal } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
+
+/** Resolved stats by remote player id -> stat id -> value (for final cloud games) */
+type ResolvedStatsMap = Record<string, Record<string, number>>
 
 export default function GameSummary() {
   const navigate = useNavigate()
@@ -12,14 +15,53 @@ export default function GameSummary() {
   const { sport, gameInfo, players, opponentScore } = state
   const [finalizing, setFinalizing] = useState(false)
   const [finalizeError, setFinalizeError] = useState<string | null>(null)
+  const [resolvedStats, setResolvedStats] = useState<ResolvedStatsMap | null>(null)
+
+  const isFinalCloudGame = state.cloudSync.gameStatus === 'final'
+  const gameId = state.cloudSync.gameId
+  const playerIdMap = state.cloudSync.playerIdMap
+
+  useEffect(() => {
+    const client = supabase
+    if (!isFinalCloudGame || !gameId || !client) return
+
+    let cancelled = false
+    const load = async () => {
+      const { data, error } = await client.rpc('get_game_stats_resolved', {
+        p_game_id: gameId,
+      })
+
+      if (cancelled) return
+      if (error) return
+
+      const byPlayer: ResolvedStatsMap = {}
+      for (const row of (data ?? []) as Array<{ player_id: string; stat_id: string; value: number }>) {
+        if (!byPlayer[row.player_id]) byPlayer[row.player_id] = {}
+        byPlayer[row.player_id][row.stat_id] = row.value
+      }
+      setResolvedStats(byPlayer)
+    }
+
+    void load()
+    return () => { cancelled = true }
+  }, [isFinalCloudGame, gameId])
 
   if (!sport || !gameInfo) {
     navigate('/')
     return null
   }
 
+  const getPlayerStats = (playerId: string): Record<string, number> => {
+    const remoteId = playerIdMap[playerId] ?? playerId
+    const player = players.find(p => p.id === playerId)
+    if (isFinalCloudGame && resolvedStats && resolvedStats[remoteId]) {
+      return resolvedStats[remoteId]
+    }
+    return player?.stats ?? {}
+  }
+
   const teamScore = players.reduce(
-    (total, player) => total + computePlayerScore(sport, player.stats),
+    (total, player) => total + computePlayerScore(sport, getPlayerStats(player.id)),
     0
   )
 
@@ -27,7 +69,10 @@ export default function GameSummary() {
 
   const teamTotals: Record<string, number> = {}
   for (const statId of allStatIds) {
-    teamTotals[statId] = players.reduce((sum, p) => sum + (p.stats[statId] || 0), 0)
+    teamTotals[statId] = players.reduce(
+      (sum, p) => sum + (getPlayerStats(p.id)[statId] || 0),
+      0
+    )
   }
 
   const handleNewGame = () => {
@@ -35,7 +80,6 @@ export default function GameSummary() {
     navigate('/')
   }
 
-  const isFinalCloudGame = state.cloudSync.gameStatus === 'final'
   const canFinalizeCloudGame = Boolean(
     isConfigured && user && supabase && state.cloudSync.gameId && !isFinalCloudGame
   )
@@ -135,13 +179,14 @@ export default function GameSummary() {
                 </thead>
                 <tbody>
                   {players.map(player => {
+                    const stats = getPlayerStats(player.id)
                     const catTotal = category.showTotal
                       ? category.actions.some(a => a.pointValue)
                         ? category.actions.reduce(
-                            (sum, a) => sum + (player.stats[a.id] || 0) * (a.pointValue || 0),
+                            (sum, a) => sum + (stats[a.id] || 0) * (a.pointValue || 0),
                             0
                           )
-                        : computeCategoryTotal(category, player.stats)
+                        : computeCategoryTotal(category, stats)
                       : null
 
                     return (
@@ -152,7 +197,7 @@ export default function GameSummary() {
                         </td>
                         {category.actions.map(action => (
                           <td key={action.id} className="text-center py-2 px-2 tabular-nums">
-                            {player.stats[action.id] || 0}
+                            {stats[action.id] || 0}
                           </td>
                         ))}
                         {category.showTotal && (

--- a/src/pages/GameSummary.tsx
+++ b/src/pages/GameSummary.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGame } from '../context/GameContext'
 import { computePlayerScore, computeCategoryTotal } from '../config/sports'
@@ -16,35 +16,78 @@ export default function GameSummary() {
   const [finalizing, setFinalizing] = useState(false)
   const [finalizeError, setFinalizeError] = useState<string | null>(null)
   const [resolvedStats, setResolvedStats] = useState<ResolvedStatsMap | null>(null)
+  const [isTeamAdmin, setIsTeamAdmin] = useState(false)
+  const [reviewMode, setReviewMode] = useState(false)
+  const [correcting, setCorrecting] = useState<{
+    playerId: string
+    playerName: string
+    statId: string
+    statLabel: string
+    currentValue: number
+  } | null>(null)
+  const [correctValue, setCorrectValue] = useState('')
+  const [correctReason, setCorrectReason] = useState('')
+  const [correctError, setCorrectError] = useState<string | null>(null)
+  const [savingCorrection, setSavingCorrection] = useState(false)
+  const [resolvedKey, setResolvedKey] = useState(0)
 
   const isFinalCloudGame = state.cloudSync.gameStatus === 'final'
   const gameId = state.cloudSync.gameId
+  const teamId = state.cloudSync.teamId
   const playerIdMap = state.cloudSync.playerIdMap
 
-  useEffect(() => {
+  const loadResolved = useCallback(async () => {
     const client = supabase
-    if (!isFinalCloudGame || !gameId || !client) return
+    if (!gameId || !client) return null
+
+    const { data, error } = await client.rpc('get_game_stats_resolved', {
+      p_game_id: gameId,
+    })
+    if (error) return null
+
+    const byPlayer: ResolvedStatsMap = {}
+    for (const row of (data ?? []) as Array<{ player_id: string; stat_id: string; value: number }>) {
+      if (!byPlayer[row.player_id]) byPlayer[row.player_id] = {}
+      byPlayer[row.player_id][row.stat_id] = row.value
+    }
+    return byPlayer
+  }, [gameId])
+
+  useEffect(() => {
+    if (!isFinalCloudGame || !gameId || !supabase) return
 
     let cancelled = false
     const load = async () => {
-      const { data, error } = await client.rpc('get_game_stats_resolved', {
-        p_game_id: gameId,
-      })
-
-      if (cancelled) return
-      if (error) return
-
-      const byPlayer: ResolvedStatsMap = {}
-      for (const row of (data ?? []) as Array<{ player_id: string; stat_id: string; value: number }>) {
-        if (!byPlayer[row.player_id]) byPlayer[row.player_id] = {}
-        byPlayer[row.player_id][row.stat_id] = row.value
-      }
+      const byPlayer = await loadResolved()
+      if (cancelled || !byPlayer) return
       setResolvedStats(byPlayer)
     }
 
     void load()
     return () => { cancelled = true }
-  }, [isFinalCloudGame, gameId])
+  }, [isFinalCloudGame, gameId, resolvedKey, loadResolved])
+
+  useEffect(() => {
+    const client = supabase
+    if (!isFinalCloudGame || !teamId || !user || !client) return
+
+    let cancelled = false
+    const loadRole = async () => {
+      const { data } = await client
+        .from('team_members')
+        .select('role')
+        .eq('team_id', teamId)
+        .eq('user_id', user.id)
+        .maybeSingle()
+
+      if (cancelled) return
+      const role = (data as { role?: string } | null)?.role
+      setIsTeamAdmin(role === 'owner' || role === 'admin')
+    }
+
+    void loadRole()
+    return () => { cancelled = true }
+  }, [isFinalCloudGame, teamId, user])
 
   if (!sport || !gameInfo) {
     navigate('/')
@@ -78,6 +121,61 @@ export default function GameSummary() {
   const handleNewGame = () => {
     dispatch({ type: 'RESET_GAME' })
     navigate('/')
+  }
+
+  const handleOpenCorrect = (
+    playerId: string,
+    playerName: string,
+    statId: string,
+    statLabel: string,
+    currentValue: number
+  ) => {
+    setCorrecting({ playerId, playerName, statId, statLabel, currentValue })
+    setCorrectValue(String(currentValue))
+    setCorrectReason('')
+    setCorrectError(null)
+  }
+
+  const handleCloseCorrect = () => {
+    setCorrecting(null)
+    setCorrectError(null)
+  }
+
+  const handleSaveCorrection = async () => {
+    if (!correcting || !gameId || !user || !supabase) return
+    const client = supabase
+    const value = parseInt(correctValue, 10)
+    if (Number.isNaN(value) || value < 0) {
+      setCorrectError('Enter a valid number (0 or more)')
+      return
+    }
+
+    setSavingCorrection(true)
+    setCorrectError(null)
+    const remotePlayerId = playerIdMap[correcting.playerId] ?? correcting.playerId
+
+    const { error } = await client
+      .from('stat_corrections')
+      .upsert(
+        {
+          game_id: gameId,
+          player_id: remotePlayerId,
+          stat_id: correcting.statId,
+          corrected_value: value,
+          corrected_by: user.id,
+          reason: correctReason.trim() || null,
+          original_primary_value: correcting.currentValue,
+        },
+        { onConflict: ['game_id', 'player_id', 'stat_id'] }
+      )
+
+    setSavingCorrection(false)
+    if (error) {
+      setCorrectError(error.message)
+      return
+    }
+    setResolvedKey(k => k + 1)
+    handleCloseCorrect()
   }
 
   const canFinalizeCloudGame = Boolean(
@@ -147,6 +245,21 @@ export default function GameSummary() {
           </div>
         )}
 
+        {isFinalCloudGame && isTeamAdmin && (
+          <div className="mb-4 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setReviewMode(!reviewMode)}
+              className={reviewMode ? 'btn-primary py-2' : 'btn-secondary py-2'}
+            >
+              {reviewMode ? 'Done reviewing' : 'Review / Correct stats'}
+            </button>
+            {reviewMode && (
+              <span className="text-xs text-slate-500">Tap a stat to correct it</span>
+            )}
+          </div>
+        )}
+
         {sport.categories.map(category => (
           <div key={category.id} className="mb-6">
             <h3 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-2">
@@ -197,7 +310,28 @@ export default function GameSummary() {
                         </td>
                         {category.actions.map(action => (
                           <td key={action.id} className="text-center py-2 px-2 tabular-nums">
-                            {stats[action.id] || 0}
+                            <span className="inline-flex items-center gap-1">
+                              {stats[action.id] || 0}
+                              {reviewMode && isFinalCloudGame && isTeamAdmin && (
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    handleOpenCorrect(
+                                      player.id,
+                                      player.name,
+                                      action.id,
+                                      action.shortLabel,
+                                      stats[action.id] || 0
+                                    )
+                                  }
+                                  className="text-slate-400 hover:text-blue-600 p-0.5"
+                                  title="Correct this stat"
+                                  aria-label="Correct stat"
+                                >
+                                  ✏️
+                                </button>
+                              )}
+                            </span>
                           </td>
                         ))}
                         {category.showTotal && (
@@ -265,6 +399,66 @@ export default function GameSummary() {
             New Game
           </button>
         </div>
+
+        {correcting && (
+          <div
+            className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-10"
+            onClick={handleCloseCorrect}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="correct-stat-title"
+          >
+            <div
+              className="card max-w-sm w-full"
+              onClick={e => e.stopPropagation()}
+            >
+              <h3 id="correct-stat-title" className="font-semibold text-slate-700 mb-3">
+                Correct stat
+              </h3>
+              <p className="text-sm text-slate-600 mb-2">
+                {correcting.playerName} — {correcting.statLabel}
+              </p>
+              <p className="text-xs text-slate-500 mb-3">
+                Current value: {correcting.currentValue}
+              </p>
+              {correctError && (
+                <div className="mb-3 text-sm text-red-600">{correctError}</div>
+              )}
+              <input
+                type="number"
+                min={0}
+                value={correctValue}
+                onChange={e => setCorrectValue(e.target.value)}
+                className="input-field mb-3"
+                placeholder="New value"
+              />
+              <input
+                type="text"
+                value={correctReason}
+                onChange={e => setCorrectReason(e.target.value)}
+                className="input-field mb-4"
+                placeholder="Reason (optional)"
+              />
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={handleSaveCorrection}
+                  disabled={savingCorrection}
+                  className="btn-primary flex-1"
+                >
+                  {savingCorrection ? 'Saving...' : 'Save'}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCloseCorrect}
+                  className="btn-secondary flex-1"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/pages/GameTracker.tsx
+++ b/src/pages/GameTracker.tsx
@@ -14,19 +14,19 @@ export default function GameTracker() {
   const [newName, setNewName] = useState('')
   const [newNumber, setNewNumber] = useState('')
 
+  // Flush cloud sync when leaving Game Tracker so latest stats are saved (must run before any early return)
+  useEffect(() => {
+    return () => {
+      flushCloudSync()
+    }
+  }, [flushCloudSync])
+
   if (!sport || !state.gameInfo || players.length === 0) {
     navigate('/')
     return null
   }
 
   const activePlayer = players.find(p => p.id === activePlayerId) || players[0]
-
-  // Flush cloud sync when leaving Game Tracker so latest stats are saved
-  useEffect(() => {
-    return () => {
-      flushCloudSync()
-    }
-  }, [flushCloudSync])
 
   const handleUndo = () => {
     dispatch({ type: 'UNDO' })

--- a/src/pages/GameTracker.tsx
+++ b/src/pages/GameTracker.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGame } from '../context/GameContext'
 import { computeCategoryTotal } from '../config/sports'
@@ -7,7 +7,7 @@ import StatButton from '../components/StatButton'
 
 export default function GameTracker() {
   const navigate = useNavigate()
-  const { state, dispatch } = useGame()
+  const { state, dispatch, flushCloudSync } = useGame()
   const { sport, players, activePlayerId, actionLog } = state
 
   const [showAddPlayer, setShowAddPlayer] = useState(false)
@@ -20,6 +20,13 @@ export default function GameTracker() {
   }
 
   const activePlayer = players.find(p => p.id === activePlayerId) || players[0]
+
+  // Flush cloud sync when leaving Game Tracker so latest stats are saved
+  useEffect(() => {
+    return () => {
+      flushCloudSync()
+    }
+  }, [flushCloudSync])
 
   const handleUndo = () => {
     dispatch({ type: 'UNDO' })

--- a/src/pages/PlayerSetup.tsx
+++ b/src/pages/PlayerSetup.tsx
@@ -187,7 +187,11 @@ export default function PlayerSetup() {
     if (!state.activePlayerId && state.players.length > 0) {
       dispatch({ type: 'SET_ACTIVE_PLAYER', playerId: state.players[0].id })
     }
-    navigate('/game')
+    if (state.cloudSync.teamId) {
+      navigate('/checkout')
+    } else {
+      navigate('/game')
+    }
   }
 
   return (

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -7,6 +7,7 @@ import { supabase } from '../lib/supabase'
 interface TeamRow {
   id: string
   name: string
+  nickname: string | null
   sport: string
   season: string | null
 }
@@ -16,6 +17,18 @@ interface PlayerRow {
   first_name: string
   last_name: string | null
   jersey_number: string | null
+  nickname: string | null
+}
+
+function teamDisplayName(team: TeamRow): string {
+  const n = team.nickname?.trim()
+  return n ? n : team.name
+}
+
+function playerDisplayName(player: PlayerRow): string {
+  const n = player.nickname?.trim()
+  if (n) return n
+  return [player.first_name, player.last_name].filter(Boolean).join(' ').trim() || 'Player'
 }
 
 export default function Teams() {
@@ -43,6 +56,12 @@ export default function Teams() {
   const [newPlayerLast, setNewPlayerLast] = useState('')
   const [newPlayerNumber, setNewPlayerNumber] = useState('')
 
+  const [editingTeamId, setEditingTeamId] = useState<string | null>(null)
+  const [editingTeamNickname, setEditingTeamNickname] = useState('')
+  const [editingPlayerId, setEditingPlayerId] = useState<string | null>(null)
+  const [editingPlayerNickname, setEditingPlayerNickname] = useState('')
+  const [savingNickname, setSavingNickname] = useState(false)
+
   const selectedTeam = useMemo(
     () => teams.find(team => team.id === selectedTeamId) ?? null,
     [teams, selectedTeamId]
@@ -57,7 +76,7 @@ export default function Teams() {
       setError(null)
       const { data, error: queryError } = await supabaseClient
         .from('teams')
-        .select('id,name,sport,season')
+        .select('id,name,nickname,sport,season')
         .order('created_at', { ascending: false })
 
       if (cancelled) return
@@ -94,7 +113,7 @@ export default function Teams() {
       setError(null)
       const { data, error: queryError } = await supabaseClient
         .from('players')
-        .select('id,first_name,last_name,jersey_number')
+        .select('id,first_name,last_name,jersey_number,nickname')
         .eq('team_id', selectedTeamId)
         .eq('is_active', true)
         .order('created_at', { ascending: true })
@@ -145,7 +164,7 @@ export default function Teams() {
         sport: newTeamSport,
         season: newTeamSeason.trim() || null,
       })
-      .select('id,name,sport,season')
+      .select('id,name,nickname,sport,season')
       .single()
 
     setCreatingTeam(false)
@@ -154,7 +173,7 @@ export default function Teams() {
       return
     }
 
-    const createdTeam = data as TeamRow
+    const createdTeam = { ...data, nickname: (data as TeamRow).nickname ?? null } as TeamRow
     setTeams(prev => [createdTeam, ...prev])
     setSelectedTeamId(createdTeam.id)
     setNewTeamName('')
@@ -177,7 +196,7 @@ export default function Teams() {
         jersey_number: newPlayerNumber.trim() || null,
         is_active: true,
       })
-      .select('id,first_name,last_name,jersey_number')
+      .select('id,first_name,last_name,jersey_number,nickname')
       .single()
 
     setSavingPlayer(false)
@@ -186,7 +205,7 @@ export default function Teams() {
       return
     }
 
-    setPlayers(prev => [...prev, data as PlayerRow])
+    setPlayers(prev => [...prev, { ...data, nickname: (data as PlayerRow).nickname ?? null } as PlayerRow])
     setNewPlayerFirst('')
     setNewPlayerLast('')
     setNewPlayerNumber('')
@@ -209,6 +228,66 @@ export default function Teams() {
     }
 
     setPlayers(prev => prev.filter(player => player.id !== playerId))
+  }
+
+  const startEditTeamNickname = (team: TeamRow) => {
+    setEditingTeamId(team.id)
+    setEditingTeamNickname(team.nickname?.trim() ?? '')
+  }
+
+  const cancelEditTeamNickname = () => {
+    setEditingTeamId(null)
+    setEditingTeamNickname('')
+  }
+
+  const handleSaveTeamNickname = async () => {
+    if (!supabaseClient || !editingTeamId) return
+    setError(null)
+    setSavingNickname(true)
+    const value = editingTeamNickname.trim() || null
+    const { error: updateError } = await supabaseClient
+      .from('teams')
+      .update({ nickname: value })
+      .eq('id', editingTeamId)
+    setSavingNickname(false)
+    if (updateError) {
+      setError(updateError.message)
+      return
+    }
+    setTeams(prev =>
+      prev.map(t => (t.id === editingTeamId ? { ...t, nickname: value } : t))
+    )
+    cancelEditTeamNickname()
+  }
+
+  const startEditPlayerNickname = (player: PlayerRow) => {
+    setEditingPlayerId(player.id)
+    setEditingPlayerNickname(player.nickname?.trim() ?? '')
+  }
+
+  const cancelEditPlayerNickname = () => {
+    setEditingPlayerId(null)
+    setEditingPlayerNickname('')
+  }
+
+  const handleSavePlayerNickname = async () => {
+    if (!supabaseClient || !editingPlayerId) return
+    setError(null)
+    setSavingNickname(true)
+    const value = editingPlayerNickname.trim() || null
+    const { error: updateError } = await supabaseClient
+      .from('players')
+      .update({ nickname: value })
+      .eq('id', editingPlayerId)
+    setSavingNickname(false)
+    if (updateError) {
+      setError(updateError.message)
+      return
+    }
+    setPlayers(prev =>
+      prev.map(p => (p.id === editingPlayerId ? { ...p, nickname: value } : p))
+    )
+    cancelEditPlayerNickname()
   }
 
   return (
@@ -287,24 +366,75 @@ export default function Teams() {
             <div className="space-y-2">
               {teams.map(team => {
                 const sport = sports.find(item => item.id === team.sport)
+                const isEditing = editingTeamId === team.id
                 return (
-                  <button
+                  <div
                     key={team.id}
-                    type="button"
-                    onClick={() => setSelectedTeamId(team.id)}
-                    className={`w-full text-left rounded-xl border px-3 py-2 transition-colors ${
+                    className={`rounded-xl border px-3 py-2 transition-colors ${
                       team.id === selectedTeamId
                         ? 'border-blue-300 bg-blue-50'
-                        : 'border-slate-200 bg-white hover:bg-slate-50'
+                        : 'border-slate-200 bg-white'
                     }`}
                   >
-                    <p className="font-medium text-slate-700">
-                      {sport?.icon ?? '🏟️'} {team.name}
-                    </p>
-                    <p className="text-xs text-slate-500">
-                      {sport?.name ?? team.sport}{team.season ? ` • ${team.season}` : ''}
-                    </p>
-                  </button>
+                    {isEditing ? (
+                      <div className="flex flex-col gap-2">
+                        <input
+                          type="text"
+                          value={editingTeamNickname}
+                          onChange={e => setEditingTeamNickname(e.target.value)}
+                          placeholder={`Display name (optional, default: ${team.name})`}
+                          className="input-field text-sm"
+                          autoFocus
+                        />
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            onClick={() => { void handleSaveTeamNickname() }}
+                            disabled={savingNickname}
+                            className="btn-primary flex-1 text-sm py-1"
+                          >
+                            {savingNickname ? 'Saving...' : 'Save'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={cancelEditTeamNickname}
+                            className="border border-slate-300 rounded-lg px-2 py-1 text-sm text-slate-600"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex items-start justify-between gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setSelectedTeamId(team.id)}
+                          className="flex-1 text-left"
+                        >
+                          <p className="font-medium text-slate-700">
+                            {sport?.icon ?? '🏟️'} {teamDisplayName(team)}
+                            {team.nickname?.trim() && (
+                              <span className="text-slate-400 font-normal text-xs ml-1">
+                                ({team.name})
+                              </span>
+                            )}
+                          </p>
+                          <p className="text-xs text-slate-500">
+                            {sport?.name ?? team.sport}{team.season ? ` • ${team.season}` : ''}
+                          </p>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={e => { e.stopPropagation(); startEditTeamNickname(team) }}
+                          className="text-slate-400 hover:text-slate-600 p-1 shrink-0"
+                          title="Edit display name"
+                          aria-label="Edit display name"
+                        >
+                          ✏️
+                        </button>
+                      </div>
+                    )}
+                  </div>
                 )
               })}
             </div>
@@ -315,7 +445,7 @@ export default function Teams() {
           <div className="flex items-center justify-between">
             <h2 className="font-semibold text-slate-700">Roster</h2>
             <span className="text-xs text-slate-400">
-              {selectedTeam ? selectedTeam.name : 'Select a team'}
+              {selectedTeam ? teamDisplayName(selectedTeam) : 'Select a team'}
             </span>
           </div>
 
@@ -359,23 +489,77 @@ export default function Teams() {
                 <p className="text-sm text-slate-500">No active players yet.</p>
               ) : (
                 <div className="space-y-2">
-                  {players.map(player => (
-                    <div key={player.id} className="flex items-center justify-between border border-slate-100 rounded-xl px-3 py-2">
-                      <div>
-                        <p className="font-medium text-slate-700">
-                          #{player.jersey_number || '—'} {player.first_name} {player.last_name || ''}
-                        </p>
+                  {players.map(player => {
+                    const isEditing = editingPlayerId === player.id
+                    return (
+                      <div key={player.id} className="border border-slate-100 rounded-xl px-3 py-2">
+                        {isEditing ? (
+                          <div className="flex flex-col gap-2">
+                            <input
+                              type="text"
+                              value={editingPlayerNickname}
+                              onChange={e => setEditingPlayerNickname(e.target.value)}
+                              placeholder={`Display name (optional)`}
+                              className="input-field text-sm"
+                              autoFocus
+                            />
+                            <div className="flex gap-2">
+                              <button
+                                type="button"
+                                onClick={() => { void handleSavePlayerNickname() }}
+                                disabled={savingNickname}
+                                className="btn-primary flex-1 text-sm py-1"
+                              >
+                                {savingNickname ? 'Saving...' : 'Save'}
+                              </button>
+                              <button
+                                type="button"
+                                onClick={cancelEditPlayerNickname}
+                                className="border border-slate-300 rounded-lg px-2 py-1 text-sm text-slate-600"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2 min-w-0">
+                              <span className="text-slate-500 shrink-0">
+                                #{player.jersey_number || '—'}
+                              </span>
+                              <p className="font-medium text-slate-700 truncate">
+                                {playerDisplayName(player)}
+                                {player.nickname?.trim() && (
+                                  <span className="text-slate-400 font-normal text-xs ml-1">
+                                    ({[player.first_name, player.last_name].filter(Boolean).join(' ')})
+                                  </span>
+                                )}
+                              </p>
+                            </div>
+                            <div className="flex items-center gap-1 shrink-0">
+                              <button
+                                type="button"
+                                onClick={() => startEditPlayerNickname(player)}
+                                className="text-slate-400 hover:text-slate-600 p-1"
+                                title="Edit display name"
+                                aria-label="Edit display name"
+                              >
+                                ✏️
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => { void handleDeactivatePlayer(player.id) }}
+                                disabled={deletingPlayerId === player.id}
+                                className="text-xs text-red-600 underline disabled:opacity-40"
+                              >
+                                {deletingPlayerId === player.id ? 'Removing...' : 'Remove'}
+                              </button>
+                            </div>
+                          </div>
+                        )}
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => { void handleDeactivatePlayer(player.id) }}
-                        disabled={deletingPlayerId === player.id}
-                        className="text-xs text-red-600 underline disabled:opacity-40"
-                      >
-                        {deletingPlayerId === player.id ? 'Removing...' : 'Remove'}
-                      </button>
-                    </div>
-                  ))}
+                    )
+                  })}
                 </div>
               )}
             </>

--- a/supabase/migrations/008_player_checkouts.sql
+++ b/supabase/migrations/008_player_checkouts.sql
@@ -1,0 +1,41 @@
+-- Player checkouts: which parent is the designated recorder per player per game (Phase 3 multi-parent).
+-- Soft claim only; all parents can still submit stats. Checkout determines whose stats show as primary.
+
+create table if not exists public.player_checkouts (
+  id uuid primary key default gen_random_uuid(),
+  game_id uuid not null references public.games(id) on delete cascade,
+  player_id uuid not null references public.players(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  is_primary boolean not null default true,
+  checked_out_at timestamptz not null default now(),
+
+  unique(game_id, player_id, user_id)
+);
+
+create index if not exists idx_checkouts_game on public.player_checkouts(game_id);
+create index if not exists idx_checkouts_game_player on public.player_checkouts(game_id, player_id);
+
+alter table public.player_checkouts enable row level security;
+
+-- Team members can read checkouts for their team's games
+create policy "checkouts_select_member" on public.player_checkouts
+  for select using (
+    game_id in (
+      select g.id from public.games g
+      where g.team_id in (
+        select tm.team_id from public.team_members tm where tm.user_id = auth.uid()
+      )
+    )
+  );
+
+-- Users can create their own checkouts
+create policy "checkouts_insert_own" on public.player_checkouts
+  for insert with check (user_id = auth.uid());
+
+-- Users can update their own checkouts (e.g. set is_primary = false)
+create policy "checkouts_update_own" on public.player_checkouts
+  for update using (user_id = auth.uid());
+
+-- Users can delete their own checkouts
+create policy "checkouts_delete_own" on public.player_checkouts
+  for delete using (user_id = auth.uid());

--- a/supabase/migrations/009_stat_corrections.sql
+++ b/supabase/migrations/009_stat_corrections.sql
@@ -1,0 +1,67 @@
+-- Admin stat corrections: override official value per (game, player, stat). Audit trail; never overwrites game_stats.
+
+create table if not exists public.stat_corrections (
+  id uuid primary key default gen_random_uuid(),
+  game_id uuid not null references public.games(id) on delete cascade,
+  player_id uuid not null references public.players(id) on delete cascade,
+  stat_id text not null,
+  corrected_value int not null,
+  original_primary_value int,
+  corrected_by uuid not null references public.profiles(id) on delete cascade,
+  reason text,
+  created_at timestamptz not null default now(),
+
+  unique(game_id, player_id, stat_id)
+);
+
+create index if not exists idx_corrections_game on public.stat_corrections(game_id);
+
+alter table public.stat_corrections enable row level security;
+
+-- Team members can read corrections for their team's games
+create policy "corrections_select_member" on public.stat_corrections
+  for select using (
+    game_id in (
+      select g.id from public.games g
+      where g.team_id in (
+        select tm.team_id from public.team_members tm where tm.user_id = auth.uid()
+      )
+    )
+  );
+
+-- Only team owner/admin can insert corrections
+create policy "corrections_insert_admin" on public.stat_corrections
+  for insert with check (
+    corrected_by = auth.uid()
+    and exists (
+      select 1 from public.games g
+      join public.team_members tm on tm.team_id = g.team_id
+      where g.id = game_id
+        and tm.user_id = auth.uid()
+        and tm.role in ('owner', 'admin')
+    )
+  );
+
+-- Only team owner/admin can update corrections
+create policy "corrections_update_admin" on public.stat_corrections
+  for update using (
+    exists (
+      select 1 from public.games g
+      join public.team_members tm on tm.team_id = g.team_id
+      where g.id = game_id
+        and tm.user_id = auth.uid()
+        and tm.role in ('owner', 'admin')
+    )
+  );
+
+-- Only team owner/admin can delete corrections
+create policy "corrections_delete_admin" on public.stat_corrections
+  for delete using (
+    exists (
+      select 1 from public.games g
+      join public.team_members tm on tm.team_id = g.team_id
+      where g.id = game_id
+        and tm.user_id = auth.uid()
+        and tm.role in ('owner', 'admin')
+    )
+  );

--- a/supabase/migrations/010_resolved_stats_rpcs.sql
+++ b/supabase/migrations/010_resolved_stats_rpcs.sql
@@ -1,0 +1,104 @@
+-- Resolved stats RPCs: single source of truth for game and season totals (Phase 3).
+-- Priority: correction > primary checkout > sole recorder > averaged.
+
+create or replace function public.get_game_stats_resolved(p_game_id uuid)
+returns table (
+  player_id uuid,
+  stat_id text,
+  value int,
+  source text,
+  recorded_by uuid,
+  recorder_count int
+) as $$
+  with corrections as (
+    select sc.player_id, sc.stat_id, sc.corrected_value as value,
+           sc.corrected_by as recorded_by, 'correction'::text as source
+    from public.stat_corrections sc
+    where sc.game_id = p_game_id
+  ),
+  primary_stats as (
+    select gs.player_id, gs.stat_id, gs.value,
+           gs.recorded_by, 'primary'::text as source
+    from public.game_stats gs
+    join public.player_checkouts pc
+      on pc.game_id = gs.game_id
+      and pc.player_id = gs.player_id
+      and pc.user_id = gs.recorded_by
+      and pc.is_primary = true
+    where gs.game_id = p_game_id
+  ),
+  sole_stats as (
+    select gs.player_id, gs.stat_id, gs.value,
+           gs.recorded_by, 'sole'::text as source
+    from public.game_stats gs
+    where gs.game_id = p_game_id
+    and not exists (
+      select 1 from public.game_stats gs2
+      where gs2.game_id = gs.game_id
+        and gs2.player_id = gs.player_id
+        and gs2.stat_id = gs.stat_id
+        and gs2.recorded_by <> gs.recorded_by
+    )
+  ),
+  averaged_stats as (
+    select gs.player_id, gs.stat_id,
+           round(avg(gs.value))::int as value,
+           null::uuid as recorded_by, 'averaged'::text as source
+    from public.game_stats gs
+    where gs.game_id = p_game_id
+    group by gs.player_id, gs.stat_id
+    having count(distinct gs.recorded_by) > 1
+  ),
+  resolved as (
+    select distinct on (player_id, stat_id)
+      player_id, stat_id, value, source, recorded_by
+    from (
+      select *, 1 as priority from corrections
+      union all
+      select *, 2 as priority from primary_stats
+      union all
+      select *, 3 as priority from sole_stats
+      union all
+      select *, 4 as priority from averaged_stats
+    ) all_sources
+    order by player_id, stat_id, priority
+  )
+  select
+    r.player_id, r.stat_id, r.value, r.source, r.recorded_by,
+    (select count(distinct gs.recorded_by)
+     from public.game_stats gs
+     where gs.game_id = p_game_id
+       and gs.player_id = r.player_id
+       and gs.stat_id = r.stat_id
+    )::int as recorder_count
+  from resolved r
+  order by r.player_id, r.stat_id;
+$$ language sql stable security invoker;
+
+-- Season aggregates over finalized games using same resolution chain
+create or replace function public.get_season_stats_resolved(p_team_id uuid)
+returns table (
+  player_id uuid,
+  stat_id text,
+  games_played bigint,
+  total bigint,
+  per_game_avg numeric,
+  season_high int
+) as $$
+  with game_resolved as (
+    select g.id as game_id, r.player_id, r.stat_id, r.value
+    from public.games g,
+    lateral public.get_game_stats_resolved(g.id) r
+    where g.team_id = p_team_id
+      and g.status = 'final'
+  )
+  select
+    player_id,
+    stat_id,
+    count(distinct game_id) as games_played,
+    sum(value) as total,
+    round(avg(value), 1) as per_game_avg,
+    max(value)::int as season_high
+  from game_resolved
+  group by player_id, stat_id;
+$$ language sql stable security invoker;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  // GitHub Pages project sites are served from "/<repo>/".
+  // Keep local dev at "/" while ensuring production builds work on Pages.
+  base: command === 'build' ? '/cursor-default/' : '/',
   plugins: [
     react(),
     VitePWA({
@@ -16,8 +19,8 @@ export default defineConfig({
         background_color: '#f8fafc',
         display: 'standalone',
         orientation: 'portrait',
-        scope: '/',
-        start_url: '/',
+        scope: '/cursor-default/',
+        start_url: '/cursor-default/',
         icons: [
           {
             src: 'pwa-192x192.png',
@@ -57,4 +60,4 @@ export default defineConfig({
     host: '0.0.0.0',
     port: 5173,
   },
-})
+}))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it introduces new Supabase schema/RLS policies and SQL RPCs that change how game/season stats are resolved, plus adjusts cloud sync timing/persistence which can affect data consistency across devices.
> 
> **Overview**
> Adds GitHub Pages deployment support via a new Actions workflow, a `GITHUB_PAGES_DEPLOY.md` guide, and Vite/PWA base-path updates for project-site hosting (plus ignores a local `cursor-default/` clone directory).
> 
> Implements Phase 3 multi-recorder flows: new Supabase migrations for `player_checkouts` and `stat_corrections`, plus `get_game_stats_resolved`/`get_season_stats_resolved` RPCs to compute “official” stats (correction/primary/sole/averaged).
> 
> Updates the app to use these capabilities: introduces a `/checkout` page to claim tracked players before a team game, ensures cloud sync is flushed on leaving `GameTracker` and persists an offline “pending sync” flag across reloads, and enhances `GameSummary` for finalized cloud games with resolved-stats display and an admin-only review/correction UI. Also adds editable team/player nicknames in `Teams`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4716696a36d9fba94a39a9b8aa75cd1a530a0331. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->