### PR TITLE
Game stats review display

### DIFF
--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -322,11 +322,28 @@ async function hydrateCloudGameFromRow(userId: string, gameRow: CloudGameRow): P
     throw new Error('Team missing for requested game')
   }
 
-  const { data: statRows, error: statsError } = await supabase
-    .from('game_stats')
-    .select('player_id,stat_id,value')
-    .eq('game_id', gameRow.id)
-    .eq('recorded_by', userId)
+  // Load stats differently depending on game status:
+  // - For final games, use resolved stats so viewers see official values
+  // - For non-final games, load only the current user's submissions
+  let statRows:
+    | Array<{ player_id: string; stat_id: string; value: number }>
+    | null = null
+  let statsError: { message?: string } | null = null
+  if (gameRow.status === 'final') {
+    const { data, error } = await supabase.rpc('get_game_stats_resolved', {
+      p_game_id: gameRow.id,
+    })
+    statRows = (data as Array<{ player_id: string; stat_id: string; value: number }> | null) ?? null
+    statsError = error
+  } else {
+    const { data, error } = await supabase
+      .from('game_stats')
+      .select('player_id,stat_id,value')
+      .eq('game_id', gameRow.id)
+      .eq('recorded_by', userId)
+    statRows = (data as Array<{ player_id: string; stat_id: string; value: number }> | null) ?? null
+    statsError = error
+  }
 
   if (statsError) {
     throw new Error(`Stats load failed: ${statsError.message}`)

--- a/src/pages/GameSummary.tsx
+++ b/src/pages/GameSummary.tsx
@@ -239,7 +239,10 @@ export default function GameSummary() {
       if (!entries) continue
       for (const [statId, entry] of Object.entries(entries)) {
         const needsReview =
-          entry.source === 'averaged' || (entry.recorder_count ?? 0) > 1
+          entry.source === 'averaged' ||
+          (((entry.recorder_count ?? 0) > 1) &&
+            entry.source !== 'correction' &&
+            entry.source !== 'primary')
         if (!needsReview) continue
         items.push({
           playerId: player.id,
@@ -623,7 +626,12 @@ export default function GameSummary() {
                         </td>
                         {category.actions.map(action => {
                           const meta = getResolvedMeta(player.id, action.id)
-                          const needsReview = meta && (meta.source === 'averaged' || (meta.recorder_count ?? 0) > 1)
+                          const needsReview =
+                            !!meta &&
+                            (meta.source === 'averaged' ||
+                              (((meta.recorder_count ?? 0) > 1) &&
+                                meta.source !== 'correction' &&
+                                meta.source !== 'primary'))
                           const submissions = getCellSubmissions(player.id, action.id)
 
                           return (


### PR DESCRIPTION
Fixes two bugs: the review queue incorrectly showing resolved stats and game summaries displaying empty stats for cross-team viewing.

The `needsReview` condition now correctly excludes stats marked as 'correction' or 'primary' to prevent already-resolved items from appearing in the review queue. The `recorded_by` filter was removed from `hydrateCloudGameFromRow` to ensure all player stats are loaded when viewing a game, regardless of who recorded them, resolving an issue where cross-team game views showed empty stats.

---