### PR TITLE
Data integrity: migration 019, cloudSync, Game Setup, Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ docs/
 ├── DESIGN_PHASE3_GAME_SUMMARY_ADMIN.md  # Design: Primary vs All Submissions, reassign primary, review queue
 ├── DESIGN_MULTI_PARENT_INVITE_LINKS.md  # Design: Invite links and multi-parent collaboration
 ├── DESIGN_TOURNAMENTS.md  # Design: Tournaments table, game link, UI and tournament-scoped views
+├── DATA_INTEGRITY_AND_CREATION_PLAN.md  # Plan: DB/app enforcement, season/team creation alignment
 └── REGRESSION_TESTING.md  # High-level test scripts for all features
 ```
 
@@ -273,7 +274,8 @@ A backlog of ideas to iterate over:
 7. **Optional stat descriptions** — Toggle to display full stat names (e.g., "Free Throw") instead of abbreviated labels (e.g., "FT"); or optionally show stat descriptions.
 8. **Games tied to season** — Determine how games are tied to an individual season (e.g., team has season field; games inherit or reference it; season filter in leaderboard). *Implemented: `seasons` table as top-level entity (migration 018); teams belong to a season via `season_id` FK; games inherit season through their team; season filter in Game Setup; season CRUD in Settings. Design: [DESIGN_SEASONS_DATA_MODEL.md](docs/DESIGN_SEASONS_DATA_MODEL.md).*
 9. **Clean up existing games** — A way to clean up existing games (delete, archive, or bulk actions). *Partially addressed by enhancement #5 (delete games individually from Games page and Data Management in Settings). Bulk actions and archive not yet implemented.*
-10. *(Add more as we go)*
+10. **Data integrity & creation order** — Stronger Supabase constraints and aligned app flows so season/team/tournament/game data stays consistent after migrations: unique team per season, optional `games.season_id` + trigger, check that `games.tournament_id` matches `games.team_id`, partial unique active jersey numbers per team, `seasons.sport` check against known IDs, and reconciling `cloudSync` season creation with the Teams UI (avoid duplicate seasons from the game-date-year shortcut). Full phased plan: [docs/DATA_INTEGRITY_AND_CREATION_PLAN.md](docs/DATA_INTEGRITY_AND_CREATION_PLAN.md).
+11. *(Add more as we go)*
 
 ### Known Issues
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ The dev server starts at `http://localhost:5173`.
    - `supabase/migrations/016_tournaments.sql`
    - `supabase/migrations/017_game_notes.sql`
    - `supabase/migrations/018_seasons_and_roster_junction.sql`
+   - `supabase/migrations/019_data_integrity_constraints.sql`
    > If you already applied earlier migrations, run only the new ones (e.g. only `018` for the seasons data model redesign).
+   > Before **`019`**, run `supabase/scripts/audit_data_integrity_pre_019.sql` in the SQL Editor if you have existing data; migration `019` aborts if duplicate teams, invalid `seasons.sport`, duplicate active jersey numbers, or bad `games.tournament_id` links exist.
    > **Migration 018 is destructive**: it drops `teams.sport`, `teams.season`, `players.team_id`, `players.jersey_number`, `players.position`, and `players.is_active` columns after migrating data to the new `seasons`, `team_players`, and `player_guardians` tables. Back up your database before running.
    > If migrations are missing or outdated, the in-app scoreboard will show a cloud sync warning/error status.
 4. Restart the dev server — the auth page will appear
@@ -184,7 +186,8 @@ supabase/
     ├── 015_home_score_adjustment.sql
     ├── 016_tournaments.sql
     ├── 017_game_notes.sql
-    └── 018_seasons_and_roster_junction.sql
+    ├── 018_seasons_and_roster_junction.sql
+    └── 019_data_integrity_constraints.sql
 
 docs/
 ├── INTEGRATION_PLAN.md    # Full architecture, data model, and phased roadmap
@@ -274,7 +277,7 @@ A backlog of ideas to iterate over:
 7. **Optional stat descriptions** — Toggle to display full stat names (e.g., "Free Throw") instead of abbreviated labels (e.g., "FT"); or optionally show stat descriptions.
 8. **Games tied to season** — Determine how games are tied to an individual season (e.g., team has season field; games inherit or reference it; season filter in leaderboard). *Implemented: `seasons` table as top-level entity (migration 018); teams belong to a season via `season_id` FK; games inherit season through their team; season filter in Game Setup; season CRUD in Settings. Design: [DESIGN_SEASONS_DATA_MODEL.md](docs/DESIGN_SEASONS_DATA_MODEL.md).*
 9. **Clean up existing games** — A way to clean up existing games (delete, archive, or bulk actions). *Partially addressed by enhancement #5 (delete games individually from Games page and Data Management in Settings). Bulk actions and archive not yet implemented.*
-10. **Data integrity & creation order** — Stronger Supabase constraints and aligned app flows so season/team/tournament/game data stays consistent after migrations: unique team per season, optional `games.season_id` + trigger, check that `games.tournament_id` matches `games.team_id`, partial unique active jersey numbers per team, `seasons.sport` check against known IDs, and reconciling `cloudSync` season creation with the Teams UI (avoid duplicate seasons from the game-date-year shortcut). Full phased plan: [docs/DATA_INTEGRITY_AND_CREATION_PLAN.md](docs/DATA_INTEGRITY_AND_CREATION_PLAN.md).
+10. **Data integrity & creation order** — *In progress:* migration `019` adds `seasons.sport` CHECK, unique team name per season, partial unique active jersey numbers, `games.season_id` + triggers, tournament/team validation trigger; app aligns `cloudSync` and Game Setup / Teams (see plan). Full phased plan: [docs/DATA_INTEGRITY_AND_CREATION_PLAN.md](docs/DATA_INTEGRITY_AND_CREATION_PLAN.md).
 11. *(Add more as we go)*
 
 ### Known Issues

--- a/docs/DATA_INTEGRITY_AND_CREATION_PLAN.md
+++ b/docs/DATA_INTEGRITY_AND_CREATION_PLAN.md
@@ -2,7 +2,7 @@
 
 This document captures a planned set of database and application changes to reduce drift after schema evolution (especially migration 018: seasons, `team_players`, `players.created_by`), align team/season creation across UI paths, and enforce clearer rules for required fields and insert order.
 
-**Status:** Planning / not fully implemented. Safe to commit as a roadmap if work is paused.
+**Status:** Partially implemented (see migration `019`, `cloudSync`, Game Setup, Teams UI). Run `supabase/scripts/audit_data_integrity_pre_019.sql` before applying `019` in production if you have legacy rows.
 
 ---
 
@@ -118,17 +118,20 @@ Implement in dependency order; each step may require Phase A cleanup first.
 
 ## 5. Completion checklist
 
-- [ ] Phase A audit queries run; problematic rows fixed or documented as exceptions.
-- [ ] Migration `019` (or next number) applied in dev/staging; production after backup.
-- [ ] `cloudSync` / Game Setup / Teams behavior matches documented season rules.
-- [ ] README migration list + INTEGRATION_PLAN updated.
-- [ ] Regression tests extended; `pnpm build` / `pnpm lint` clean.
+- [ ] Phase A audit queries run (`supabase/scripts/audit_data_integrity_pre_019.sql`); problematic rows fixed or documented as exceptions.
+- [ ] Migration `019_data_integrity_constraints.sql` applied in dev/staging; production after backup.
+- [x] `cloudSync` prefers matching owner team+season by name+sport before year-based season; `ensureTeam` handles unique-name conflicts; `ensureGame` includes optional `season_id` with column fallback.
+- [x] Game Setup: tournament name required when “+ Add new tournament”; optional season picker for **New team** cloud path; Teams: required season name when creating new season.
+- [x] README migration list updated; INTEGRATION_PLAN + regression doc nudged.
+- [ ] Full regression pass in app against a DB with `019` applied.
 
 ---
 
 ## 6. References
 
 - Migration: `supabase/migrations/018_seasons_and_roster_junction.sql`
+- Migration: `supabase/migrations/019_data_integrity_constraints.sql`
+- Pre-migration audit: `supabase/scripts/audit_data_integrity_pre_019.sql`
 - Cloud sync: `src/lib/cloudSync.ts` (`ensureSeason`, `ensureTeam`, `ensureGame`, `ensurePlayerId`)
 - Team creation: `src/pages/Teams.tsx`
 - Game setup: `src/pages/GameSetup.tsx`

--- a/docs/DATA_INTEGRITY_AND_CREATION_PLAN.md
+++ b/docs/DATA_INTEGRITY_AND_CREATION_PLAN.md
@@ -1,0 +1,135 @@
+# Data integrity & creation-order plan
+
+This document captures a planned set of database and application changes to reduce drift after schema evolution (especially migration 018: seasons, `team_players`, `players.created_by`), align team/season creation across UI paths, and enforce clearer rules for required fields and insert order.
+
+**Status:** Planning / not fully implemented. Safe to commit as a roadmap if work is paused.
+
+---
+
+## 1. Problem statement & reasoning
+
+### 1.1 Why old or mixed data behaves poorly
+
+- **Season identity is ambiguous.** There is no uniqueness rule tying “one logical season” to a single row. The **Teams** flow creates seasons with human names (e.g. `"Spring 2026"`). **`cloudSync.ts`** (`ensureSeason`) creates or finds a season using the **calendar year from the game date** as the season `name`, plus `sport`. The same user can end up with multiple seasons for the same sport/year or divergent naming, and duplicate **teams** (`owner_id` + `name` + `season_id`) are not prevented by the database.
+- **Games do not store `season_id`.** Season is implied only through `teams.season_id`. If team/season data was repaired or inconsistent in SQL, games have no direct column to validate or filter without joining teams.
+- **Tournament linkage is only partially enforced.** `games.tournament_id` is nullable; `tournament_name` is denormalized for display. Nothing in the database prevents `tournament_id` pointing at a `tournaments` row whose `team_id` differs from `games.team_id`, or `tournament_name` disagreeing with the FK row.
+- **Roster flexibility vs. ambiguity.** `team_players.jersey_number` is optional. That is fine for flexibility but allows ambiguous rosters and confusing stats when historical data is messy.
+
+### 1.2 Current canonical model (post–018)
+
+| Entity        | Key facts |
+|---------------|-----------|
+| `seasons`     | Top-level; `owner_id`, `name`, `sport` required in DB. |
+| `teams`       | `season_id` NOT NULL; sport lives on season, not team. |
+| `tournaments` | Scoped by `team_id` only (season is indirect via team). |
+| `players`     | Global row; `created_by` NOT NULL. |
+| `team_players`| Junction: player ↔ team, optional `jersey_number`. |
+| `games`       | `team_id` + optional `tournament_id` + `tournament_name`; season via team. |
+
+### 1.3 Two creation paths today
+
+1. **Teams / Admin UI** — Explicit season (new or existing), then team with `season_id`.
+2. **`ensureSeason` / `ensureTeam` in `src/lib/cloudSync.ts`** — When there is no `cloudSync.seasonId`, season name is derived from **game date year**; team is matched or created by `owner_id`, `name`, `season_id`.
+
+These paths can fork: a user who created a team under `"Spring 2026"` can still trigger creation of a separate season named `"2025"` when starting a game without an existing cloud team selection, producing duplicate teams/seasons and confusing history.
+
+---
+
+## 2. Target order of operations (canonical)
+
+Use this for documentation, RPCs, wizards, and manual Supabase fixes (respect FK order).
+
+1. **`auth.users` / `profiles`** — User exists.
+2. **`seasons`** — `owner_id`, `name`, `sport` (+ optional `start_date`, `end_date`).
+3. **`teams`** — `owner_id`, `name`, `season_id` (trigger adds owner to `team_members`).
+4. **`tournaments`** (optional) — `team_id`, `name` after team exists.
+5. **`players`** — `created_by`, `first_name`, etc.
+6. **`team_players`** — Link player to team; set `jersey_number`, `is_active`.
+7. **`player_guardians`** (recommended for consistency) — e.g. creator as guardian where the product expects pool/guardian behavior everywhere.
+8. **`games`** — `team_id`, `opponent_name`, `game_date`, `created_by`, status; set `tournament_id` only when it belongs to the **same** `team_id`; keep `tournament_name` consistent with chosen tournament or explicit display rules.
+9. **Downstream** — `game_stats`, `player_checkouts`, `stat_corrections`, etc.
+
+---
+
+## 3. Proposed work (phased)
+
+### Phase A — Data audit & cleanup (Supabase / one-off SQL)
+
+Before adding strict constraints, run checks and fix rows that would violate new rules.
+
+| Check | Action |
+|-------|--------|
+| `teams.season_id` NULL or broken FK | Should not exist post-018; fix or delete orphans. |
+| `games.tournament_id` set but `tournaments.team_id <> games.team_id` | Clear `tournament_id` or reassign to correct tournament; align `tournament_name`. |
+| `tournament_id` set but `tournament_name` mismatches `tournaments.name` | Backfill name from join or clear FK. |
+| Duplicate teams same `season_id` + `name` | Merge teams (hard) or rename; required before `UNIQUE(season_id, name)` if adopted. |
+| Duplicate active jersey numbers per team | Resolve conflicts before partial unique index on active roster. |
+
+Deliverable: short SQL notebook or commented script in repo (e.g. `supabase/scripts/` — optional) documenting queries used.
+
+### Phase B — Database enforcement (new migration, e.g. `019`)
+
+Implement in dependency order; each step may require Phase A cleanup first.
+
+| Change | Rationale |
+|--------|-----------|
+| **`CHECK` on `seasons.sport`** | Restrict to known app sport IDs (align with `src/config/sports.ts`) so `GameSetup` filters (`.eq('seasons.sport', sport.id)`) never silently return empty due to typos. |
+| **`UNIQUE (season_id, name)` on `teams`** | Prevents duplicate team names within one season. **Skip or defer** if product requires duplicate names. |
+| **Partial unique index on `team_players`** | e.g. unique `(team_id, jersey_number)` WHERE `jersey_number IS NOT NULL AND jersey_number <> '' AND is_active = true` — prevents two active players sharing a number on one team. Tune for empty-string vs NULL. |
+| **Integrity for game ↔ tournament** | `CHECK` constraint or trigger: `tournament_id IS NULL OR EXISTS (SELECT 1 FROM tournaments t WHERE t.id = games.tournament_id AND t.team_id = games.team_id)`. |
+| **Optional `games.season_id`** | Add nullable column; `BEFORE INSERT/UPDATE` trigger sets `season_id` from `teams.season_id` for the game’s `team_id`. Backfill existing games via `UPDATE games g SET season_id = t.season_id FROM teams t WHERE t.id = g.team_id`. Simplifies reporting and future constraints. |
+
+**Optional / stricter (later):**
+
+- NOT NULL `team_players.jersey_number` for cloud flows — product decision; needs UI + backfill.
+- Require `player_guardians` for creator — policy + backfill.
+
+**RPCs (optional):**
+
+- `create_team_with_season(...)` or transactional helper to insert season + team in one call and return IDs, reducing half-created states on flaky clients.
+
+### Phase C — Application alignment
+
+| Area | Change |
+|------|--------|
+| **`cloudSync.ts`** | Prefer **explicit** season when available: if UI has set `cloudSync.seasonId`, always use it for `ensureTeam` (already partially true); for “new team” cloud path, avoid relying **only** on calendar year — e.g. require season pick in Game Setup, or default season name from a visible rule consistent with Teams. Document behavior in README/INTEGRATION_PLAN. |
+| **Game Setup** | When creating a new tournament (`+ Add new tournament`), validate non-empty name before proceed; on failure, show error (avoid silent no-op). |
+| **Teams / Admin** | Optionally require explicit season name when creating new season (instead of only fallback `"{team} Season"`). |
+| **Player Setup / Teams** | Optional UI validation: require jersey number for cloud teams (no DB change) if product wants stricter rosters. |
+
+### Phase D — Documentation & tests
+
+- Update [`docs/INTEGRATION_PLAN.md`](INTEGRATION_PLAN.md) schema section if `games.season_id` or new constraints land.
+- Extend [`docs/REGRESSION_TESTING.md`](REGRESSION_TESTING.md) with cases: duplicate team blocked, invalid tournament FK rejected, cloud game uses selected team’s season.
+- Add new migration filename to [`README.md`](../README.md) migration list when shipped.
+
+---
+
+## 4. Risks & decisions
+
+| Topic | Decision needed |
+|-------|-----------------|
+| `UNIQUE(season_id, name)` on teams | Confirm no legitimate duplicate names in one season. |
+| Partial unique on jersey | How to treat `''` vs NULL; inactive rows must not block re-use. |
+| `seasons.sport` CHECK | Must update migration if new sports are added to `sports.ts` (or use a lookup table). |
+| `games.season_id` | Slight redundancy with `teams.season_id`; tradeoff is simpler queries and safer audits. |
+
+---
+
+## 5. Completion checklist
+
+- [ ] Phase A audit queries run; problematic rows fixed or documented as exceptions.
+- [ ] Migration `019` (or next number) applied in dev/staging; production after backup.
+- [ ] `cloudSync` / Game Setup / Teams behavior matches documented season rules.
+- [ ] README migration list + INTEGRATION_PLAN updated.
+- [ ] Regression tests extended; `pnpm build` / `pnpm lint` clean.
+
+---
+
+## 6. References
+
+- Migration: `supabase/migrations/018_seasons_and_roster_junction.sql`
+- Cloud sync: `src/lib/cloudSync.ts` (`ensureSeason`, `ensureTeam`, `ensureGame`, `ensurePlayerId`)
+- Team creation: `src/pages/Teams.tsx`
+- Game setup: `src/pages/GameSetup.tsx`
+- Sport IDs: `src/config/sports.ts`

--- a/docs/INTEGRATION_PLAN.md
+++ b/docs/INTEGRATION_PLAN.md
@@ -99,6 +99,8 @@ VITE_SUPABASE_ANON_KEY=<anon-key>
 
 Migrations `008_player_checkouts.sql`, `009_stat_corrections.sql`, and `010_resolved_stats_rpcs.sql` implement these Phase 3 structures.
 
+**Post–018 / 019 data model notes:** Migration `019_data_integrity_constraints.sql` adds `games.season_id` (denormalized from `teams.season_id`, kept in sync by trigger), validates `games.tournament_id` against `tournaments.team_id` via trigger, constrains `seasons.sport` to known app ids, unique `(season_id, name)` on teams, and a partial unique index on active non-empty jersey numbers per team. See [`DATA_INTEGRITY_AND_CREATION_PLAN.md`](DATA_INTEGRITY_AND_CREATION_PLAN.md) and `supabase/scripts/audit_data_integrity_pre_019.sql` before applying on existing databases.
+
 ### 1.3 Row Level Security Policies
 
 ```sql

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -243,4 +243,18 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 
 - **HashRouter:** In-app links use hash routes (e.g. `/#/game`, `/#/teams`).  
 - **localStorage:** Game and settings key `statkeeper_game`; clear to reset local state.  
-- **Migrations:** If a script fails on cloud features, confirm all migrations through 011 are applied in Supabase SQL Editor.
+- **Migrations:** If a script fails on cloud features, confirm migrations through **019** are applied in Supabase SQL Editor when using seasons, `team_players`, and data-integrity constraints (`019_data_integrity_constraints.sql`). Run `supabase/scripts/audit_data_integrity_pre_019.sql` before `019` if upgrading an existing project.
+
+---
+
+## 13. Data integrity (after migration 019)
+
+**Precondition:** Migration `019` applied; no duplicate-team or duplicate-jersey violations in DB.
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 13.1 | Teams → create new season **without** season name → Create Team | Button disabled or error: season name required |
+| 13.2 | Teams → create team in a season, then create **another** team same name same season | Error: duplicate team name in season |
+| 13.3 | Teams → roster: two active players with same non-empty jersey number | Second add fails with friendly error |
+| 13.4 | Game Setup → existing team → tournament **+ Add new** → leave name empty → Next | Error: enter tournament name |
+| 13.5 | Game Setup → New Team (cloud) → pick **Season for new team** matching an existing season → complete game → sync | Cloud team attaches to that season (not only year-from-date) |

--- a/src/config/sports.ts
+++ b/src/config/sports.ts
@@ -326,3 +326,8 @@ export function computeCategoryTotal(category: { actions: { id: string }[] }, st
 export function computeHockeyPoints(stats: Record<string, number>): number {
   return (stats['goal'] || 0) + (stats['h_ast'] || 0)
 }
+
+/** Ids persisted on `seasons.sport`; must match supabase migration 019 CHECK. */
+export type SportId = (typeof sports)[number]['id']
+
+export const KNOWN_SPORT_IDS: readonly SportId[] = sports.map(s => s.id)

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -36,6 +36,7 @@ type CloudGameRow = {
   opponent_name: string
   tournament_name: string | null
   tournament_id?: string | null
+  season_id?: string | null
   game_date: string
   opponent_score: number | null
   home_score_adjustment?: number | null
@@ -65,6 +66,11 @@ function isMissingNotesColumnError(error: { message?: string } | null): boolean 
     error.message.includes("'notes'") ||
     (error.message.includes('notes') && error.message.includes('column'))
   )
+}
+
+function isMissingSeasonIdColumnError(error: { message?: string } | null): boolean {
+  if (!error?.message) return false
+  return error.message.includes('season_id') && error.message.includes('column')
 }
 
 export type LastOpenedPreferenceSupport = 'unknown' | 'supported' | 'missing'
@@ -104,8 +110,32 @@ async function ensureSeason(state: GameState, userId: string): Promise<string> {
     return state.cloudSync.seasonId
   }
 
-  const seasonName = getSeasonFromDate(state.gameInfo!.date)
   const sportId = state.sport!.id
+  const teamName = state.gameInfo!.teamName.trim()
+
+  // Prefer an existing cloud team with the same name and sport so we reuse the
+  // season from Teams / Game Setup instead of creating a parallel year-based season.
+  if (teamName) {
+    const { data: teamRows, error: teamSeasonError } = await supabase
+      .from('teams')
+      .select('season_id, seasons!inner(sport)')
+      .eq('owner_id', userId)
+      .eq('name', teamName)
+      .eq('seasons.sport', sportId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+
+    if (teamSeasonError) {
+      throw new Error(`Team season lookup failed: ${teamSeasonError.message}`)
+    }
+
+    const sid = teamRows?.[0]?.season_id as string | undefined
+    if (sid) {
+      return sid
+    }
+  }
+
+  const seasonName = getSeasonFromDate(state.gameInfo!.date)
 
   const { data: existing, error: lookupError } = await supabase
     .from('seasons')
@@ -150,11 +180,13 @@ async function ensureTeam(state: GameState, userId: string, seasonId: string): P
     return state.cloudSync.teamId
   }
 
+  const teamName = state.gameInfo!.teamName.trim()
+
   const { data: existingTeams, error: lookupError } = await supabase
     .from('teams')
     .select('id')
     .eq('owner_id', userId)
-    .eq('name', state.gameInfo!.teamName)
+    .eq('name', teamName)
     .eq('season_id', seasonId)
     .order('created_at', { ascending: false })
     .limit(1)
@@ -171,11 +203,29 @@ async function ensureTeam(state: GameState, userId: string, seasonId: string): P
     .from('teams')
     .insert({
       owner_id: userId,
-      name: state.gameInfo!.teamName,
+      name: teamName,
       season_id: seasonId,
     })
     .select('id')
     .single()
+
+  if (createError?.code === '23505') {
+    const { data: again, error: againError } = await supabase
+      .from('teams')
+      .select('id')
+      .eq('owner_id', userId)
+      .eq('name', teamName)
+      .eq('season_id', seasonId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+
+    if (againError) {
+      throw new Error(`Team lookup after conflict failed: ${againError.message}`)
+    }
+    if (again && again.length > 0) {
+      return again[0].id as string
+    }
+  }
 
   if (createError || !createdTeam) {
     throw new Error(`Team creation failed: ${createError?.message ?? 'unknown error'}`)
@@ -184,13 +234,19 @@ async function ensureTeam(state: GameState, userId: string, seasonId: string): P
   return createdTeam.id as string
 }
 
-async function ensureGame(state: GameState, userId: string, teamId: string): Promise<string> {
+async function ensureGame(
+  state: GameState,
+  userId: string,
+  teamId: string,
+  seasonIdForGame: string | null
+): Promise<string> {
   if (!supabase) {
     throw new Error('Supabase client not configured')
   }
 
   const gamePayload = {
     team_id: teamId,
+    ...(seasonIdForGame ? { season_id: seasonIdForGame } : {}),
     opponent_name: state.gameInfo!.opponentName,
     opponent_score: state.opponentScore,
     home_score_adjustment: state.homeScoreAdjustment,
@@ -203,9 +259,15 @@ async function ensureGame(state: GameState, userId: string, teamId: string): Pro
   }
 
   // Fallback payload without optional columns that may not exist yet (pre-migration)
-  function buildFallbackPayload(omitHomeAdj: boolean, omitTournamentId: boolean, omitNotes: boolean) {
+  function buildFallbackPayload(
+    omitHomeAdj: boolean,
+    omitTournamentId: boolean,
+    omitNotes: boolean,
+    omitSeasonId: boolean
+  ) {
     return {
       team_id: teamId,
+      ...(omitSeasonId || !seasonIdForGame ? {} : { season_id: seasonIdForGame }),
       opponent_name: state.gameInfo!.opponentName,
       opponent_score: state.opponentScore,
       ...(omitHomeAdj ? {} : { home_score_adjustment: state.homeScoreAdjustment }),
@@ -238,11 +300,14 @@ async function ensureGame(state: GameState, userId: string, teamId: string): Pro
     const missingHomeAdj = isMissingHomeScoreAdjustmentColumnError(error)
     const missingTournamentId = isMissingTournamentIdColumnError(error)
     const missingNotes = isMissingNotesColumnError(error)
-    if (!missingHomeAdj && !missingTournamentId && !missingNotes) {
+    const missingSeasonId = isMissingSeasonIdColumnError(error)
+    if (!missingHomeAdj && !missingTournamentId && !missingNotes && !missingSeasonId) {
       throw new Error(`Game ${op} failed: ${error.message}`)
     }
 
-    ;({ error, data } = await run(buildFallbackPayload(missingHomeAdj, missingTournamentId, missingNotes)))
+    ;({ error, data } = await run(
+      buildFallbackPayload(missingHomeAdj, missingTournamentId, missingNotes, missingSeasonId)
+    ))
     if (error) throw new Error(`Game ${op} failed: ${error.message}`)
     return op === 'update' ? gameId! : (data!.id as string)
   }
@@ -413,7 +478,7 @@ export async function syncGameSnapshotToCloud({
 
   const seasonId = await ensureSeason(state, userId)
   const teamId = await ensureTeam(state, userId, seasonId)
-  const gameId = await ensureGame(state, userId, teamId)
+  const gameId = await ensureGame(state, userId, teamId, seasonId)
 
   const nextPlayerIdMap: Record<string, string> = {}
   for (const player of state.players) {
@@ -457,7 +522,10 @@ async function hydrateCloudGameFromRow(userId: string, gameRow: CloudGameRow): P
   }
 
   let sportId = ''
-  const seasonId = (teamRow.season_id as string | null) ?? null
+  const seasonId =
+    (gameRow.season_id as string | null | undefined) ??
+    (teamRow.season_id as string | null) ??
+    null
   if (seasonId) {
     const { data: seasonRow } = await supabase
       .from('seasons')
@@ -564,7 +632,7 @@ async function loadLatestGameRow(userId: string): Promise<CloudGameRow | null> {
   }
 
   // All optional columns (may not exist before their respective migrations)
-  const allOptional = 'home_score_adjustment,tournament_id,notes,last_opened_at'
+  const allOptional = 'home_score_adjustment,tournament_id,notes,last_opened_at,season_id'
   const baseColumns =
     'id,team_id,opponent_name,tournament_name,game_date,opponent_score,status,created_at'
 
@@ -588,8 +656,9 @@ async function loadLatestGameRow(userId: string): Promise<CloudGameRow | null> {
   const missingHomeAdjust = isMissingHomeScoreAdjustmentColumnError(advanced.error)
   const missingTournamentId = isMissingTournamentIdColumnError(advanced.error)
   const missingNotes = isMissingNotesColumnError(advanced.error)
+  const missingSeasonId = isMissingSeasonIdColumnError(advanced.error)
 
-  if (!missingLastOpened && !missingHomeAdjust && !missingTournamentId && !missingNotes) {
+  if (!missingLastOpened && !missingHomeAdjust && !missingTournamentId && !missingNotes && !missingSeasonId) {
     throw new Error(`Game load failed: ${advanced.error.message}`)
   }
 
@@ -600,7 +669,8 @@ async function loadLatestGameRow(userId: string): Promise<CloudGameRow | null> {
     (!missingHomeAdjust ? ',home_score_adjustment' : '') +
     (!missingTournamentId ? ',tournament_id' : '') +
     (!missingNotes ? ',notes' : '') +
-    (!missingLastOpened ? ',last_opened_at' : '')
+    (!missingLastOpened ? ',last_opened_at' : '') +
+    (!missingSeasonId ? ',season_id' : '')
 
   const retry = await supabase
     .from('games')
@@ -621,7 +691,8 @@ async function loadLatestGameRow(userId: string): Promise<CloudGameRow | null> {
     isMissingLastOpenedColumnError(retry.error) ||
     isMissingHomeScoreAdjustmentColumnError(retry.error) ||
     isMissingTournamentIdColumnError(retry.error) ||
-    isMissingNotesColumnError(retry.error)
+    isMissingNotesColumnError(retry.error) ||
+    isMissingSeasonIdColumnError(retry.error)
 
   if (isStillOptionalMissing) {
     const finalRetry = await supabase
@@ -660,7 +731,7 @@ export async function loadCloudGameById(userId: string, gameId: string): Promise
 
   const { data: gameRow, error: gameError } = await supabase
     .from('games')
-    .select(`${baseById},home_score_adjustment,tournament_id,notes`)
+    .select(`${baseById},home_score_adjustment,tournament_id,notes,season_id`)
     .eq('id', gameId)
     .maybeSingle()
 
@@ -668,14 +739,16 @@ export async function loadCloudGameById(userId: string, gameId: string): Promise
     const missingHomeAdj = isMissingHomeScoreAdjustmentColumnError(gameError)
     const missingTournamentId = isMissingTournamentIdColumnError(gameError)
     const missingNotes = isMissingNotesColumnError(gameError)
-    if (!missingHomeAdj && !missingTournamentId && !missingNotes) {
+    const missingSeasonId = isMissingSeasonIdColumnError(gameError)
+    if (!missingHomeAdj && !missingTournamentId && !missingNotes && !missingSeasonId) {
       throw new Error(`Game load failed: ${gameError.message}`)
     }
     const fallbackSelect =
       baseById +
       (!missingHomeAdj ? ',home_score_adjustment' : '') +
       (!missingTournamentId ? ',tournament_id' : '') +
-      (!missingNotes ? ',notes' : '')
+      (!missingNotes ? ',notes' : '') +
+      (!missingSeasonId ? ',season_id' : '')
     const { data: gameRowFallback, error: gameErrorFallback } = await supabase
       .from('games')
       .select(fallbackSelect)

--- a/src/pages/GameSetup.tsx
+++ b/src/pages/GameSetup.tsx
@@ -55,6 +55,12 @@ export default function GameSetup() {
   const [confirmDeleteTournament, setConfirmDeleteTournament] = useState<TournamentOption | null>(null)
   const [deletingTournamentId, setDeletingTournamentId] = useState<string | null>(null)
 
+  /** When creating a new cloud team from setup, optional season to attach (else sync uses year-from-date). */
+  const [seasonsForNewTeam, setSeasonsForNewTeam] = useState<Array<{ id: string; name: string }>>([])
+  const [loadingSeasonsForNewTeam, setLoadingSeasonsForNewTeam] = useState(false)
+  const [selectedNewTeamSeasonId, setSelectedNewTeamSeasonId] = useState('')
+  const [setupError, setSetupError] = useState<string | null>(null)
+
   useEffect(() => {
     if (!sport || !isCloudFlow || !userId) return
 
@@ -103,6 +109,30 @@ export default function GameSetup() {
       isCancelled = true
     }
   }, [isCloudFlow, sport, state.cloudSync.teamId, state.gameInfo?.teamName, userId])
+
+  useEffect(() => {
+    if (!isCloudFlow || !userId || !sport || !supabase) return
+    const client = supabase
+    let cancelled = false
+    const load = async () => {
+      setLoadingSeasonsForNewTeam(true)
+      const { data, error } = await client
+        .from('seasons')
+        .select('id,name')
+        .eq('owner_id', userId)
+        .eq('sport', sport.id)
+        .order('created_at', { ascending: false })
+      if (cancelled) return
+      if (!error) {
+        setSeasonsForNewTeam((data ?? []) as Array<{ id: string; name: string }>)
+      }
+      setLoadingSeasonsForNewTeam(false)
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [isCloudFlow, userId, sport])
 
   // Stable snapshot of the current tournament selection (avoids effect dep on full gameInfo object)
   const existingTournamentId = state.gameInfo?.tournamentId ?? null
@@ -183,6 +213,7 @@ export default function GameSetup() {
 
   const handleNext = async () => {
     if (!canProceed) return
+    setSetupError(null)
 
     // Resolve tournament: existing selection, create new, or free-text
     let resolvedTournamentId: string | null = null
@@ -192,7 +223,11 @@ export default function GameSetup() {
       if (selectedTournamentId === '__new__') {
         // Create (or find) tournament in Supabase
         const trimmed = newTournamentName.trim()
-        if (trimmed && supabase) {
+        if (!trimmed) {
+          setSetupError('Enter a tournament name or choose another option.')
+          return
+        }
+        if (supabase) {
           setCreatingTournament(true)
           const { data, error } = await supabase
             .from('tournaments')
@@ -200,7 +235,11 @@ export default function GameSetup() {
             .select('id')
             .single()
           setCreatingTournament(false)
-          if (!error && data) {
+          if (error) {
+            setSetupError(error.message)
+            return
+          }
+          if (data) {
             resolvedTournamentId = data.id as string
             resolvedTournamentName = trimmed
           }
@@ -213,10 +252,17 @@ export default function GameSetup() {
       // selectedTournamentId === '' means no tournament — both stay null/empty
     }
 
+    const resolvedSeasonIdForSync =
+      teamMode === 'existing' && selectedTeam
+        ? selectedTeam.season_id
+        : teamMode === 'new' && selectedNewTeamSeasonId
+          ? selectedNewTeamSeasonId
+          : null
+
     dispatch({
       type: 'SET_CLOUD_SYNC_STATE',
       cloudSync: {
-        seasonId: teamMode === 'existing' && selectedTeam ? selectedTeam.season_id : null,
+        seasonId: resolvedSeasonIdForSync,
         teamId: teamMode === 'existing' ? selectedTeamId || null : null,
         gameId: null,
         gameStatus: null,
@@ -274,6 +320,11 @@ export default function GameSetup() {
               {teamsError && (
                 <p className="text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg p-2">
                   {teamsError}
+                </p>
+              )}
+              {setupError && (
+                <p className="text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg p-2">
+                  {setupError}
                 </p>
               )}
 
@@ -350,7 +401,7 @@ export default function GameSetup() {
                   </select>
                 </div>
               ) : (
-                <div>
+                <div className="space-y-2">
                   <label className="block text-sm font-medium text-slate-600 mb-1">
                     Your Team Name *
                   </label>
@@ -362,6 +413,28 @@ export default function GameSetup() {
                     className="input-field"
                     autoFocus
                   />
+                  {loadingSeasonsForNewTeam ? (
+                    <p className="text-xs text-slate-400 animate-pulse">Loading seasons...</p>
+                  ) : seasonsForNewTeam.length > 0 ? (
+                    <div>
+                      <label className="block text-sm font-medium text-slate-600 mb-1">
+                        Season for new team
+                      </label>
+                      <select
+                        value={selectedNewTeamSeasonId}
+                        onChange={e => setSelectedNewTeamSeasonId(e.target.value)}
+                        className="input-field"
+                      >
+                        <option value="">Auto (use year from game date)</option>
+                        {seasonsForNewTeam.map(s => (
+                          <option key={s.id} value={s.id}>{s.name}</option>
+                        ))}
+                      </select>
+                      <p className="text-xs text-slate-500 mt-1">
+                        Pick an existing season to match Teams you already created, or leave on Auto.
+                      </p>
+                    </div>
+                  ) : null}
                 </div>
               )}
             </div>

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -480,11 +480,16 @@ export default function Teams() {
       }
       seasonData = found
     } else {
+      if (!newTeamSeason.trim()) {
+        setError('Season name is required')
+        setCreatingTeam(false)
+        return
+      }
       const { data: newSeason, error: seasonError } = await supabaseClient
         .from('seasons')
         .insert({
           owner_id: userId,
-          name: newTeamSeason.trim() || `${newTeamName.trim()} Season`,
+          name: newTeamSeason.trim(),
           sport: newTeamSport,
         })
         .select('id,name,sport')
@@ -511,7 +516,11 @@ export default function Teams() {
 
     setCreatingTeam(false)
     if (createError || !data) {
-      setError(createError?.message ?? 'Could not create team')
+      if (createError?.code === '23505') {
+        setError('A team with this name already exists in this season.')
+      } else {
+        setError(createError?.message ?? 'Could not create team')
+      }
       return
     }
 
@@ -567,7 +576,11 @@ export default function Teams() {
 
     setSavingPlayer(false)
     if (junctionError) {
-      setError(junctionError.message)
+      if (junctionError.code === '23505') {
+        setError('That jersey number is already used on this team.')
+      } else {
+        setError(junctionError.message)
+      }
       return
     }
 
@@ -600,7 +613,11 @@ export default function Teams() {
 
     setAddingExistingPlayer(false)
     if (junctionError) {
-      setError(junctionError.message)
+      if (junctionError.code === '23505') {
+        setError('That jersey number is already used on this team.')
+      } else {
+        setError(junctionError.message)
+      }
       return
     }
 
@@ -903,15 +920,21 @@ export default function Teams() {
                 type="text"
                 value={newTeamSeason}
                 onChange={e => setNewTeamSeason(e.target.value)}
-                placeholder="Season name"
+                placeholder="Season name (required)"
                 className="input-field"
+                required
               />
             </div>
           )}
           <button
             type="button"
             onClick={() => { void handleCreateTeam() }}
-            disabled={!newTeamName.trim() || creatingTeam || (seasonMode === 'existing' && !selectedSeasonId)}
+            disabled={
+              !newTeamName.trim()
+              || creatingTeam
+              || (seasonMode === 'existing' && !selectedSeasonId)
+              || (seasonMode === 'new' && !newTeamSeason.trim())
+            }
             className="btn-primary w-full"
           >
             {creatingTeam ? 'Creating...' : 'Create Team'}

--- a/supabase/migrations/019_data_integrity_constraints.sql
+++ b/supabase/migrations/019_data_integrity_constraints.sql
@@ -1,0 +1,210 @@
+-- ============================================================================
+-- Migration 019: Data integrity — seasons.sport, teams uniqueness, roster
+-- jerseys, games.season_id + tournament FK check, sync trigger
+-- ============================================================================
+-- See docs/DATA_INTEGRITY_AND_CREATION_PLAN.md
+--
+-- Preconditions (migration will abort with clear errors if violated):
+--   - No duplicate (season_id, name) on teams
+--   - No duplicate active jersey numbers per team (non-empty jersey_number)
+--   - All seasons.sport values must be one of the app sport ids (lowercase)
+-- ============================================================================
+
+-- --------------------------------------------------------------------------
+-- 1. Normalize and validate seasons.sport (must match src/config/sports.ts)
+-- --------------------------------------------------------------------------
+
+UPDATE public.seasons
+SET sport = lower(trim(sport))
+WHERE sport IS NOT NULL AND sport <> lower(trim(sport));
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.seasons
+    WHERE sport NOT IN ('basketball', 'baseball', 'football', 'hockey', 'soccer')
+  ) THEN
+    RAISE EXCEPTION
+      'Migration 019: seasons.sport contains values outside app sport ids. '
+      'Update offending rows to one of: basketball, baseball, football, hockey, soccer '
+      '(see src/config/sports.ts).';
+  END IF;
+END $$;
+
+ALTER TABLE public.seasons
+  DROP CONSTRAINT IF EXISTS seasons_sport_valid;
+
+ALTER TABLE public.seasons
+  ADD CONSTRAINT seasons_sport_valid
+  CHECK (sport IN ('basketball', 'baseball', 'football', 'hockey', 'soccer'));
+
+COMMENT ON CONSTRAINT seasons_sport_valid ON public.seasons IS
+  'Aligns with StatKeeper sport ids in src/config/sports.ts; extend when adding sports.';
+
+-- --------------------------------------------------------------------------
+-- 2. Unique team display name per season (owner-visible scope is per season)
+-- --------------------------------------------------------------------------
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT season_id, name
+    FROM public.teams
+    GROUP BY season_id, name
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION
+      'Migration 019: duplicate teams with the same season_id and name exist. '
+      'Rename or merge duplicates, then re-run this migration.';
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_unique_name_per_season
+  ON public.teams (season_id, name);
+
+-- --------------------------------------------------------------------------
+-- 3. Active roster: at most one player per non-empty jersey number per team
+-- --------------------------------------------------------------------------
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT team_id, btrim(jersey_number) AS jn
+    FROM public.team_players
+    WHERE is_active = true
+      AND jersey_number IS NOT NULL
+      AND btrim(jersey_number) <> ''
+    GROUP BY team_id, btrim(jersey_number)
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION
+      'Migration 019: duplicate active jersey numbers on the same team exist. '
+      'Fix team_players rows, then re-run this migration.';
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_players_active_jersey_unique
+  ON public.team_players (team_id, (btrim(jersey_number)))
+  WHERE is_active = true
+    AND jersey_number IS NOT NULL
+    AND btrim(jersey_number) <> '';
+
+-- --------------------------------------------------------------------------
+-- 4. games.season_id — denormalized from teams for reporting / integrity
+-- --------------------------------------------------------------------------
+
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS season_id uuid REFERENCES public.seasons(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_games_season ON public.games(season_id);
+
+UPDATE public.games g
+SET season_id = t.season_id
+FROM public.teams t
+WHERE g.team_id = t.id
+  AND (g.season_id IS DISTINCT FROM t.season_id);
+
+CREATE OR REPLACE FUNCTION public.set_game_season_from_team()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.team_id IS NULL THEN
+    NEW.season_id := NULL;
+    RETURN NEW;
+  END IF;
+
+  SELECT t.season_id INTO NEW.season_id
+  FROM public.teams t
+  WHERE t.id = NEW.team_id;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS games_set_season_id ON public.games;
+
+CREATE TRIGGER games_set_season_id
+  BEFORE INSERT OR UPDATE OF team_id ON public.games
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.set_game_season_from_team();
+
+COMMENT ON COLUMN public.games.season_id IS
+  'Denormalized from teams.season_id; kept in sync by trigger games_set_season_id.';
+
+-- --------------------------------------------------------------------------
+-- 5. Tournament FK must reference a tournament that belongs to the same team
+--    (PostgreSQL CHECK cannot use subqueries; use a trigger.)
+-- --------------------------------------------------------------------------
+
+-- Fix obvious bad links before enforcing
+UPDATE public.games g
+SET tournament_id = NULL
+WHERE g.tournament_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.tournaments tr
+    WHERE tr.id = g.tournament_id AND tr.team_id = g.team_id
+  );
+
+CREATE OR REPLACE FUNCTION public.validate_game_tournament_team()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.tournament_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.tournaments tr
+    WHERE tr.id = NEW.tournament_id
+      AND tr.team_id = NEW.team_id
+  ) THEN
+    RAISE EXCEPTION
+      'tournament_id % does not belong to team_id %',
+      NEW.tournament_id,
+      NEW.team_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS games_validate_tournament_team ON public.games;
+
+CREATE TRIGGER games_validate_tournament_team
+  BEFORE INSERT OR UPDATE OF team_id, tournament_id ON public.games
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.validate_game_tournament_team();
+
+COMMENT ON FUNCTION public.validate_game_tournament_team() IS
+  'Ensures games.tournament_id references a tournaments row with matching team_id.';
+
+-- --------------------------------------------------------------------------
+-- 6. Refresh games_display view (018) to include games.season_id
+-- --------------------------------------------------------------------------
+
+DROP VIEW IF EXISTS public.games_display;
+CREATE VIEW public.games_display WITH (security_invoker = true) AS
+SELECT
+  g.id,
+  g.team_id,
+  t.name AS team_name,
+  g.season_id,
+  s.name AS season_name,
+  g.opponent_name,
+  g.opponent_score,
+  g.tournament_id,
+  tour.name AS tournament_name,
+  g.game_date,
+  g.status,
+  g.created_by,
+  p.display_name AS created_by_name,
+  g.home_score_adjustment,
+  g.notes,
+  g.created_at
+FROM public.games g
+LEFT JOIN public.teams t ON t.id = g.team_id
+LEFT JOIN public.seasons s ON s.id = g.season_id
+LEFT JOIN public.tournaments tour ON tour.id = g.tournament_id
+LEFT JOIN public.profiles p ON p.id = g.created_by;

--- a/supabase/scripts/audit_data_integrity_pre_019.sql
+++ b/supabase/scripts/audit_data_integrity_pre_019.sql
@@ -1,0 +1,32 @@
+-- Optional: run in Supabase SQL Editor BEFORE applying migration 019_data_integrity_constraints.sql
+-- to find rows that will block the migration. Fix data, then apply 019.
+
+-- 1) Seasons with sport outside app ids (must become basketball|baseball|football|hockey|soccer)
+SELECT id, name, sport
+FROM public.seasons
+WHERE lower(trim(sport)) NOT IN ('basketball', 'baseball', 'football', 'hockey', 'soccer')
+   OR sport <> lower(trim(sport));
+
+-- 2) Duplicate team name within same season
+SELECT season_id, name, COUNT(*) AS n
+FROM public.teams
+GROUP BY season_id, name
+HAVING COUNT(*) > 1;
+
+-- 3) Duplicate active jersey numbers (non-empty) on same team
+SELECT team_id, btrim(jersey_number) AS jn, COUNT(*) AS n
+FROM public.team_players
+WHERE is_active = true
+  AND jersey_number IS NOT NULL
+  AND btrim(jersey_number) <> ''
+GROUP BY team_id, btrim(jersey_number)
+HAVING COUNT(*) > 1;
+
+-- 4) Games pointing at a tournament for a different team
+SELECT g.id, g.team_id, g.tournament_id
+FROM public.games g
+WHERE g.tournament_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.tournaments tr
+    WHERE tr.id = g.tournament_id AND tr.team_id = g.team_id
+  );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the [data integrity plan](docs/DATA_INTEGRITY_AND_CREATION_PLAN.md): new Supabase migration **019**, pre-migration audit script, app changes for season/tournament/team flows, and doc updates.

## Database (019)

- `seasons.sport` CHECK against known ids (`basketball`, `baseball`, `football`, `hockey`, `soccer`); normalizes to lowercase first
- Unique `(season_id, name)` on `teams`
- Partial unique index: active roster rows with non-empty trimmed jersey number are unique per team
- `games.season_id` + trigger to set from `teams.season_id` on insert/update of `team_id`
- Trigger validates `games.tournament_id` belongs to same `team_id`
- Clears invalid `tournament_id` before enforcing; recreates `games_display` with `season_id`
- **Run** `supabase/scripts/audit_data_integrity_pre_019.sql` first if upgrading existing data; migration raises clear errors if preconditions fail

## App

- **`cloudSync`**: Before year-based season, looks up owner team by name + sport and reuses its `season_id`; `ensureTeam` retries on unique violation; `ensureGame` sends `season_id` when column exists; load paths tolerate missing `season_id` column
- **Game Setup**: Tournament name required when "+ Add new tournament"; optional season dropdown for cloud **New team** to set `cloudSync.seasonId`
- **Teams**: Season name required when creating new season; clearer errors for duplicate team / duplicate jersey

## Docs

- README migration list + Future enhancement #10 note
- INTEGRATION_PLAN, REGRESSION_TESTING (§13), DATA_INTEGRITY plan checklist

## Verify

`pnpm build` passes locally. After applying **019** in Supabase, run regression §13 in `docs/REGRESSION_TESTING.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dae96d56-007c-4f91-b66c-2a10339413b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dae96d56-007c-4f91-b66c-2a10339413b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

