### PR TITLE
feat(stat-ui): Phase 6 — career, season scope, team stats, RPC 020

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The dev server starts at `http://localhost:5173`.
    - `supabase/migrations/017_game_notes.sql`
    - `supabase/migrations/018_seasons_and_roster_junction.sql`
    - `supabase/migrations/019_data_integrity_constraints.sql`
+   - `supabase/migrations/020_stat_tracking_ui_rpcs.sql` — career / player game log / team game log RPCs ([DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md))
    > If you already applied earlier migrations, run only the new ones (e.g. only `018` for the seasons data model redesign).
    > Before **`019`**, run `supabase/scripts/audit_data_integrity_pre_019.sql` in the SQL Editor if you have existing data; migration `019` aborts if duplicate teams, invalid `seasons.sport`, duplicate active jersey numbers, or bad `games.tournament_id` links exist.
    > **Migration 018 is destructive**: it drops `teams.sport`, `teams.season`, `players.team_id`, `players.jersey_number`, `players.position`, and `players.is_active` columns after migrating data to the new `seasons`, `team_players`, and `player_guardians` tables. Back up your database before running.
@@ -138,7 +139,8 @@ src/
 ├── lib/
 │   ├── supabase.ts        # Supabase client init (graceful fallback if not configured)
 │   ├── cloudSync.ts       # Cloud game snapshot sync, hydration, and resume logic
-│   └── display.ts         # Shared display name helpers (teams, players)
+│   ├── display.ts         # Shared display name helpers (teams, players)
+│   └── statDisplay.ts     # Compact stat lines for game logs (sport-aware)
 ├── config/
 │   └── sports.ts          # Sport definitions (stats, categories, scoring rules)
 ├── context/
@@ -155,8 +157,10 @@ src/
 │   ├── GameSummary.tsx    # Post-game stat tables (resolved stats + admin corrections)
 │   ├── Games.tsx          # Cloud game history, resume/final flows, delete games
 │   ├── Teams.tsx          # Cloud team + roster management + invites + delete
-│   ├── Leaderboard.tsx    # Season leaderboard (sortable by stat)
-│   ├── PlayerProfile.tsx  # Player season totals and game log
+│   ├── Leaderboard.tsx    # Season leaderboard (season + team scope, sortable)
+│   ├── PlayerProfile.tsx  # Player season totals, game log with inline stats, career link
+│   ├── CareerStats.tsx    # Career stats (/career)
+│   ├── TeamStats.tsx      # Team season summary (/team-stats)
 │   └── Admin.tsx          # Settings — sports, seasons CRUD, cloud links, data management
 ├── components/
 │   ├── ConfirmDialog.tsx  # Reusable confirmation modal (delete prompts)
@@ -187,12 +191,14 @@ supabase/
     ├── 016_tournaments.sql
     ├── 017_game_notes.sql
     ├── 018_seasons_and_roster_junction.sql
-    └── 019_data_integrity_constraints.sql
+    ├── 019_data_integrity_constraints.sql
+    └── 020_stat_tracking_ui_rpcs.sql
 
 docs/
 ├── INTEGRATION_PLAN.md    # Full architecture, data model, and phased roadmap
 ├── DESIGN_SEASONS_DATA_MODEL.md  # Design: Seasons entity, roster junction, player guardians
 ├── DESIGN_STAT_TRACKING_UI.md    # Design: Career/season/game/tournament stat views
+├── STAT_TRACKING_UI_PROGRESS.md  # Checklist: Phase 6 stat UI implementation
 ├── DESIGN_PHASE3_GAME_SUMMARY_ADMIN.md  # Design: Primary vs All Submissions, reassign primary, review queue
 ├── DESIGN_MULTI_PARENT_INVITE_LINKS.md  # Design: Invite links and multi-parent collaboration
 ├── DESIGN_TOURNAMENTS.md  # Design: Tournaments table, game link, UI and tournament-scoped views

--- a/docs/DESIGN_SEASONS_DATA_MODEL.md
+++ b/docs/DESIGN_SEASONS_DATA_MODEL.md
@@ -562,7 +562,7 @@ The migration is destructive (drops columns). Before running, recommend a Supaba
 | **3. Roster Refactor** | Teams page uses `team_players` junction; "Add Existing" player pool mode; PlayerSetup updated | **Done** |
 | **4. Guardian Claim** | "Claim" button on roster players; guardian status indicator; auto-guardian on player creation | **Done** |
 | **5. Cloud Sync** | `cloudSync.ts` handles season context, junction-based player lookup, auto-create guardian link | **Done** |
-| **6. Stat Views** | Career stats page, season-scoped stats, game stats (player + team splits) | Planned (see [DESIGN_STAT_TRACKING_UI.md](DESIGN_STAT_TRACKING_UI.md)) |
+| **6. Stat Views** | Career stats page, season-scoped stats, game stats (player + team splits) | **In progress** — branch `cursor/stat-tracking-ui-phase6`; migration `020_stat_tracking_ui_rpcs.sql`; see [DESIGN_STAT_TRACKING_UI.md](DESIGN_STAT_TRACKING_UI.md) §Progress |
 | **7. Player Transfer** | UI to add an existing player to a new team; player search/autocomplete | Planned |
 
 ---

--- a/docs/DESIGN_STAT_TRACKING_UI.md
+++ b/docs/DESIGN_STAT_TRACKING_UI.md
@@ -2,6 +2,21 @@
 
 Redesign the stat viewing pages to support **career stats**, **season-scoped stats**, and **game stats split into player and team views**. Builds on the seasons data model from [DESIGN_SEASONS_DATA_MODEL.md](DESIGN_SEASONS_DATA_MODEL.md).
 
+### Progress (live)
+
+| Item | Status |
+|------|--------|
+| Migration `020_stat_tracking_ui_rpcs.sql` (`get_player_game_log`, `get_career_stats_resolved`, `get_team_game_log`) | Done in repo — apply in Supabase |
+| Leaderboard season selector + `seasonId` URL + GP + Team Stats link | Done |
+| Player Profile season label + Career link + inline game log (RPC + fallback) | Done |
+| Career page `/career` | Done |
+| Team Season Summary `/team-stats` | Done (MVP: record, totals, game list) |
+| Tournament stats page + `get_tournament_stats_resolved` RPC | Not started |
+| Game Summary Players / Team tab | Not started |
+| `SportConfig.keyStats` + shared compact line helper | Partial (`keyStatIds` + `statDisplay.ts`; basketball only) |
+
+Detailed checklist: [STAT_TRACKING_UI_PROGRESS.md](STAT_TRACKING_UI_PROGRESS.md).
+
 ---
 
 ## 1. Current State

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -182,6 +182,10 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 9.4 | Game Log section | List of finalized games for that player |
 | 9.5 | View (on a game) | Loads game and navigates to Summary |
 | 9.6 | Leaderboard: change "Sort by" | Order updates (e.g. by Assists) |
+| 9.7 | Leaderboard: change **Season** dropdown | Team list filters; URL updates `seasonId` |
+| 9.8 | Leaderboard: **Team stats →** | Opens `/team-stats` with W/L and game list |
+| 9.9 | Player Profile: **Career →** | Opens `/career` with totals; migration **020** applied for RPC |
+| 9.10 | Teams → roster **Career** on a player | Same as 9.9 |
 
 ---
 

--- a/docs/STAT_TRACKING_UI_PROGRESS.md
+++ b/docs/STAT_TRACKING_UI_PROGRESS.md
@@ -1,0 +1,24 @@
+# Stat tracking UI (Phase 6) — implementation progress
+
+Parent plan: [DESIGN_STAT_TRACKING_UI.md](DESIGN_STAT_TRACKING_UI.md) · Seasons phase table: [DESIGN_SEASONS_DATA_MODEL.md §10](DESIGN_SEASONS_DATA_MODEL.md).
+
+## Done (this branch)
+
+- [x] Migration **`020_stat_tracking_ui_rpcs.sql`**: `get_player_game_log`, `get_career_stats_resolved`, `get_team_game_log`
+- [x] **Leaderboard**: season dropdown, URL `seasonId` + `teamId`, games played on rows, **Team stats →** link
+- [x] **Player profile**: season line in header, **Career →**, inline game log (RPC; N×`get_game_stats_resolved` fallback if RPC missing)
+- [x] **`/career`**: career totals + by-season list; multi-sport picker when needed
+- [x] **`/team-stats`**: W/L, tournaments list + placement, game-by-game (RPC or per-game fallback)
+- [x] **Teams** roster: **Career** link per player
+- [x] **`keyStatIds`** on basketball + **`formatCompactGameStatLine`** in `src/lib/statDisplay.ts`
+
+## Not done yet
+
+- [ ] **Tournament stats** page + `get_tournament_stats_resolved` RPC
+- [ ] **Game Summary** Players / Team tab toggle
+- [ ] **`keyStatIds`** for sports other than basketball (optional)
+- [ ] Team season summary: per-opponent table, richer tournament W/L (optional)
+
+## Apply in Supabase
+
+Run `020_stat_tracking_ui_rpcs.sql` after migrations through **010** (resolved stats). Optional if you rely on client fallbacks, but recommended for performance.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import Teams from './pages/Teams'
 import Games from './pages/Games'
 import Leaderboard from './pages/Leaderboard'
 import PlayerProfile from './pages/PlayerProfile'
+import CareerStats from './pages/CareerStats'
+import TeamStats from './pages/TeamStats'
 
 function AppRoutes() {
   const { user, loading, isConfigured } = useAuth()
@@ -48,6 +50,8 @@ function AppRoutes() {
           <Route path="/games" element={<Games />} />
           <Route path="/leaderboard" element={<Leaderboard />} />
           <Route path="/player" element={<PlayerProfile />} />
+          <Route path="/career" element={<CareerStats />} />
+          <Route path="/team-stats" element={<TeamStats />} />
         </Routes>
       </GameProvider>
     </SettingsProvider>

--- a/src/config/sports.ts
+++ b/src/config/sports.ts
@@ -13,6 +13,7 @@ export const sports: SportConfig[] = [
       gradient: 'from-orange-500 to-amber-500',
     },
     scoreLabel: 'Points',
+    keyStatIds: ['ast', 'stl', 'blk'],
     categories: [
       {
         id: 'scoring',

--- a/src/lib/statDisplay.ts
+++ b/src/lib/statDisplay.ts
@@ -1,0 +1,32 @@
+import type { SportConfig } from '../types'
+import { computePlayerScore } from '../config/sports'
+
+function statShortLabel(sport: SportConfig, statId: string): string {
+  for (const cat of sport.categories) {
+    const action = cat.actions.find(a => a.id === statId)
+    if (action) return action.shortLabel
+  }
+  return statId
+}
+
+/** Compact "12 PTS · 4 REB · 3 AST" for one game's resolved stat map. */
+export function formatCompactGameStatLine(sport: SportConfig, stats: Record<string, number>): string {
+  const parts: string[] = []
+  const score = computePlayerScore(sport, stats)
+  const scoreLabel = sport.scoreLabel === 'Points' ? 'PTS' : sport.scoreLabel
+  parts.push(`${score} ${scoreLabel}`)
+
+  if (sport.id === 'basketball') {
+    const reb = (stats.oreb ?? 0) + (stats.dreb ?? 0)
+    if (reb > 0) parts.push(`${reb} REB`)
+  }
+
+  const keys = sport.keyStatIds?.length ? sport.keyStatIds : ['ast', 'stl', 'blk']
+  for (const id of keys) {
+    const v = stats[id] ?? 0
+    if (v > 0) parts.push(`${v} ${statShortLabel(sport, id)}`)
+  }
+
+  const line = parts.filter(Boolean).join(' · ')
+  return line || '—'
+}

--- a/src/pages/CareerStats.tsx
+++ b/src/pages/CareerStats.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { sports, computePlayerScore } from '../config/sports'
+import { useAuth } from '../context/AuthContext'
+import { supabase } from '../lib/supabase'
+import { playerDisplayName } from '../lib/display'
+
+interface CareerRow {
+  season_id: string
+  season_name: string
+  team_id: string
+  team_name: string
+  sport: string
+  stat_id: string
+  games_played: number
+  total: number
+  per_game_avg: number
+  season_high: number
+}
+
+interface PlayerMeta {
+  id: string
+  first_name: string
+  last_name: string | null
+  nickname: string | null
+}
+
+export default function CareerStats() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const playerId = searchParams.get('playerId')
+  const sportParam = searchParams.get('sport')
+
+  const { isConfigured } = useAuth()
+  const supabaseClient = supabase
+
+  const [player, setPlayer] = useState<PlayerMeta | null>(null)
+  const [rows, setRows] = useState<CareerRow[]>([])
+  const [selectedSport, setSelectedSport] = useState<string>('')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const sportsInData = useMemo(() => {
+    const set = new Set(rows.map(r => r.sport))
+    return [...set].sort()
+  }, [rows])
+
+  useEffect(() => {
+    if (!playerId || !isConfigured || !supabaseClient) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+
+      const [playerRes, careerRes] = await Promise.all([
+        supabaseClient
+          .from('players')
+          .select('id,first_name,last_name,nickname')
+          .eq('id', playerId)
+          .single(),
+        supabaseClient.rpc('get_career_stats_resolved', { p_player_id: playerId }),
+      ])
+
+      if (cancelled) return
+
+      if (playerRes.error || !playerRes.data) {
+        setError(playerRes.error?.message ?? 'Player not found')
+        setLoading(false)
+        return
+      }
+
+      if (careerRes.error) {
+        setError(
+          careerRes.error.message.includes('function') && careerRes.error.message.includes('does not exist')
+            ? 'Run migration 020_stat_tracking_ui_rpcs.sql in Supabase to enable career stats.'
+            : careerRes.error.message
+        )
+        setLoading(false)
+        return
+      }
+
+      setPlayer(playerRes.data as PlayerMeta)
+      setRows((careerRes.data ?? []) as CareerRow[])
+      setLoading(false)
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [playerId, isConfigured, supabaseClient])
+
+  useEffect(() => {
+    if (sportsInData.length === 0) return
+    const fromUrl = sportParam && sportsInData.includes(sportParam) ? sportParam : null
+    setSelectedSport(prev => {
+      if (fromUrl) return fromUrl
+      if (prev && sportsInData.includes(prev)) return prev
+      return sportsInData[0]
+    })
+  }, [sportsInData, sportParam])
+
+  const filteredRows = useMemo(
+    () => rows.filter(r => r.sport === selectedSport),
+    [rows, selectedSport]
+  )
+
+  const sportConfig = useMemo(
+    () => sports.find(s => s.id === selectedSport) ?? null,
+    [selectedSport]
+  )
+
+  const careerTotals = useMemo(() => {
+    const byStat: Record<string, { total: number; high: number }> = {}
+    for (const r of filteredRows) {
+      if (!byStat[r.stat_id]) byStat[r.stat_id] = { total: 0, high: 0 }
+      byStat[r.stat_id].total += Number(r.total)
+      byStat[r.stat_id].high = Math.max(byStat[r.stat_id].high, r.season_high)
+    }
+    return byStat
+  }, [filteredRows])
+
+  /** Sum of games_played per season+team stint (same value on each stat row in a stint). */
+  const careerGamesApprox = useMemo(() => {
+    const byStint = new Map<string, number>()
+    for (const r of filteredRows) {
+      const k = `${r.season_id}::${r.team_id}`
+      if (!byStint.has(k)) byStint.set(k, r.games_played)
+    }
+    let sum = 0
+    for (const g of byStint.values()) sum += g
+    return { stintCount: byStint.size, gameSum: sum }
+  }, [filteredRows])
+
+  const segments = useMemo(() => {
+    const map = new Map<string, CareerRow[]>()
+    for (const r of filteredRows) {
+      const key = `${r.season_id}::${r.team_id}`
+      if (!map.has(key)) map.set(key, [])
+      map.get(key)!.push(r)
+    }
+    return [...map.entries()].map(([key, statRows]) => {
+      const first = statRows[0]
+      const stats: Record<string, number> = {}
+      for (const x of statRows) stats[x.stat_id] = x.total
+      const score = sportConfig ? computePlayerScore(sportConfig, stats) : 0
+      const gp = Math.max(...statRows.map(x => x.games_played), 0)
+      return {
+        key,
+        seasonName: first.season_name,
+        teamName: first.team_name,
+        gamesPlayed: gp,
+        score,
+        statRows,
+      }
+    })
+  }, [filteredRows, sportConfig])
+
+  if (!playerId) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Missing player</p>
+          <button type="button" onClick={() => navigate('/leaderboard')} className="btn-primary w-full">
+            Back to Leaderboard
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!isConfigured) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Cloud required</p>
+          <p className="text-sm text-slate-500 mb-4">Career stats need Supabase.</p>
+          <button type="button" onClick={() => navigate('/')} className="btn-primary w-full">
+            Home
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-slate-500 animate-pulse">Loading career stats...</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex flex-col px-4 py-6 max-w-lg mx-auto">
+        <div className="card bg-red-50 border-red-200 text-red-700 text-sm mb-4">{error}</div>
+        <button type="button" onClick={() => navigate(-1)} className="btn-primary">
+          Back
+        </button>
+      </div>
+    )
+  }
+
+  const shortLabel = (statId: string) => {
+    if (!sportConfig) return statId
+    for (const cat of sportConfig.categories) {
+      const a = cat.actions.find(x => x.id === statId)
+      if (a) return a.shortLabel
+    }
+    return statId
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="bg-gradient-to-r from-slate-700 to-slate-600 text-white px-4 py-4">
+        <div className="max-w-lg mx-auto flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center active:scale-90 transition-transform"
+          >
+            ←
+          </button>
+          <div className="min-w-0">
+            <h1 className="text-lg font-bold truncate">Career Stats</h1>
+            {player && (
+              <p className="text-sm opacity-80 truncate">{playerDisplayName(player)}</p>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <div className="flex-1 px-4 py-6 max-w-lg mx-auto w-full space-y-4">
+        {sportsInData.length > 1 && (
+          <section className="card space-y-2">
+            <h2 className="font-semibold text-slate-700 text-sm">Sport</h2>
+            <select
+              value={selectedSport}
+              onChange={e => {
+                const s = e.target.value
+                setSelectedSport(s)
+                if (playerId) {
+                  navigate(`/career?playerId=${encodeURIComponent(playerId)}&sport=${encodeURIComponent(s)}`, {
+                    replace: true,
+                  })
+                }
+              }}
+              className="input-field"
+            >
+              {sportsInData.map(id => {
+                const sp = sports.find(x => x.id === id)
+                return (
+                  <option key={id} value={id}>
+                    {sp?.icon} {sp?.name ?? id}
+                  </option>
+                )
+              })}
+            </select>
+          </section>
+        )}
+
+        {filteredRows.length === 0 ? (
+          <p className="text-sm text-slate-500">No finalized career stats yet for this sport.</p>
+        ) : (
+          <>
+            <section className="card space-y-3">
+              <h2 className="font-semibold text-slate-700">Career totals</h2>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                {Object.entries(careerTotals).map(([statId, agg]) => (
+                  <div key={statId} className="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2">
+                    <p className="text-xs text-slate-500 uppercase">{shortLabel(statId)}</p>
+                    <p className="font-semibold text-slate-800">{agg.total}</p>
+                    <p className="text-xs text-slate-400">
+                      {careerGamesApprox.gameSum > 0
+                        ? `${(agg.total / careerGamesApprox.gameSum).toFixed(1)}/g · `
+                        : ''}
+                      high {agg.high}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              {sportConfig && (
+                <p className="text-xs text-slate-500">
+                  {computePlayerScore(
+                    sportConfig,
+                    Object.fromEntries(Object.entries(careerTotals).map(([k, v]) => [k, v.total]))
+                  )}{' '}
+                  {sportConfig.scoreLabel} (scoring actions)
+                </p>
+              )}
+              <p className="text-xs text-slate-500">
+                ~{careerGamesApprox.gameSum} game{careerGamesApprox.gameSum !== 1 ? 's' : ''} across{' '}
+                {careerGamesApprox.stintCount} season/team
+                {careerGamesApprox.stintCount !== 1 ? 's' : ''}
+              </p>
+            </section>
+
+            <section className="card space-y-3">
+              <h2 className="font-semibold text-slate-700">By season</h2>
+              <div className="space-y-3">
+                {segments.map(seg => (
+                  <div key={seg.key} className="rounded-xl border border-slate-200 bg-white px-3 py-2">
+                    <p className="font-medium text-slate-800">{seg.seasonName}</p>
+                    <p className="text-sm text-slate-500">{seg.teamName}</p>
+                    <p className="text-xs text-slate-500 mt-1">
+                      {seg.gamesPlayed} GP
+                      {sportConfig && (
+                        <>
+                          {' · '}
+                          {seg.score} {sportConfig.scoreLabel}
+                        </>
+                      )}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { sports, computePlayerScore } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
@@ -15,6 +15,11 @@ interface TeamRow {
     name: string
     sport: string
   }
+}
+
+interface SeasonOption {
+  id: string
+  name: string
 }
 
 interface PlayerRow {
@@ -34,14 +39,27 @@ interface SeasonStatRow {
   season_high: number
 }
 
+function uniqueSeasonsFromTeams(teams: TeamRow[]): SeasonOption[] {
+  const map = new Map<string, string>()
+  for (const t of teams) {
+    if (!map.has(t.season_id)) map.set(t.season_id, t.seasons.name)
+  }
+  return Array.from(map.entries())
+    .map(([id, name]) => ({ id, name }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
 export default function Leaderboard() {
   const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
   const teamIdFromUrl = searchParams.get('teamId')
+  const seasonIdFromUrl = searchParams.get('seasonId')
+
   const { user, isConfigured } = useAuth()
   const supabaseClient = supabase
 
   const [teams, setTeams] = useState<TeamRow[]>([])
+  const [selectedSeasonId, setSelectedSeasonId] = useState<string>('')
   const [selectedTeamId, setSelectedTeamId] = useState<string>('')
   const [players, setPlayers] = useState<PlayerRow[]>([])
   const [seasonStats, setSeasonStats] = useState<SeasonStatRow[]>([])
@@ -51,6 +69,13 @@ export default function Leaderboard() {
   const [loadingStats, setLoadingStats] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const seasonOptions = useMemo(() => uniqueSeasonsFromTeams(teams), [teams])
+
+  const filteredTeams = useMemo(
+    () => (selectedSeasonId ? teams.filter(t => t.season_id === selectedSeasonId) : teams),
+    [teams, selectedSeasonId]
+  )
+
   const selectedTeam = useMemo(
     () => teams.find(t => t.id === selectedTeamId) ?? null,
     [teams, selectedTeamId]
@@ -59,6 +84,16 @@ export default function Leaderboard() {
   const sport = useMemo(
     () => sports.find(s => s.id === selectedTeam?.seasons?.sport) ?? null,
     [selectedTeam?.seasons?.sport]
+  )
+
+  const pushLeaderboardParams = useCallback(
+    (seasonId: string, teamId: string) => {
+      const next = new URLSearchParams()
+      if (seasonId) next.set('seasonId', seasonId)
+      if (teamId) next.set('teamId', teamId)
+      setSearchParams(next, { replace: true })
+    },
+    [setSearchParams]
   )
 
   useEffect(() => {
@@ -82,17 +117,35 @@ export default function Leaderboard() {
 
       const loadedTeams = (data ?? []) as unknown as TeamRow[]
       setTeams(loadedTeams)
-      setSelectedTeamId(prev => {
-        if (teamIdFromUrl && loadedTeams.some(t => t.id === teamIdFromUrl)) return teamIdFromUrl
-        if (prev && loadedTeams.some(t => t.id === prev)) return prev
-        return loadedTeams[0]?.id ?? ''
-      })
+
+      const seasons = uniqueSeasonsFromTeams(loadedTeams)
+      const seasonFromTeam =
+        teamIdFromUrl && loadedTeams.find(t => t.id === teamIdFromUrl)?.season_id
+      const nextSeasonId =
+        (seasonIdFromUrl && seasons.some(s => s.id === seasonIdFromUrl) ? seasonIdFromUrl : null) ??
+        (seasonFromTeam && seasons.some(s => s.id === seasonFromTeam) ? seasonFromTeam : null) ??
+        seasons[0]?.id ??
+        ''
+
+      const inSeason = loadedTeams.filter(t => t.season_id === nextSeasonId)
+      const nextTeamId =
+        (teamIdFromUrl && inSeason.some(t => t.id === teamIdFromUrl) ? teamIdFromUrl : null) ??
+        inSeason[0]?.id ??
+        ''
+
+      setSelectedSeasonId(nextSeasonId)
+      setSelectedTeamId(nextTeamId)
       setLoadingTeams(false)
+      if (nextSeasonId && nextTeamId) {
+        pushLeaderboardParams(nextSeasonId, nextTeamId)
+      }
     }
 
     void loadTeams()
-    return () => { cancelled = true }
-  }, [isConfigured, supabaseClient, user, teamIdFromUrl])
+    return () => {
+      cancelled = true
+    }
+  }, [isConfigured, supabaseClient, user, teamIdFromUrl, seasonIdFromUrl, pushLeaderboardParams])
 
   useEffect(() => {
     if (!selectedTeamId || !supabaseClient) {
@@ -142,7 +195,9 @@ export default function Leaderboard() {
     }
 
     void load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [selectedTeamId, supabaseClient])
 
   const playerStatsMap = useMemo(() => {
@@ -154,12 +209,21 @@ export default function Leaderboard() {
     return map
   }, [seasonStats])
 
+  const gamesPlayedByPlayer = useMemo(() => {
+    const m: Record<string, number> = {}
+    for (const row of seasonStats) {
+      const g = row.games_played
+      if (!m[row.player_id] || g > m[row.player_id]) m[row.player_id] = g
+    }
+    return m
+  }, [seasonStats])
+
   const leaderboardRows = useMemo(() => {
     return players
       .map(player => {
         const stats = playerStatsMap[player.id] ?? {}
         const score = sport ? computePlayerScore(sport, stats) : 0
-        return { player, stats, score }
+        return { player, stats, score, gamesPlayed: gamesPlayedByPlayer[player.id] ?? 0 }
       })
       .filter(row => Object.keys(row.stats).length > 0)
       .sort((a, b) => {
@@ -168,7 +232,7 @@ export default function Leaderboard() {
         const bVal = b.stats[sortBy] ?? 0
         return bVal - aVal
       })
-  }, [players, playerStatsMap, sport, sortBy])
+  }, [players, playerStatsMap, sport, sortBy, gamesPlayedByPlayer])
 
   const sortOptions = useMemo(() => {
     if (!sport) return [{ id: 'score', label: 'Score' }]
@@ -184,9 +248,21 @@ export default function Leaderboard() {
   }, [sport])
 
   useEffect(() => {
-    // Reset sort selection when switching teams/sports to a valid default
     setSortBy('score')
   }, [selectedTeamId])
+
+  const handleSeasonChange = (nextSeasonId: string) => {
+    setSelectedSeasonId(nextSeasonId)
+    const nextList = teams.filter(t => t.season_id === nextSeasonId)
+    const nextTeamId = nextList[0]?.id ?? ''
+    setSelectedTeamId(nextTeamId)
+    if (nextSeasonId && nextTeamId) pushLeaderboardParams(nextSeasonId, nextTeamId)
+  }
+
+  const handleSelectTeam = (teamId: string) => {
+    setSelectedTeamId(teamId)
+    if (selectedSeasonId && teamId) pushLeaderboardParams(selectedSeasonId, teamId)
+  }
 
   if (!isConfigured) {
     return (
@@ -230,20 +306,52 @@ export default function Leaderboard() {
         )}
 
         <section className="card space-y-3">
-          <h2 className="font-semibold text-slate-700">Team</h2>
+          <h2 className="font-semibold text-slate-700">Season</h2>
           {loadingTeams ? (
-            <p className="text-sm text-slate-500 animate-pulse">Loading teams...</p>
-          ) : teams.length === 0 ? (
+            <p className="text-sm text-slate-500 animate-pulse">Loading...</p>
+          ) : seasonOptions.length === 0 ? (
             <p className="text-sm text-slate-500">No teams yet.</p>
           ) : (
+            <select
+              value={selectedSeasonId}
+              onChange={e => handleSeasonChange(e.target.value)}
+              className="input-field"
+            >
+              {seasonOptions.map(s => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </section>
+
+        <section className="card space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="font-semibold text-slate-700">Team</h2>
+            {selectedTeamId && (
+              <button
+                type="button"
+                onClick={() => navigate(`/team-stats?teamId=${selectedTeamId}`)}
+                className="text-sm font-semibold text-blue-600 underline"
+              >
+                Team stats →
+              </button>
+            )}
+          </div>
+          {loadingTeams ? (
+            <p className="text-sm text-slate-500 animate-pulse">Loading teams...</p>
+          ) : filteredTeams.length === 0 ? (
+            <p className="text-sm text-slate-500">No teams in this season.</p>
+          ) : (
             <div className="space-y-2">
-              {teams.map(team => {
+              {filteredTeams.map(team => {
                 const s = sports.find(item => item.id === team.seasons.sport)
                 return (
                   <button
                     key={team.id}
                     type="button"
-                    onClick={() => setSelectedTeamId(team.id)}
+                    onClick={() => handleSelectTeam(team.id)}
                     className={`w-full text-left rounded-xl border px-3 py-2 transition-colors ${
                       team.id === selectedTeamId
                         ? 'border-blue-300 bg-blue-50'
@@ -254,7 +362,7 @@ export default function Leaderboard() {
                       {s?.icon ?? '🏟️'} {teamDisplayName(team)}
                     </p>
                     <p className="text-xs text-slate-500">
-                      {s?.name ?? team.seasons.sport}{team.seasons.name ? ` • ${team.seasons.name}` : ''}
+                      {s?.name ?? team.seasons.sport}
                     </p>
                   </button>
                 )
@@ -295,13 +403,15 @@ export default function Leaderboard() {
                     key={row.player.id}
                     type="button"
                     onClick={() =>
-                      navigate(`/player?teamId=${selectedTeamId}&playerId=${row.player.id}`)
+                      navigate(
+                        `/player?teamId=${selectedTeamId}&playerId=${row.player.id}&seasonId=${selectedSeasonId}`
+                      )
                     }
                     className="w-full text-left rounded-xl border border-slate-200 bg-white
                                px-3 py-2 hover:border-blue-200 hover:bg-blue-50/50 transition-colors
                                active:scale-[0.99]"
                   >
-                    <div className="flex items-center justify-between">
+                    <div className="flex items-center justify-between gap-2">
                       <div className="flex items-center gap-2 min-w-0">
                         <span className="text-slate-400 shrink-0 w-6">
                           {idx + 1}.
@@ -313,13 +423,15 @@ export default function Leaderboard() {
                           {playerDisplayName(row.player)}
                         </p>
                       </div>
-                      <div className="flex items-center gap-3 shrink-0">
+                      <div className="flex flex-col items-end shrink-0 text-right">
                         {sport?.scoreLabel && (
                           <span className="font-semibold text-slate-800">
                             {row.score} {sport.scoreLabel}
                           </span>
                         )}
-                        <span className="text-slate-400">›</span>
+                        <span className="text-xs text-slate-500">
+                          {row.gamesPlayed} GP
+                        </span>
                       </div>
                     </div>
                   </button>

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -6,7 +6,8 @@ import { useGame } from '../context/GameContext'
 import { supabase } from '../lib/supabase'
 import { loadCloudGameById, touchCloudGameLastOpened } from '../lib/cloudSync'
 import type { GameState } from '../types'
-import { playerDisplayName } from '../lib/display'
+import { playerDisplayName, teamDisplayName } from '../lib/display'
+import { formatCompactGameStatLine } from '../lib/statDisplay'
 
 interface TeamRow {
   id: string
@@ -43,6 +44,14 @@ interface GameLogRow {
   opponent_name: string
 }
 
+interface GameLogLineRow {
+  game_id: string
+  game_date: string
+  opponent_name: string
+  stat_id: string
+  value: number
+}
+
 function getStatShortLabel(sportId: string, statId: string): string {
   const sport = sports.find(s => s.id === sportId)
   if (!sport) return statId
@@ -53,11 +62,16 @@ function getStatShortLabel(sportId: string, statId: string): string {
   return statId
 }
 
+function isMissingRpcError(msg: string): boolean {
+  return msg.includes('does not exist') || msg.includes('function')
+}
+
 export default function PlayerProfile() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const teamId = searchParams.get('teamId')
   const playerId = searchParams.get('playerId')
+  const seasonIdFromUrl = searchParams.get('seasonId')
 
   const { user, isConfigured } = useAuth()
   const { dispatch } = useGame()
@@ -67,6 +81,7 @@ export default function PlayerProfile() {
   const [player, setPlayer] = useState<PlayerRow | null>(null)
   const [seasonStats, setSeasonStats] = useState<SeasonStatRow[]>([])
   const [gameLog, setGameLog] = useState<GameLogRow[]>([])
+  const [gameLogLines, setGameLogLines] = useState<GameLogLineRow[]>([])
 
   const [loading, setLoading] = useState(true)
   const [loadingGameId, setLoadingGameId] = useState<string | null>(null)
@@ -76,6 +91,15 @@ export default function PlayerProfile() {
     () => sports.find(s => s.id === team?.seasons?.sport) ?? null,
     [team?.seasons?.sport]
   )
+
+  const statsByGame = useMemo(() => {
+    const m = new Map<string, Record<string, number>>()
+    for (const row of gameLogLines) {
+      if (!m.has(row.game_id)) m.set(row.game_id, {})
+      m.get(row.game_id)![row.stat_id] = row.value
+    }
+    return m
+  }, [gameLogLines])
 
   useEffect(() => {
     if (!teamId || !playerId || !isConfigured || !supabaseClient) {
@@ -88,7 +112,7 @@ export default function PlayerProfile() {
       setLoading(true)
       setError(null)
 
-      const [teamRes, playerRes, statsRes, gameStatsRes] = await Promise.all([
+      const [teamRes, playerRes, statsRes, logRpcRes, gameStatsRes] = await Promise.all([
         supabaseClient.from('teams').select('id,name,nickname,season_id,seasons!inner(id,name,sport)').eq('id', teamId).single(),
         supabaseClient
           .from('team_players')
@@ -97,6 +121,10 @@ export default function PlayerProfile() {
           .eq('player_id', playerId)
           .single(),
         supabaseClient.rpc('get_season_stats_resolved', { p_team_id: teamId }),
+        supabaseClient.rpc('get_player_game_log', {
+          p_player_id: playerId,
+          p_team_id: teamId,
+        }),
         supabaseClient.from('game_stats').select('game_id').eq('player_id', playerId),
       ])
 
@@ -129,6 +157,16 @@ export default function PlayerProfile() {
       } as PlayerRow)
       setSeasonStats((statsRes.data ?? []).filter((r: SeasonStatRow) => r.player_id === playerId) as SeasonStatRow[])
 
+      if (!logRpcRes.error) {
+        setGameLogLines((logRpcRes.data ?? []) as GameLogLineRow[])
+      } else if (isMissingRpcError(logRpcRes.error.message)) {
+        setGameLogLines([])
+      } else {
+        setError(logRpcRes.error.message)
+        setLoading(false)
+        return
+      }
+
       const gameIds = [...new Set(((gameStatsRes.data ?? []) as { game_id: string }[]).map(r => r.game_id))]
       if (gameIds.length === 0) {
         setGameLog([])
@@ -150,11 +188,34 @@ export default function PlayerProfile() {
       } else {
         setGameLog((gamesRes.data ?? []) as GameLogRow[])
       }
+
+      if (logRpcRes.error && isMissingRpcError(logRpcRes.error.message) && gamesRes.data?.length) {
+        const lines: GameLogLineRow[] = []
+        for (const g of gamesRes.data as GameLogRow[]) {
+          const res = await supabaseClient.rpc('get_game_stats_resolved', { p_game_id: g.id })
+          if (res.error) continue
+          for (const row of (res.data ?? []) as { player_id: string; stat_id: string; value: number }[]) {
+            if (row.player_id === playerId) {
+              lines.push({
+                game_id: g.id,
+                game_date: g.game_date,
+                opponent_name: g.opponent_name,
+                stat_id: row.stat_id,
+                value: row.value,
+              })
+            }
+          }
+        }
+        if (!cancelled) setGameLogLines(lines)
+      }
+
       setLoading(false)
     }
 
     void load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [teamId, playerId, isConfigured, supabaseClient])
 
   const handleViewGame = async (gameId: string) => {
@@ -200,6 +261,10 @@ export default function PlayerProfile() {
     setLoadingGameId(null)
     navigate('/summary')
   }
+
+  const leaderboardHref = team
+    ? `/leaderboard?teamId=${team.id}&seasonId=${team.season_id}`
+    : '/leaderboard'
 
   if (!teamId || !playerId) {
     return (
@@ -256,23 +321,37 @@ export default function PlayerProfile() {
     0
   )
 
+  const careerQuery = seasonIdFromUrl
+    ? `playerId=${encodeURIComponent(playerId)}&sport=${encodeURIComponent(team.seasons.sport)}`
+    : `playerId=${encodeURIComponent(playerId)}&sport=${encodeURIComponent(team.seasons.sport)}`
+
   return (
     <div className="min-h-screen flex flex-col">
       <header className="bg-gradient-to-r from-slate-700 to-slate-600 text-white px-4 py-4">
         <div className="max-w-lg mx-auto flex items-center gap-3">
           <button
-            onClick={() => navigate(`/leaderboard?teamId=${teamId}`)}
+            onClick={() => navigate(leaderboardHref)}
             className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center
                        active:scale-90 transition-transform"
           >
             ←
           </button>
-          <div>
+          <div className="flex-1 min-w-0">
             <h1 className="text-lg font-bold">Player Profile</h1>
             <p className="text-sm opacity-80">
               #{player.jersey_number || '—'} {playerDisplayName(player)}
             </p>
+            <p className="text-xs opacity-70 truncate">
+              {teamDisplayName(team)} · {team.seasons.name}
+            </p>
           </div>
+          <button
+            type="button"
+            onClick={() => navigate(`/career?${careerQuery}`)}
+            className="shrink-0 text-xs font-semibold bg-white/20 hover:bg-white/30 rounded-lg px-2 py-1.5"
+          >
+            Career →
+          </button>
         </div>
       </header>
 
@@ -318,26 +397,38 @@ export default function PlayerProfile() {
             <p className="text-sm text-slate-500">No games yet.</p>
           ) : (
             <div className="space-y-2">
-              {gameLog.map(game => (
-                <div
-                  key={game.id}
-                  className="flex items-center justify-between rounded-xl border border-slate-200
-                             bg-white px-3 py-2"
-                >
-                  <div>
-                    <p className="font-medium text-slate-700">{game.game_date}</p>
-                    <p className="text-sm text-slate-500">vs {game.opponent_name}</p>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => handleViewGame(game.id)}
-                    disabled={loadingGameId === game.id}
-                    className="btn-primary py-2 px-4 text-sm"
+              {gameLog.map(game => {
+                const statMap = statsByGame.get(game.id) ?? {}
+                const line =
+                  sport && Object.keys(statMap).length > 0
+                    ? formatCompactGameStatLine(sport, statMap)
+                    : null
+                return (
+                  <div
+                    key={game.id}
+                    className="flex flex-col gap-1 rounded-xl border border-slate-200
+                               bg-white px-3 py-2"
                   >
-                    {loadingGameId === game.id ? 'Loading...' : 'View'}
-                  </button>
-                </div>
-              ))}
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="font-medium text-slate-700">{game.game_date}</p>
+                        <p className="text-sm text-slate-500">vs {game.opponent_name}</p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleViewGame(game.id)}
+                        disabled={loadingGameId === game.id}
+                        className="btn-primary py-2 px-4 text-sm shrink-0"
+                      >
+                        {loadingGameId === game.id ? 'Loading...' : 'View'}
+                      </button>
+                    </div>
+                    {line && (
+                      <p className="text-xs text-slate-500 pl-0.5">{line}</p>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           )}
         </section>

--- a/src/pages/TeamStats.tsx
+++ b/src/pages/TeamStats.tsx
@@ -1,0 +1,358 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { sports, computePlayerScore } from '../config/sports'
+import { useAuth } from '../context/AuthContext'
+import { supabase } from '../lib/supabase'
+import { teamDisplayName } from '../lib/display'
+import { formatCompactGameStatLine } from '../lib/statDisplay'
+
+interface TeamRow {
+  id: string
+  name: string
+  nickname: string | null
+  season_id: string
+  seasons: { id: string; name: string; sport: string }
+}
+
+interface GameMeta {
+  id: string
+  game_date: string
+  opponent_name: string
+  opponent_score: number
+  home_score_adjustment: number | null
+  tournament_id: string | null
+}
+
+interface TeamLogRow {
+  game_id: string
+  game_date: string
+  opponent_name: string
+  opponent_score: number
+  home_score_adjustment: number
+  stat_id: string
+  team_total: number
+}
+
+interface TournamentRow {
+  id: string
+  name: string
+  placement: number | null
+}
+
+function isMissingRpcError(msg: string): boolean {
+  return msg.includes('does not exist') || msg.includes('function')
+}
+
+export default function TeamStats() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const teamId = searchParams.get('teamId')
+
+  const { isConfigured } = useAuth()
+  const supabaseClient = supabase
+
+  const [team, setTeam] = useState<TeamRow | null>(null)
+  const [games, setGames] = useState<GameMeta[]>([])
+  const [tournaments, setTournaments] = useState<TournamentRow[]>([])
+  const [logRows, setLogRows] = useState<TeamLogRow[]>([])
+  const [useRpc, setUseRpc] = useState(true)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const sport = useMemo(
+    () => (team ? sports.find(s => s.id === team.seasons.sport) ?? null : null),
+    [team]
+  )
+
+  useEffect(() => {
+    if (!teamId || !isConfigured || !supabaseClient) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+
+      const [teamRes, gamesRes, tourRes, logRes] = await Promise.all([
+        supabaseClient
+          .from('teams')
+          .select('id,name,nickname,season_id,seasons!inner(id,name,sport)')
+          .eq('id', teamId)
+          .single(),
+        supabaseClient
+          .from('games')
+          .select('id,game_date,opponent_name,opponent_score,home_score_adjustment,tournament_id')
+          .eq('team_id', teamId)
+          .eq('status', 'final')
+          .order('game_date', { ascending: false }),
+        supabaseClient.from('tournaments').select('id,name,placement').eq('team_id', teamId),
+        supabaseClient.rpc('get_team_game_log', { p_team_id: teamId }),
+      ])
+
+      if (cancelled) return
+
+      if (teamRes.error || !teamRes.data) {
+        setError(teamRes.error?.message ?? 'Team not found')
+        setLoading(false)
+        return
+      }
+
+      setTeam(teamRes.data as unknown as TeamRow)
+      setGames((gamesRes.data ?? []) as GameMeta[])
+      setTournaments((tourRes.data ?? []) as TournamentRow[])
+
+      if (logRes.error && isMissingRpcError(logRes.error.message)) {
+        setUseRpc(false)
+        const finals = (gamesRes.data ?? []) as GameMeta[]
+        const aggregated: TeamLogRow[] = []
+        for (const g of finals) {
+          const res = await supabaseClient.rpc('get_game_stats_resolved', { p_game_id: g.id })
+          if (res.error) continue
+          const byStat: Record<string, number> = {}
+          for (const row of (res.data ?? []) as { stat_id: string; value: number }[]) {
+            byStat[row.stat_id] = (byStat[row.stat_id] ?? 0) + Number(row.value)
+          }
+          const adj = g.home_score_adjustment ?? 0
+          for (const [statId, team_total] of Object.entries(byStat)) {
+            aggregated.push({
+              game_id: g.id,
+              game_date: g.game_date,
+              opponent_name: g.opponent_name,
+              opponent_score: g.opponent_score,
+              home_score_adjustment: adj,
+              stat_id: statId,
+              team_total,
+            })
+          }
+        }
+        setLogRows(aggregated)
+      } else if (logRes.error) {
+        setError(logRes.error.message)
+        setLoading(false)
+        return
+      } else {
+        setUseRpc(true)
+        setLogRows((logRes.data ?? []) as TeamLogRow[])
+      }
+
+      setLoading(false)
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [teamId, isConfigured, supabaseClient])
+
+  const gameLines = useMemo(() => {
+    const empty = { lines: [] as Array<{ game: GameMeta; homeScore: number; won: boolean; compact: string }>, wins: 0, losses: 0, total: 0 }
+    if (!sport) return empty
+    const byGame = new Map<
+      string,
+      { meta: GameMeta; stats: Record<string, number>; homeAdj: number }
+    >()
+
+    if (useRpc && logRows.length > 0) {
+      for (const row of logRows) {
+        if (!byGame.has(row.game_id)) {
+          byGame.set(row.game_id, {
+            meta: {
+              id: row.game_id,
+              game_date: row.game_date,
+              opponent_name: row.opponent_name,
+              opponent_score: row.opponent_score,
+              home_score_adjustment: row.home_score_adjustment,
+              tournament_id: null,
+            },
+            stats: {},
+            homeAdj: row.home_score_adjustment,
+          })
+        }
+        byGame.get(row.game_id)!.stats[row.stat_id] = Number(row.team_total)
+      }
+    } else {
+      for (const g of games) {
+        byGame.set(g.id, {
+          meta: g,
+          stats: {},
+          homeAdj: g.home_score_adjustment ?? 0,
+        })
+      }
+    }
+
+    let wins = 0
+    let losses = 0
+    const lines: Array<{
+      game: GameMeta
+      homeScore: number
+      won: boolean
+      compact: string
+    }> = []
+
+    for (const g of games) {
+      const entry = byGame.get(g.id)
+      const stats = entry?.stats ?? {}
+      const base = sport ? computePlayerScore(sport, stats) : 0
+      const homeAdj = entry?.homeAdj ?? g.home_score_adjustment ?? 0
+      const homeScore = base + homeAdj
+      const won = homeScore > g.opponent_score
+      if (homeScore !== g.opponent_score) {
+        if (won) wins++
+        else losses++
+      }
+      const compact =
+        Object.keys(stats).length > 0 && sport
+          ? formatCompactGameStatLine(sport, stats)
+          : '—'
+      lines.push({ game: g, homeScore, won, compact })
+    }
+
+    return { lines, wins, losses, total: games.length }
+  }, [games, logRows, useRpc, sport])
+
+  if (!teamId) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Missing team</p>
+          <button type="button" onClick={() => navigate('/leaderboard')} className="btn-primary w-full">
+            Leaderboard
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!isConfigured) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <p className="text-slate-600">Supabase required</p>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-slate-500 animate-pulse">Loading team stats...</p>
+      </div>
+    )
+  }
+
+  if (!team || error) {
+    return (
+      <div className="min-h-screen flex flex-col px-4 py-6 max-w-lg mx-auto">
+        {error && <div className="card bg-red-50 text-red-700 text-sm mb-4">{error}</div>}
+        <button type="button" onClick={() => navigate('/leaderboard')} className="btn-primary">
+          Back
+        </button>
+      </div>
+    )
+  }
+
+  const { lines, wins, losses, total } = gameLines
+  const decided = wins + losses
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="bg-gradient-to-r from-slate-700 to-slate-600 text-white px-4 py-4">
+        <div className="max-w-lg mx-auto flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => navigate(`/leaderboard?teamId=${teamId}&seasonId=${team.season_id}`)}
+            className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center active:scale-90 transition-transform"
+          >
+            ←
+          </button>
+          <div className="min-w-0">
+            <h1 className="text-lg font-bold truncate">Team stats</h1>
+            <p className="text-sm opacity-80 truncate">
+              {sport?.icon} {teamDisplayName(team)} · {team.seasons.name}
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex-1 px-4 py-6 max-w-lg mx-auto w-full space-y-4">
+        {!useRpc && logRows.length === 0 && games.length > 0 && (
+          <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg p-2">
+            Apply migration <code className="text-[11px]">020_stat_tracking_ui_rpcs.sql</code> for
+            faster team game lines. Per-game stats unavailable.
+          </p>
+        )}
+
+        <section className="card space-y-2">
+          <h2 className="font-semibold text-slate-700">Season record</h2>
+          <div className="flex gap-4">
+            <div className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-3 flex-1 text-center">
+              <p className="text-2xl font-bold text-emerald-700">{wins}</p>
+              <p className="text-xs text-slate-500">Wins</p>
+            </div>
+            <div className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-3 flex-1 text-center">
+              <p className="text-2xl font-bold text-rose-700">{losses}</p>
+              <p className="text-xs text-slate-500">Losses</p>
+            </div>
+            <div className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-3 flex-1 text-center">
+              <p className="text-2xl font-bold text-slate-800">{total}</p>
+              <p className="text-xs text-slate-500">Games</p>
+            </div>
+          </div>
+          {decided > 0 && (
+            <p className="text-xs text-slate-500">
+              {((wins / decided) * 100).toFixed(0)}% in decided games ({wins}-{losses})
+            </p>
+          )}
+        </section>
+
+        {tournaments.length > 0 && (
+          <section className="card space-y-2">
+            <h2 className="font-semibold text-slate-700">Tournaments</h2>
+            <ul className="space-y-1 text-sm">
+              {tournaments.map(t => (
+                <li key={t.id} className="flex justify-between gap-2">
+                  <span>🏆 {t.name}</span>
+                  {t.placement != null && (
+                    <span className="text-slate-500">
+                      {t.placement === 1 ? '🥇 1st' : t.placement === 2 ? '🥈 2nd' : t.placement === 3 ? '🥉 3rd' : `#${t.placement}`}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <section className="card space-y-3">
+          <h2 className="font-semibold text-slate-700">Game by game</h2>
+          {lines.length === 0 ? (
+            <p className="text-sm text-slate-500">No finalized games.</p>
+          ) : (
+            <div className="space-y-2">
+              {lines.map(({ game, homeScore, won, compact }) => (
+                <div
+                  key={game.id}
+                  className="rounded-xl border border-slate-200 bg-white px-3 py-2"
+                >
+                  <div className="flex justify-between gap-2 items-start">
+                    <div>
+                      <p className="font-medium text-slate-800">{game.game_date}</p>
+                      <p className="text-sm text-slate-600">vs {game.opponent_name}</p>
+                    </div>
+                    <span
+                      className={`text-sm font-semibold shrink-0 ${won ? 'text-emerald-700' : 'text-rose-700'}`}
+                    >
+                      {won ? 'W' : 'L'} {homeScore}-{game.opponent_score}
+                    </span>
+                  </div>
+                  <p className="text-xs text-slate-500 mt-1">{compact}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -1247,6 +1247,19 @@ export default function Teams() {
                               </p>
                             </div>
                             <div className="flex items-center gap-1 shrink-0">
+                              {selectedTeam && (
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    navigate(
+                                      `/career?playerId=${encodeURIComponent(player.id)}&sport=${encodeURIComponent(selectedTeam.seasons.sport)}`
+                                    )
+                                  }
+                                  className="text-xs font-semibold text-blue-600 px-1.5 py-0.5"
+                                >
+                                  Career
+                                </button>
+                              )}
                               <button
                                 type="button"
                                 onClick={() => startEditPlayer(player)}

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,8 @@ export interface SportConfig {
   theme: SportTheme
   categories: StatCategory[]
   scoreLabel: string
+  /** Stat ids for compact per-game lines (e.g. game log). Optional; falls back to score + common stats. */
+  keyStatIds?: string[]
 }
 
 export interface GameInfo {

--- a/supabase/migrations/020_stat_tracking_ui_rpcs.sql
+++ b/supabase/migrations/020_stat_tracking_ui_rpcs.sql
@@ -1,0 +1,126 @@
+-- Stat tracking UI (Phase 6): RPCs for player game log and career stats.
+-- See docs/DESIGN_STAT_TRACKING_UI.md
+
+-- Per-game resolved stat lines for one player on one team (finalized games).
+CREATE OR REPLACE FUNCTION public.get_player_game_log(
+  p_player_id uuid,
+  p_team_id uuid
+)
+RETURNS TABLE (
+  game_id uuid,
+  game_date date,
+  opponent_name text,
+  stat_id text,
+  value int
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT
+    g.id AS game_id,
+    g.game_date,
+    g.opponent_name,
+    r.stat_id,
+    r.value
+  FROM public.games g
+  CROSS JOIN LATERAL public.get_game_stats_resolved(g.id) r
+  WHERE g.team_id = p_team_id
+    AND g.status = 'final'
+    AND r.player_id = p_player_id
+  ORDER BY g.game_date DESC, r.stat_id;
+$$;
+
+COMMENT ON FUNCTION public.get_player_game_log(uuid, uuid) IS
+  'Resolved stats per game for player profile game log (DESIGN_STAT_TRACKING_UI).';
+
+-- Career / cross-season aggregates: one row per (season, team, stat).
+CREATE OR REPLACE FUNCTION public.get_career_stats_resolved(p_player_id uuid)
+RETURNS TABLE (
+  season_id uuid,
+  season_name text,
+  team_id uuid,
+  team_name text,
+  sport text,
+  stat_id text,
+  games_played bigint,
+  total bigint,
+  per_game_avg numeric,
+  season_high int
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH game_resolved AS (
+    SELECT
+      s.id AS season_id,
+      s.name AS season_name,
+      t.id AS team_id,
+      t.name AS team_name,
+      s.sport,
+      g.id AS game_id,
+      r.stat_id,
+      r.value
+    FROM public.games g
+    JOIN public.teams t ON t.id = g.team_id
+    JOIN public.seasons s ON s.id = t.season_id
+    CROSS JOIN LATERAL public.get_game_stats_resolved(g.id) r
+    WHERE r.player_id = p_player_id
+      AND g.status = 'final'
+  )
+  SELECT
+    gr.season_id,
+    gr.season_name,
+    gr.team_id,
+    gr.team_name,
+    gr.sport,
+    gr.stat_id,
+    COUNT(DISTINCT gr.game_id) AS games_played,
+    SUM(gr.value)::bigint AS total,
+    ROUND(AVG(gr.value), 1) AS per_game_avg,
+    MAX(gr.value)::int AS season_high
+  FROM game_resolved gr
+  GROUP BY gr.season_id, gr.season_name, gr.team_id, gr.team_name, gr.sport, gr.stat_id
+  ORDER BY gr.season_name, gr.team_name, gr.stat_id;
+$$;
+
+COMMENT ON FUNCTION public.get_career_stats_resolved(uuid) IS
+  'Resolved career stats by season/team for a player (DESIGN_STAT_TRACKING_UI).';
+
+-- Team-level resolved stat totals per finalized game (for team season summary).
+CREATE OR REPLACE FUNCTION public.get_team_game_log(p_team_id uuid)
+RETURNS TABLE (
+  game_id uuid,
+  game_date date,
+  opponent_name text,
+  opponent_score int,
+  home_score_adjustment int,
+  stat_id text,
+  team_total bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT
+    g.id AS game_id,
+    g.game_date,
+    g.opponent_name,
+    g.opponent_score,
+    COALESCE(g.home_score_adjustment, 0)::int AS home_score_adjustment,
+    r.stat_id,
+    SUM(r.value)::bigint AS team_total
+  FROM public.games g
+  CROSS JOIN LATERAL public.get_game_stats_resolved(g.id) r
+  WHERE g.team_id = p_team_id
+    AND g.status = 'final'
+  GROUP BY g.id, g.game_date, g.opponent_name, g.opponent_score, g.home_score_adjustment, r.stat_id
+  ORDER BY g.game_date DESC, r.stat_id;
+$$;
+
+COMMENT ON FUNCTION public.get_team_game_log(uuid) IS
+  'Per-game team stat totals from resolved stats (DESIGN_STAT_TRACKING_UI).';


### PR DESCRIPTION
- Add migration 020: get_player_game_log, get_career_stats_resolved, get_team_game_log (SECURITY INVOKER, search_path locked)
- Leaderboard: season selector, seasonId+teamId in URL, GP on rows, link to /team-stats
- PlayerProfile: season context, Career link, inline game log via RPC with per-game resolved fallback
- New /career and /team-stats pages; TeamStats falls back if RPC missing
- statDisplay + basketball keyStatIds; Teams roster Career link
- Docs: seasons phase 6 in progress, STAT_TRACKING_UI_PROGRESS, design progress table; README migration 020 + structure