### PR TITLE
feat(stat-ui): tournament stats (021), Team stats links, Game Summary…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The dev server starts at `http://localhost:5173`.
    - `supabase/migrations/018_seasons_and_roster_junction.sql`
    - `supabase/migrations/019_data_integrity_constraints.sql`
    - `supabase/migrations/020_stat_tracking_ui_rpcs.sql` — career / player game log / team game log RPCs ([DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md))
+   - `supabase/migrations/021_tournament_stats_rpc.sql` — `get_tournament_stats_resolved`
    > If you already applied earlier migrations, run only the new ones (e.g. only `018` for the seasons data model redesign).
    > Before **`019`**, run `supabase/scripts/audit_data_integrity_pre_019.sql` in the SQL Editor if you have existing data; migration `019` aborts if duplicate teams, invalid `seasons.sport`, duplicate active jersey numbers, or bad `games.tournament_id` links exist.
    > **Migration 018 is destructive**: it drops `teams.sport`, `teams.season`, `players.team_id`, `players.jersey_number`, `players.position`, and `players.is_active` columns after migrating data to the new `seasons`, `team_players`, and `player_guardians` tables. Back up your database before running.
@@ -161,6 +162,7 @@ src/
 │   ├── PlayerProfile.tsx  # Player season totals, game log with inline stats, career link
 │   ├── CareerStats.tsx    # Career stats (/career)
 │   ├── TeamStats.tsx      # Team season summary (/team-stats)
+│   ├── TournamentStats.tsx # Tournament stats (/tournament-stats)
 │   └── Admin.tsx          # Settings — sports, seasons CRUD, cloud links, data management
 ├── components/
 │   ├── ConfirmDialog.tsx  # Reusable confirmation modal (delete prompts)
@@ -192,7 +194,8 @@ supabase/
     ├── 017_game_notes.sql
     ├── 018_seasons_and_roster_junction.sql
     ├── 019_data_integrity_constraints.sql
-    └── 020_stat_tracking_ui_rpcs.sql
+    ├── 020_stat_tracking_ui_rpcs.sql
+    └── 021_tournament_stats_rpc.sql
 
 docs/
 ├── INTEGRATION_PLAN.md    # Full architecture, data model, and phased roadmap

--- a/docs/DESIGN_STAT_TRACKING_UI.md
+++ b/docs/DESIGN_STAT_TRACKING_UI.md
@@ -11,8 +11,8 @@ Redesign the stat viewing pages to support **career stats**, **season-scoped sta
 | Player Profile season label + Career link + inline game log (RPC + fallback) | Done |
 | Career page `/career` | Done |
 | Team Season Summary `/team-stats` | Done (MVP: record, totals, game list) |
-| Tournament stats page + `get_tournament_stats_resolved` RPC | Not started |
-| Game Summary Players / Team tab | Not started |
+| Tournament stats page + `get_tournament_stats_resolved` RPC | Done (`021_tournament_stats_rpc.sql`, `/tournament-stats`) |
+| Game Summary Players / Team tab | Done (toggle on summary) |
 | `SportConfig.keyStats` + shared compact line helper | Partial (`keyStatIds` + `statDisplay.ts`; basketball only) |
 
 Detailed checklist: [STAT_TRACKING_UI_PROGRESS.md](STAT_TRACKING_UI_PROGRESS.md).
@@ -623,8 +623,8 @@ Existing RPCs unchanged:
 | **3. Player Profile Update** | Inline game stat lines in game log; "Career →" link; season context label | Phase 1 RPCs |
 | **4. Career Stats Page** | New `/career` route and page; career totals + per-season breakdown; sport selector | Phase 1 RPCs |
 | **5. Team Season Summary** | New `/team-stats` route and page; W/L record, team totals, game-by-game, tournament list with W/L and placement | Phase 1 RPCs |
-| **6. Tournament Stats Page** | New `/tournament-stats` route and page; tournament W/L, placement badge, tournament leaderboard, game list | Phase 1 RPCs, Phase 5 |
-| **7. Game Summary Split** | Players/Team tab toggle on Game Summary | No dependencies |
+| **6. Tournament Stats Page** | New `/tournament-stats` route and page; tournament W/L, placement badge, tournament leaderboard, game list | **Done** (migration `021` + page; link from Team stats) |
+| **7. Game Summary Split** | Players/Team tab toggle on Game Summary | **Done** (no backend deps) |
 
 Phase 7 (Game Summary split) has no backend dependencies and can be done in parallel with other phases.
 

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -186,6 +186,8 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 9.8 | Leaderboard: **Team stats →** | Opens `/team-stats` with W/L and game list |
 | 9.9 | Player Profile: **Career →** | Opens `/career` with totals; migration **020** applied for RPC |
 | 9.10 | Teams → roster **Career** on a player | Same as 9.9 |
+| 9.11 | Team stats → tournament row **Stats →** | Opens tournament stats; W/L and leaderboard when games have `tournament_id` |
+| 9.12 | Game Summary → **Team** tab | Only team totals tables + score card; **Players** shows full grid |
 
 ---
 

--- a/docs/STAT_TRACKING_UI_PROGRESS.md
+++ b/docs/STAT_TRACKING_UI_PROGRESS.md
@@ -14,10 +14,16 @@ Parent plan: [DESIGN_STAT_TRACKING_UI.md](DESIGN_STAT_TRACKING_UI.md) · Seasons
 
 ## Not done yet
 
-- [ ] **Tournament stats** page + `get_tournament_stats_resolved` RPC
-- [ ] **Game Summary** Players / Team tab toggle
+- [x] **Tournament stats** page `/tournament-stats` + migration **021** `get_tournament_stats_resolved` (fallback aggregates per game if RPC missing)
+- [x] **Game Summary** Players / Team tab (team tab = score card + team totals tables only)
 - [ ] **`keyStatIds`** for sports other than basketball (optional)
-- [ ] Team season summary: per-opponent table, richer tournament W/L (optional)
+- [ ] Team season summary: per-opponent table (optional)
+
+## Latest slice (021 + UI)
+
+- `021_tournament_stats_rpc.sql`
+- `TournamentStats.tsx`, route, Team stats → **Stats →** per tournament
+- `GameSummary.tsx`: **Players** / **Team** toggle (alongside cloud Primary/All when applicable)
 
 ## Apply in Supabase
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Leaderboard from './pages/Leaderboard'
 import PlayerProfile from './pages/PlayerProfile'
 import CareerStats from './pages/CareerStats'
 import TeamStats from './pages/TeamStats'
+import TournamentStats from './pages/TournamentStats'
 
 function AppRoutes() {
   const { user, loading, isConfigured } = useAuth()
@@ -52,6 +53,7 @@ function AppRoutes() {
           <Route path="/player" element={<PlayerProfile />} />
           <Route path="/career" element={<CareerStats />} />
           <Route path="/team-stats" element={<TeamStats />} />
+          <Route path="/tournament-stats" element={<TournamentStats />} />
         </Routes>
       </GameProvider>
     </SettingsProvider>

--- a/src/pages/GameSummary.tsx
+++ b/src/pages/GameSummary.tsx
@@ -46,6 +46,8 @@ export default function GameSummary() {
   const [savingCorrection, setSavingCorrection] = useState(false)
   const [resolvedKey, setResolvedKey] = useState(0)
   const [viewMode, setViewMode] = useState<'primary' | 'all'>('primary')
+  /** Players vs Team layout for stat tables (design: Game Summary split). */
+  const [summaryTab, setSummaryTab] = useState<'players' | 'team'>('players')
   const [allSubmissions, setAllSubmissions] = useState<AllSubmissionsMap | null>(null)
   const [checkoutsByPlayer, setCheckoutsByPlayer] = useState<CheckoutsByPlayerMap | null>(null)
   const [settingPrimaryFor, setSettingPrimaryFor] = useState<string | null>(null)
@@ -565,8 +567,29 @@ export default function GameSummary() {
           </>
         )}
 
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <div className="flex rounded-lg border border-slate-200 bg-white p-0.5">
+            <button
+              type="button"
+              onClick={() => setSummaryTab('players')}
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                summaryTab === 'players' ? 'bg-slate-700 text-white' : 'text-slate-600 hover:bg-slate-100'
+              }`}
+            >
+              Players
+            </button>
+            <button
+              type="button"
+              onClick={() => setSummaryTab('team')}
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                summaryTab === 'team' ? 'bg-slate-700 text-white' : 'text-slate-600 hover:bg-slate-100'
+              }`}
+            >
+              Team
+            </button>
+          </div>
         {isFinalCloudGame && (
-          <div className="mb-4 flex flex-wrap items-center gap-2">
+          <>
             <div className="flex rounded-lg border border-slate-200 bg-white p-0.5">
               <button
                 type="button"
@@ -601,10 +624,33 @@ export default function GameSummary() {
                 )}
               </>
             )}
+          </>
+        )}
+        </div>
+
+        {summaryTab === 'team' && (
+          <div className="card mb-6 border-slate-200">
+            <h3 className="text-sm font-semibold text-slate-600 mb-3">Team vs opponent</h3>
+            <div className="flex items-center justify-center gap-6 mb-4">
+              <div className="text-center">
+                <p className="text-xs text-slate-500">{gameInfo.teamName}</p>
+                <p className="text-2xl font-bold text-slate-800">{teamScore}</p>
+              </div>
+              <span className="text-slate-400">vs</span>
+              <div className="text-center">
+                <p className="text-xs text-slate-500">{gameInfo.opponentName}</p>
+                <p className="text-2xl font-bold text-slate-800">{opponentScore}</p>
+              </div>
+            </div>
+            {homeScoreAdjustment !== 0 && (
+              <p className="text-xs text-slate-500 text-center mb-2">
+                Score adjustment: {homeScoreAdjustment >= 0 ? '+' : ''}{homeScoreAdjustment}
+              </p>
+            )}
           </div>
         )}
 
-        {sport.categories.map(category => {
+        {summaryTab === 'players' && sport.categories.map(category => {
           // Map madeStatId → miss action for this category (used in Primary view)
           const missActionMap: Record<string, typeof category.actions[0]> = {}
           for (const action of category.actions) {
@@ -805,6 +851,90 @@ export default function GameSummary() {
             </div>
           )
         })}
+
+        {summaryTab === 'team' &&
+          sport.categories.map(category => {
+            const missActionMap: Record<string, typeof category.actions[0]> = {}
+            for (const action of category.actions) {
+              if (action.madeStatId) missActionMap[action.madeStatId] = action
+            }
+            const visibleActions =
+              viewMode === 'primary'
+                ? category.actions.filter(a => !a.madeStatId)
+                : category.actions
+
+            return (
+              <div key={`team-${category.id}`} className="mb-6">
+                <h3 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-2">
+                  {category.name}
+                  {category.showTotal && (
+                    <span className="text-slate-400 ml-2 normal-case">— {category.totalLabel}</span>
+                  )}
+                </h3>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-slate-200">
+                        <th className="text-left py-2 pr-3 font-semibold text-slate-600">Team</th>
+                        {visibleActions.map(action => {
+                          const hasMiss = !!missActionMap[action.id]
+                          return (
+                            <th
+                              key={action.id}
+                              className="text-center py-2 px-2 font-semibold text-slate-600 min-w-[48px]"
+                            >
+                              {hasMiss ? `${action.shortLabel} M/A` : action.shortLabel}
+                            </th>
+                          )
+                        })}
+                        {category.showTotal && (
+                          <th className="text-center py-2 px-2 font-bold text-slate-700 min-w-[50px]">
+                            TOT
+                          </th>
+                        )}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr className="bg-slate-50 font-semibold border-b border-slate-100">
+                        <td className="py-2 pr-3">Totals</td>
+                        {visibleActions.map(action => {
+                          const missAction = missActionMap[action.id]
+                          const made = teamTotals[action.id] || 0
+                          const missVal = missAction ? teamTotals[missAction.id] || 0 : 0
+                          return (
+                            <td key={action.id} className="text-center py-2 px-2 tabular-nums">
+                              {missAction ? (
+                                <>
+                                  {made}/{made + missVal}
+                                  {made + missVal > 0 && (
+                                    <span className="text-slate-400 ml-1 text-xs">
+                                      ({Math.round((made / (made + missVal)) * 100)}%)
+                                    </span>
+                                  )}
+                                </>
+                              ) : (
+                                made
+                              )}
+                            </td>
+                          )
+                        })}
+                        {category.showTotal && (
+                          <td className="text-center py-2 px-2 font-bold tabular-nums">
+                            {category.actions.some(a => a.pointValue)
+                              ? category.actions.reduce(
+                                  (sum, a) => sum + (teamTotals[a.id] || 0) * (a.pointValue || 0),
+                                  0
+                                )
+                              : computeCategoryTotal(category, teamTotals)}
+                          </td>
+                        )}
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )
+          })}
 
         {state.notes && (
           <div className="mb-6">

--- a/src/pages/TeamStats.tsx
+++ b/src/pages/TeamStats.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { sports, computePlayerScore } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
@@ -309,15 +309,23 @@ export default function TeamStats() {
         {tournaments.length > 0 && (
           <section className="card space-y-2">
             <h2 className="font-semibold text-slate-700">Tournaments</h2>
-            <ul className="space-y-1 text-sm">
+            <ul className="space-y-2 text-sm">
               {tournaments.map(t => (
-                <li key={t.id} className="flex justify-between gap-2">
-                  <span>🏆 {t.name}</span>
-                  {t.placement != null && (
-                    <span className="text-slate-500">
-                      {t.placement === 1 ? '🥇 1st' : t.placement === 2 ? '🥈 2nd' : t.placement === 3 ? '🥉 3rd' : `#${t.placement}`}
-                    </span>
-                  )}
+                <li key={t.id} className="flex items-center justify-between gap-2">
+                  <span className="truncate">🏆 {t.name}</span>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {t.placement != null && (
+                      <span className="text-slate-500 text-xs">
+                        {t.placement === 1 ? '🥇 1st' : t.placement === 2 ? '🥈 2nd' : t.placement === 3 ? '🥉 3rd' : `#${t.placement}`}
+                      </span>
+                    )}
+                    <Link
+                      to={`/tournament-stats?tournamentId=${encodeURIComponent(t.id)}&teamId=${encodeURIComponent(team.id)}`}
+                      className="text-xs font-semibold text-blue-600 underline"
+                    >
+                      Stats →
+                    </Link>
+                  </div>
                 </li>
               ))}
             </ul>
@@ -341,9 +349,15 @@ export default function TeamStats() {
                       <p className="text-sm text-slate-600">vs {game.opponent_name}</p>
                     </div>
                     <span
-                      className={`text-sm font-semibold shrink-0 ${won ? 'text-emerald-700' : 'text-rose-700'}`}
+                      className={`text-sm font-semibold shrink-0 ${
+                        homeScore === game.opponent_score
+                          ? 'text-slate-600'
+                          : won
+                            ? 'text-emerald-700'
+                            : 'text-rose-700'
+                      }`}
                     >
-                      {won ? 'W' : 'L'} {homeScore}-{game.opponent_score}
+                      {homeScore === game.opponent_score ? 'T' : won ? 'W' : 'L'} {homeScore}-{game.opponent_score}
                     </span>
                   </div>
                   <p className="text-xs text-slate-500 mt-1">{compact}</p>

--- a/src/pages/TournamentStats.tsx
+++ b/src/pages/TournamentStats.tsx
@@ -1,0 +1,471 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { sports, computePlayerScore } from '../config/sports'
+import { useAuth } from '../context/AuthContext'
+import { supabase } from '../lib/supabase'
+import { teamDisplayName, playerDisplayName } from '../lib/display'
+import { formatCompactGameStatLine } from '../lib/statDisplay'
+
+interface TeamRow {
+  id: string
+  name: string
+  nickname: string | null
+  season_id: string
+  seasons: { id: string; name: string; sport: string }
+}
+
+interface TournamentRow {
+  id: string
+  name: string
+  placement: number | null
+  team_id: string
+}
+
+interface GameMeta {
+  id: string
+  game_date: string
+  opponent_name: string
+  opponent_score: number
+  home_score_adjustment: number | null
+}
+
+interface StatRow {
+  player_id: string
+  stat_id: string
+  games_played: number
+  total: number
+  per_game_avg: number
+  tournament_high: number
+}
+
+interface PlayerRow {
+  id: string
+  first_name: string
+  last_name: string | null
+  jersey_number: string | null
+  nickname: string | null
+}
+
+interface GameLine {
+  game: GameMeta
+  homeScore: number
+  won: boolean
+  compact: string
+}
+
+function isMissingRpcError(msg: string): boolean {
+  return msg.includes('does not exist') || msg.includes('function')
+}
+
+function placementLabel(p: number | null): string | null {
+  if (p == null) return null
+  if (p === 1) return '🥇 1st'
+  if (p === 2) return '🥈 2nd'
+  if (p === 3) return '🥉 3rd'
+  return `${p}th`
+}
+
+export default function TournamentStats() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const tournamentId = searchParams.get('tournamentId')
+  const teamId = searchParams.get('teamId')
+
+  const { isConfigured } = useAuth()
+  const supabaseClient = supabase
+
+  const [team, setTeam] = useState<TeamRow | null>(null)
+  const [tournament, setTournament] = useState<TournamentRow | null>(null)
+  const [games, setGames] = useState<GameMeta[]>([])
+  const [statRows, setStatRows] = useState<StatRow[]>([])
+  const [players, setPlayers] = useState<PlayerRow[]>([])
+  const [gameLines, setGameLines] = useState<GameLine[]>([])
+  const [wins, setWins] = useState(0)
+  const [losses, setLosses] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const sport = useMemo(
+    () => (team ? sports.find(s => s.id === team.seasons.sport) ?? null : null),
+    [team]
+  )
+
+  useEffect(() => {
+    if (!tournamentId || !teamId || !isConfigured || !supabaseClient) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+
+      const [tourRes, teamRes, gamesRes, statsRpc, rosterRes] = await Promise.all([
+        supabaseClient.from('tournaments').select('id,name,placement,team_id').eq('id', tournamentId).single(),
+        supabaseClient
+          .from('teams')
+          .select('id,name,nickname,season_id,seasons!inner(id,name,sport)')
+          .eq('id', teamId)
+          .single(),
+        supabaseClient
+          .from('games')
+          .select('id,game_date,opponent_name,opponent_score,home_score_adjustment')
+          .eq('team_id', teamId)
+          .eq('tournament_id', tournamentId)
+          .eq('status', 'final')
+          .order('game_date', { ascending: false }),
+        supabaseClient.rpc('get_tournament_stats_resolved', { p_tournament_id: tournamentId }),
+        supabaseClient
+          .from('team_players')
+          .select('jersey_number,players!inner(id,first_name,last_name,nickname)')
+          .eq('team_id', teamId)
+          .eq('is_active', true)
+          .order('joined_at', { ascending: true }),
+      ])
+
+      if (cancelled) return
+
+      if (tourRes.error || !tourRes.data) {
+        setError(tourRes.error?.message ?? 'Tournament not found')
+        setLoading(false)
+        return
+      }
+      const tr = tourRes.data as TournamentRow
+      if (tr.team_id !== teamId) {
+        setError('Tournament does not belong to this team.')
+        setLoading(false)
+        return
+      }
+      if (teamRes.error || !teamRes.data) {
+        setError(teamRes.error?.message ?? 'Team not found')
+        setLoading(false)
+        return
+      }
+
+      const teamData = teamRes.data as unknown as TeamRow
+      const sportCfg = sports.find(s => s.id === teamData.seasons.sport) ?? null
+      const finals = (gamesRes.data ?? []) as GameMeta[]
+
+      setTournament(tr)
+      setTeam(teamData)
+      setGames(finals)
+
+      type RosterJoin = { jersey_number: string | null; players: { id: string; first_name: string; last_name: string | null; nickname: string | null } }
+      setPlayers(
+        ((rosterRes.data ?? []) as unknown as RosterJoin[]).map(r => ({
+          id: r.players.id,
+          first_name: r.players.first_name,
+          last_name: r.players.last_name,
+          jersey_number: r.jersey_number,
+          nickname: r.players.nickname,
+        }))
+      )
+
+      if (statsRpc.error && isMissingRpcError(statsRpc.error.message)) {
+        const agg = new Map<string, Map<string, { total: number; games: Set<string>; high: number }>>()
+        for (const g of finals) {
+          const res = await supabaseClient.rpc('get_game_stats_resolved', { p_game_id: g.id })
+          if (res.error) continue
+          for (const row of (res.data ?? []) as { player_id: string; stat_id: string; value: number }[]) {
+            if (!agg.has(row.player_id)) agg.set(row.player_id, new Map())
+            const pm = agg.get(row.player_id)!
+            if (!pm.has(row.stat_id)) {
+              pm.set(row.stat_id, { total: 0, games: new Set(), high: 0 })
+            }
+            const e = pm.get(row.stat_id)!
+            e.total += Number(row.value)
+            e.games.add(g.id)
+            e.high = Math.max(e.high, Number(row.value))
+          }
+        }
+        const flat: StatRow[] = []
+        for (const [pid, sm] of agg) {
+          for (const [statId, e] of sm) {
+            const gp = e.games.size
+            flat.push({
+              player_id: pid,
+              stat_id: statId,
+              games_played: gp,
+              total: e.total,
+              per_game_avg: gp ? Math.round((e.total / gp) * 10) / 10 : 0,
+              tournament_high: e.high,
+            })
+          }
+        }
+        setStatRows(flat)
+      } else if (statsRpc.error) {
+        setError(statsRpc.error.message)
+        setLoading(false)
+        return
+      } else {
+        setStatRows((statsRpc.data ?? []) as StatRow[])
+      }
+
+      let w = 0
+      let l = 0
+      const lines: GameLine[] = []
+      if (sportCfg) {
+        for (const g of finals) {
+          const res = await supabaseClient.rpc('get_game_stats_resolved', { p_game_id: g.id })
+          const byStat: Record<string, number> = {}
+          if (!res.error) {
+            for (const row of (res.data ?? []) as { stat_id: string; value: number }[]) {
+              byStat[row.stat_id] = (byStat[row.stat_id] ?? 0) + Number(row.value)
+            }
+          }
+          const base = computePlayerScore(sportCfg, byStat)
+          const adj = g.home_score_adjustment ?? 0
+          const homeScore = base + adj
+          const opp = g.opponent_score
+          const decided = homeScore !== opp
+          const won = homeScore > opp
+          if (decided) {
+            if (won) w++
+            else l++
+          }
+          const compact =
+            Object.keys(byStat).length > 0 ? formatCompactGameStatLine(sportCfg, byStat) : '—'
+          lines.push({ game: g, homeScore, won, compact })
+        }
+      }
+      if (!cancelled) {
+        setWins(w)
+        setLosses(l)
+        setGameLines(lines)
+      }
+
+      setLoading(false)
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [tournamentId, teamId, isConfigured, supabaseClient])
+
+  const playerStatMap = useMemo(() => {
+    const m: Record<string, Record<string, number>> = {}
+    for (const r of statRows) {
+      if (!m[r.player_id]) m[r.player_id] = {}
+      m[r.player_id][r.stat_id] = r.total
+    }
+    return m
+  }, [statRows])
+
+  const gamesPlayedByPlayer = useMemo(() => {
+    const m: Record<string, number> = {}
+    for (const r of statRows) {
+      m[r.player_id] = Math.max(m[r.player_id] ?? 0, r.games_played)
+    }
+    return m
+  }, [statRows])
+
+  const leaderboardRows = useMemo(() => {
+    if (!sport) return []
+    return players
+      .map(p => {
+        const stats = playerStatMap[p.id] ?? {}
+        const score = computePlayerScore(sport, stats)
+        return { player: p, stats, score, gp: gamesPlayedByPlayer[p.id] ?? 0 }
+      })
+      .filter(r => Object.keys(r.stats).length > 0)
+      .sort((a, b) => b.score - a.score)
+  }, [players, playerStatMap, sport, gamesPlayedByPlayer])
+
+  const tournamentTotalsByStat = useMemo(() => {
+    const t: Record<string, number> = {}
+    for (const r of statRows) {
+      t[r.stat_id] = (t[r.stat_id] ?? 0) + r.total
+    }
+    return t
+  }, [statRows])
+
+  const shortLabel = (statId: string) => {
+    if (!sport) return statId
+    for (const cat of sport.categories) {
+      const a = cat.actions.find(x => x.id === statId)
+      if (a) return a.shortLabel
+    }
+    return statId
+  }
+
+  const gpTournament = games.length
+
+  if (!tournamentId || !teamId) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Missing parameters</p>
+          <button type="button" onClick={() => navigate('/leaderboard')} className="btn-primary w-full">
+            Leaderboard
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!isConfigured) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <p className="text-slate-600">Supabase required</p>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-slate-500 animate-pulse">Loading tournament…</p>
+      </div>
+    )
+  }
+
+  if (error || !team || !tournament) {
+    return (
+      <div className="min-h-screen flex flex-col px-4 py-6 max-w-lg mx-auto">
+        {error && <div className="card bg-red-50 text-red-700 text-sm mb-4">{error}</div>}
+        <button type="button" onClick={() => navigate(`/team-stats?teamId=${teamId}`)} className="btn-primary">
+          Back to team stats
+        </button>
+      </div>
+    )
+  }
+
+  const decided = wins + losses
+  const tourScore = sport ? computePlayerScore(sport, tournamentTotalsByStat) : 0
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="bg-gradient-to-r from-slate-700 to-slate-600 text-white px-4 py-4">
+        <div className="max-w-lg mx-auto flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => navigate(`/team-stats?teamId=${teamId}`)}
+            className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center active:scale-90 transition-transform"
+          >
+            ←
+          </button>
+          <div className="min-w-0">
+            <h1 className="text-lg font-bold truncate">🏆 {tournament.name}</h1>
+            <p className="text-sm opacity-80 truncate">
+              {sport?.icon} {teamDisplayName(team)} · {team.seasons.name}
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex-1 px-4 py-6 max-w-lg mx-auto w-full space-y-4">
+        <section className="card space-y-2">
+          <h2 className="font-semibold text-slate-700">Record</h2>
+          <div className="flex gap-3 flex-wrap">
+            <div className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-2 text-center flex-1 min-w-[72px]">
+              <p className="text-xl font-bold text-emerald-700">{wins}</p>
+              <p className="text-xs text-slate-500">W</p>
+            </div>
+            <div className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-2 text-center flex-1 min-w-[72px]">
+              <p className="text-xl font-bold text-rose-700">{losses}</p>
+              <p className="text-xs text-slate-500">L</p>
+            </div>
+            <div className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-2 text-center flex-1 min-w-[72px]">
+              <p className="text-xl font-bold text-slate-800">{games.length}</p>
+              <p className="text-xs text-slate-500">Games</p>
+            </div>
+            {placementLabel(tournament.placement) && (
+              <div className="rounded-xl border border-amber-100 bg-amber-50 px-4 py-2 text-center flex-1 min-w-[72px]">
+                <p className="text-sm font-bold text-amber-900">{placementLabel(tournament.placement)}</p>
+                <p className="text-xs text-amber-800/80">Placement</p>
+              </div>
+            )}
+          </div>
+          {decided > 0 && (
+            <p className="text-xs text-slate-500">{((wins / decided) * 100).toFixed(0)}% wins</p>
+          )}
+        </section>
+
+        {sport && Object.keys(tournamentTotalsByStat).length > 0 && (
+          <section className="card space-y-3">
+            <h2 className="font-semibold text-slate-700">Tournament totals</h2>
+            <p className="text-sm text-slate-600">
+              {tourScore} {sport.scoreLabel} · {gpTournament} GP
+            </p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              {Object.entries(tournamentTotalsByStat).map(([statId, total]) => (
+                <div key={statId} className="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2">
+                  <p className="text-xs text-slate-500">{shortLabel(statId)}</p>
+                  <p className="font-semibold text-slate-800">{total}</p>
+                  {gpTournament > 0 && (
+                    <p className="text-xs text-slate-400">{(total / gpTournament).toFixed(1)}/g</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section className="card space-y-3">
+          <h2 className="font-semibold text-slate-700">Leaderboard</h2>
+          {leaderboardRows.length === 0 ? (
+            <p className="text-sm text-slate-500">No stats in this tournament yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {leaderboardRows.map((row, idx) => (
+                <button
+                  key={row.player.id}
+                  type="button"
+                  onClick={() =>
+                    navigate(
+                      `/player?teamId=${teamId}&playerId=${row.player.id}&seasonId=${team.season_id}`
+                    )
+                  }
+                  className="w-full text-left rounded-xl border border-slate-200 bg-white px-3 py-2
+                             hover:border-blue-200 hover:bg-blue-50/40 transition-colors"
+                >
+                  <div className="flex justify-between gap-2">
+                    <span className="text-slate-500 w-6 shrink-0">{idx + 1}.</span>
+                    <div className="flex-1 min-w-0">
+                      <span className="text-slate-500 text-sm">#{row.player.jersey_number || '—'} </span>
+                      <span className="font-medium text-slate-800">{playerDisplayName(row.player)}</span>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <p className="font-semibold text-slate-800">
+                        {row.score} {sport?.scoreLabel}
+                      </p>
+                      <p className="text-xs text-slate-500">{row.gp} GP</p>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="card space-y-3">
+          <h2 className="font-semibold text-slate-700">Games</h2>
+          {gameLines.length === 0 ? (
+            <p className="text-sm text-slate-500">No finalized games in this tournament.</p>
+          ) : (
+            <div className="space-y-2">
+              {gameLines.map(({ game, homeScore, won, compact }) => (
+                <div key={game.id} className="rounded-xl border border-slate-200 bg-white px-3 py-2">
+                  <div className="flex justify-between gap-2">
+                    <div>
+                      <p className="font-medium text-slate-800">{game.game_date}</p>
+                      <p className="text-sm text-slate-600">vs {game.opponent_name}</p>
+                    </div>
+                    <span
+                      className={`text-sm font-semibold shrink-0 ${won ? 'text-emerald-700' : 'text-rose-700'}`}
+                    >
+                      {homeScore === game.opponent_score ? 'T' : won ? 'W' : 'L'} {homeScore}-{game.opponent_score}
+                    </span>
+                  </div>
+                  <p className="text-xs text-slate-500 mt-1">{compact}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/supabase/migrations/021_tournament_stats_rpc.sql
+++ b/supabase/migrations/021_tournament_stats_rpc.sql
@@ -1,0 +1,37 @@
+-- Tournament-scoped resolved stats (Phase 6 continuation).
+-- See docs/DESIGN_STAT_TRACKING_UI.md §3.5
+
+CREATE OR REPLACE FUNCTION public.get_tournament_stats_resolved(p_tournament_id uuid)
+RETURNS TABLE (
+  player_id uuid,
+  stat_id text,
+  games_played bigint,
+  total bigint,
+  per_game_avg numeric,
+  tournament_high int
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH game_resolved AS (
+    SELECT g.id AS game_id, r.player_id, r.stat_id, r.value
+    FROM public.games g
+    CROSS JOIN LATERAL public.get_game_stats_resolved(g.id) r
+    WHERE g.tournament_id = p_tournament_id
+      AND g.status = 'final'
+  )
+  SELECT
+    gr.player_id,
+    gr.stat_id,
+    COUNT(DISTINCT gr.game_id) AS games_played,
+    SUM(gr.value)::bigint AS total,
+    ROUND(AVG(gr.value), 1) AS per_game_avg,
+    MAX(gr.value)::int AS tournament_high
+  FROM game_resolved gr
+  GROUP BY gr.player_id, gr.stat_id;
+$$;
+
+COMMENT ON FUNCTION public.get_tournament_stats_resolved(uuid) IS
+  'Per-player resolved stats across finalized games in a tournament (DESIGN_STAT_TRACKING_UI).';


### PR DESCRIPTION
… tabs

- Add 021_tournament_stats_rpc: get_tournament_stats_resolved
- TournamentStats page + /tournament-stats route; fallback if RPC missing
- TeamStats: Stats → link per tournament
- GameSummary: Players / Team tab (team = score + totals only)
- Docs: README 021, progress + design tables, regression 9.11–9.12