### PR TITLE
feat(stat-ui): keyStatIds all sports, team by-opponent, games list po…

### DIFF
--- a/docs/DESIGN_STAT_TRACKING_UI.md
+++ b/docs/DESIGN_STAT_TRACKING_UI.md
@@ -13,7 +13,7 @@ Redesign the stat viewing pages to support **career stats**, **season-scoped sta
 | Team Season Summary `/team-stats` | Done (MVP: record, totals, game list) |
 | Tournament stats page + `get_tournament_stats_resolved` RPC | Done (`021_tournament_stats_rpc.sql`, `/tournament-stats`) |
 | Game Summary Players / Team tab | Done (toggle on summary) |
-| `SportConfig.keyStats` + shared compact line helper | Partial (`keyStatIds` + `statDisplay.ts`; basketball only) |
+| `SportConfig.keyStats` + shared compact line helper | Done (`keyStatIds` on all sports + `statDisplay.ts`) |
 
 Detailed checklist: [STAT_TRACKING_UI_PROGRESS.md](STAT_TRACKING_UI_PROGRESS.md).
 

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -135,6 +135,8 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 6.8 | Cloud Games → open finalized game | View Summary (read-only) |
 | 6.9 | Second device/session: sign in → Cloud Games | Same game list; resume same game if in progress |
 | 6.10 | Cloud Games → tap ✏️ next to opponent name on any game card | Inline input appears; type new name → Save | Opponent name updates on card; persists after reload |
+| 6.11 | Cloud Games → **Final** game card | Shows home–away score (from resolved stats + adjustment) when RPC succeeds |
+| 6.12 | Cloud Games → game with `tournament_id` | **Tournament stats** link next to tournament name opens `/tournament-stats` |
 | 6.11 | Cloud Games → Edit opponent name → press Escape or ✕ | Edit cancelled; original name restored |
 
 ---
@@ -188,6 +190,7 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 9.10 | Teams → roster **Career** on a player | Same as 9.9 |
 | 9.11 | Team stats → tournament row **Stats →** | Opens tournament stats; W/L and leaderboard when games have `tournament_id` |
 | 9.12 | Game Summary → **Team** tab | Only team totals tables + score card; **Players** shows full grid |
+| 9.13 | Team stats → **By opponent** | Table lists opponents with W-L-T and PF-PA when multiple finals exist |
 
 ---
 

--- a/docs/STAT_TRACKING_UI_PROGRESS.md
+++ b/docs/STAT_TRACKING_UI_PROGRESS.md
@@ -16,14 +16,22 @@ Parent plan: [DESIGN_STAT_TRACKING_UI.md](DESIGN_STAT_TRACKING_UI.md) · Seasons
 
 - [x] **Tournament stats** page `/tournament-stats` + migration **021** `get_tournament_stats_resolved` (fallback aggregates per game if RPC missing)
 - [x] **Game Summary** Players / Team tab (team tab = score card + team totals tables only)
-- [ ] **`keyStatIds`** for sports other than basketball (optional)
-- [ ] Team season summary: per-opponent table (optional)
+- [x] **`keyStatIds`** for baseball, football, hockey, soccer + `statDisplay` uses only configured keys (no bogus basketball ids)
+- [x] Team season summary: **By opponent** table (aggregated W-L-T, PF-PA, +/-)
+- [x] **Cloud Games** list: `teamDisplayName`, final score line via `get_game_stats_resolved`, **Tournament stats** link when `tournament_id` set
 
 ## Latest slice (021 + UI)
 
 - `021_tournament_stats_rpc.sql`
 - `TournamentStats.tsx`, route, Team stats → **Stats →** per tournament
 - `GameSummary.tsx`: **Players** / **Team** toggle (alongside cloud Primary/All when applicable)
+
+## Slice: polish (keyStatIds, team by-opponent, games list)
+
+- `sports.ts`: `keyStatIds` for all sports
+- `statDisplay.ts`: score label helper; only iterate `keyStatIds` when set
+- `TeamStats.tsx`: **By opponent** section
+- `Games.tsx`: nickname + season in team query, score on final cards, tournament deep link
 
 ## Apply in Supabase
 

--- a/src/config/sports.ts
+++ b/src/config/sports.ts
@@ -80,6 +80,7 @@ export const sports: SportConfig[] = [
       gradient: 'from-red-600 to-red-500',
     },
     scoreLabel: 'Runs',
+    keyStatIds: ['r', 'rbi', 'hr', 'sb'],
     categories: [
       {
         id: 'hitting',
@@ -140,6 +141,7 @@ export const sports: SportConfig[] = [
       gradient: 'from-green-700 to-green-600',
     },
     scoreLabel: 'Points',
+    keyStatIds: ['pass_td', 'rush_td', 'rec_td', 'fg'],
     categories: [
       {
         id: 'passing',
@@ -206,6 +208,7 @@ export const sports: SportConfig[] = [
       gradient: 'from-blue-600 to-cyan-500',
     },
     scoreLabel: 'Goals',
+    keyStatIds: ['goal', 'h_ast', 'shot'],
     categories: [
       {
         id: 'offense',
@@ -263,6 +266,7 @@ export const sports: SportConfig[] = [
       gradient: 'from-emerald-600 to-teal-500',
     },
     scoreLabel: 'Goals',
+    keyStatIds: ['s_goal', 's_ast', 's_shot'],
     categories: [
       {
         id: 'attack',

--- a/src/lib/statDisplay.ts
+++ b/src/lib/statDisplay.ts
@@ -9,20 +9,25 @@ function statShortLabel(sport: SportConfig, statId: string): string {
   return statId
 }
 
-/** Compact "12 PTS · 4 REB · 3 AST" for one game's resolved stat map. */
+function scoreLineLabel(sport: SportConfig): string {
+  if (sport.scoreLabel === 'Points') return 'PTS'
+  return sport.scoreLabel
+}
+
+/** Compact per-game line for game logs (sport-aware). */
 export function formatCompactGameStatLine(sport: SportConfig, stats: Record<string, number>): string {
   const parts: string[] = []
   const score = computePlayerScore(sport, stats)
-  const scoreLabel = sport.scoreLabel === 'Points' ? 'PTS' : sport.scoreLabel
-  parts.push(`${score} ${scoreLabel}`)
+  parts.push(`${score} ${scoreLineLabel(sport)}`)
 
   if (sport.id === 'basketball') {
     const reb = (stats.oreb ?? 0) + (stats.dreb ?? 0)
     if (reb > 0) parts.push(`${reb} REB`)
   }
 
-  const keys = sport.keyStatIds?.length ? sport.keyStatIds : ['ast', 'stl', 'blk']
+  const keys = sport.keyStatIds?.length ? sport.keyStatIds : []
   for (const id of keys) {
+    if (sport.id === 'basketball' && (id === 'oreb' || id === 'dreb')) continue
     const v = stats[id] ?? 0
     if (v > 0) parts.push(`${v} ${statShortLabel(sport, id)}`)
   }

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
 import { supabase } from '../lib/supabase'
 import { loadCloudGameById, touchCloudGameLastOpened } from '../lib/cloudSync'
-import { sports } from '../config/sports'
+import { sports, computePlayerScore } from '../config/sports'
 import type { GameState } from '../types'
 import ConfirmDialog from '../components/ConfirmDialog'
+import { teamDisplayName } from '../lib/display'
 
 interface GameRow {
   id: string
@@ -14,6 +15,8 @@ interface GameRow {
   opponent_name: string
   opponent_score: number
   tournament_name: string | null
+  tournament_id: string | null
+  home_score_adjustment: number | null
   game_date: string
   status: string
   created_at: string
@@ -22,6 +25,8 @@ interface GameRow {
 interface TeamRow {
   id: string
   name: string
+  nickname: string | null
+  season_id: string
   seasons: { sport: string }
 }
 
@@ -60,6 +65,7 @@ export default function Games() {
 
   const [games, setGames] = useState<GameRow[]>([])
   const [teamMap, setTeamMap] = useState<Record<string, TeamRow>>({})
+  const [finalScoreLines, setFinalScoreLines] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(false)
   const [loadingGameId, setLoadingGameId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -80,7 +86,9 @@ export default function Games() {
 
       const { data: gameRows, error: gamesError } = await supabaseClient
         .from('games')
-        .select('id,team_id,opponent_name,opponent_score,tournament_name,game_date,status,created_at')
+        .select(
+          'id,team_id,opponent_name,opponent_score,tournament_name,tournament_id,home_score_adjustment,game_date,status,created_at'
+        )
         .eq('created_by', userId)
         .order('created_at', { ascending: false })
 
@@ -103,7 +111,7 @@ export default function Games() {
 
       const { data: teams, error: teamsError } = await supabaseClient
         .from('teams')
-        .select('id,name,seasons!inner(sport)')
+        .select('id,name,nickname,season_id,seasons!inner(sport)')
         .in('id', teamIds)
 
       if (cancelled) return
@@ -119,6 +127,8 @@ export default function Games() {
         map[row.id] = {
           id: row.id,
           name: row.name,
+          nickname: row.nickname ?? null,
+          season_id: row.season_id,
           seasons: seasons ?? { sport: '' },
         }
         return map
@@ -132,6 +142,45 @@ export default function Games() {
       cancelled = true
     }
   }, [isConfigured, supabaseClient, userId])
+
+  useEffect(() => {
+    if (!supabaseClient) return
+    const finals = games.filter(g => g.status === 'final')
+    if (finals.length === 0) {
+      setFinalScoreLines({})
+      return
+    }
+
+    let cancelled = false
+    const loadScores = async () => {
+      const next: Record<string, string> = {}
+      for (const g of finals) {
+        const team = teamMap[g.team_id]
+        const sport = sports.find(s => s.id === team?.seasons?.sport)
+        if (!sport) continue
+
+        const { data, error: rpcError } = await supabaseClient.rpc('get_game_stats_resolved', {
+          p_game_id: g.id,
+        })
+        if (cancelled || rpcError) continue
+
+        const byStat: Record<string, number> = {}
+        for (const row of (data ?? []) as { stat_id: string; value: number }[]) {
+          byStat[row.stat_id] = (byStat[row.stat_id] ?? 0) + Number(row.value)
+        }
+        const base = computePlayerScore(sport, byStat)
+        const adj = g.home_score_adjustment ?? 0
+        const home = base + adj
+        next[g.id] = `${home}–${g.opponent_score}`
+      }
+      if (!cancelled) setFinalScoreLines(next)
+    }
+
+    void loadScores()
+    return () => {
+      cancelled = true
+    }
+  }, [games, teamMap, supabaseClient])
 
   const grouped = useMemo(() => {
     const finalGames = games.filter(game => game.status === 'final')
@@ -254,11 +303,13 @@ export default function Games() {
   const renderGameCard = (game: GameRow) => {
     const team = teamMap[game.team_id]
     const sport = sports.find(item => item.id === team?.seasons?.sport)
+    const scoreHint = game.status === 'final' ? finalScoreLines[game.id] : null
+
     return (
       <div key={game.id} className="card">
         <div className="flex items-center justify-between mb-2">
           <p className="font-semibold text-slate-700">
-            {sport?.icon ?? '🏟️'} {team?.name ?? 'Unknown Team'}
+            {sport?.icon ?? '🏟️'} {team ? teamDisplayName(team) : 'Unknown Team'}
           </p>
           <span className={`text-[11px] px-2 py-1 rounded-full font-semibold ${statusBadge(game.status)}`}>
             {statusLabel(game.status)}
@@ -273,7 +324,10 @@ export default function Games() {
               onChange={e => setEditingOpponentName(e.target.value)}
               className="input-field flex-1 text-sm py-1"
               autoFocus
-              onKeyDown={e => { if (e.key === 'Enter') void handleSaveOpponentName(); if (e.key === 'Escape') cancelEditOpponentName() }}
+              onKeyDown={e => {
+                if (e.key === 'Enter') void handleSaveOpponentName()
+                if (e.key === 'Escape') cancelEditOpponentName()
+              }}
             />
             <button
               onClick={() => { void handleSaveOpponentName() }}
@@ -290,8 +344,11 @@ export default function Games() {
             </button>
           </div>
         ) : (
-          <div className="flex items-center gap-1 mt-1">
+          <div className="flex items-center gap-1 mt-1 flex-wrap">
             <p className="text-sm text-slate-600">vs {game.opponent_name}</p>
+            {scoreHint && (
+              <span className="text-sm font-semibold text-slate-800 tabular-nums">{scoreHint}</span>
+            )}
             <button
               onClick={() => startEditOpponentName(game)}
               className="text-slate-300 hover:text-slate-500 transition-colors p-0.5"
@@ -303,7 +360,17 @@ export default function Games() {
           </div>
         )}
         {game.tournament_name && (
-          <p className="text-xs text-slate-400 mt-0.5">🏆 {game.tournament_name}</p>
+          <div className="text-xs text-slate-400 mt-0.5 flex flex-wrap items-center gap-2">
+            <span>🏆 {game.tournament_name}</span>
+            {game.tournament_id && team && (
+              <Link
+                to={`/tournament-stats?tournamentId=${encodeURIComponent(game.tournament_id)}&teamId=${encodeURIComponent(game.team_id)}`}
+                className="text-blue-600 font-semibold underline"
+              >
+                Tournament stats
+              </Link>
+            )}
+          </div>
         )}
         <p className="text-xs text-slate-400 mt-1">
           {game.game_date}

--- a/src/pages/TeamStats.tsx
+++ b/src/pages/TeamStats.tsx
@@ -212,6 +212,27 @@ export default function TeamStats() {
     return { lines, wins, losses, total: games.length }
   }, [games, logRows, useRpc, sport])
 
+  const opponentBreakdown = useMemo(() => {
+    const map = new Map<
+      string,
+      { name: string; wins: number; losses: number; ties: number; pf: number; pa: number; gp: number }
+    >()
+    for (const row of gameLines.lines) {
+      const name = row.game.opponent_name.trim() || 'Unknown'
+      if (!map.has(name)) {
+        map.set(name, { name, wins: 0, losses: 0, ties: 0, pf: 0, pa: 0, gp: 0 })
+      }
+      const o = map.get(name)!
+      o.gp += 1
+      o.pf += row.homeScore
+      o.pa += row.game.opponent_score
+      if (row.homeScore === row.game.opponent_score) o.ties += 1
+      else if (row.won) o.wins += 1
+      else o.losses += 1
+    }
+    return [...map.values()].sort((a, b) => a.name.localeCompare(b.name))
+  }, [gameLines.lines])
+
   if (!teamId) {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center px-4">
@@ -329,6 +350,57 @@ export default function TeamStats() {
                 </li>
               ))}
             </ul>
+          </section>
+        )}
+
+        {opponentBreakdown.length > 0 && (
+          <section className="card space-y-3">
+            <h2 className="font-semibold text-slate-700">By opponent</h2>
+            <p className="text-xs text-slate-500">
+              Combined results when you played the same opponent more than once.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 text-left">
+                    <th className="py-2 pr-2 font-semibold text-slate-600">Opponent</th>
+                    <th className="py-2 px-1 font-semibold text-slate-600 text-center">W-L-T</th>
+                    <th className="py-2 pl-2 font-semibold text-slate-600 text-right">PF-PA</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {opponentBreakdown.map(row => {
+                    const decided = row.wins + row.losses
+                    const plusMinus = row.pf - row.pa
+                    return (
+                      <tr key={row.name} className="border-b border-slate-100">
+                        <td className="py-2 pr-2 font-medium text-slate-800 max-w-[140px] truncate">
+                          {row.name}
+                        </td>
+                        <td className="py-2 px-1 text-center tabular-nums text-slate-700">
+                          {row.wins}-{row.losses}-{row.ties}
+                          {decided > 0 && (
+                            <span className="text-slate-400 text-xs block">
+                              {((row.wins / decided) * 100).toFixed(0)}%
+                            </span>
+                          )}
+                        </td>
+                        <td className="py-2 pl-2 text-right tabular-nums">
+                          <span className="text-slate-800">
+                            {row.pf}-{row.pa}
+                          </span>
+                          <span
+                            className={`text-xs ml-1 ${plusMinus > 0 ? 'text-emerald-600' : plusMinus < 0 ? 'text-rose-600' : 'text-slate-400'}`}
+                          >
+                            ({plusMinus > 0 ? '+' : ''}{plusMinus})
+                          </span>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
           </section>
         )}
 


### PR DESCRIPTION
…lish

- sports: keyStatIds for baseball, football, hockey, soccer
- statDisplay: scoreLineLabel; only use keyStatIds (no default bb-only ids)
- TeamStats: By opponent table (W-L-T, PF-PA, +/−)
- Games: team nickname+season_id query, teamDisplayName, final score from get_game_stats_resolved, tournament stats link when tournament_id set
- Docs: progress, design table, regression 6.11–6.12, 9.13