### PR TITLE
feat: leaderboard career links and editable tournament placement

### DIFF
--- a/docs/DESIGN_STAT_TRACKING_UI.md
+++ b/docs/DESIGN_STAT_TRACKING_UI.md
@@ -7,11 +7,11 @@ Redesign the stat viewing pages to support **career stats**, **season-scoped sta
 | Item | Status |
 |------|--------|
 | Migration `020_stat_tracking_ui_rpcs.sql` (`get_player_game_log`, `get_career_stats_resolved`, `get_team_game_log`) | Done in repo — apply in Supabase |
-| Leaderboard season selector + `seasonId` URL + GP + Team Stats link | Done |
+| Leaderboard season selector + `seasonId` URL + GP + Team Stats link + **Career** link per row | Done |
 | Player Profile season label + Career link + inline game log (RPC + fallback) | Done |
 | Career page `/career` | Done |
 | Team Season Summary `/team-stats` | Done (MVP: record, totals, game list) |
-| Tournament stats page + `get_tournament_stats_resolved` RPC | Done (`021_tournament_stats_rpc.sql`, `/tournament-stats`) |
+| Tournament stats page + `get_tournament_stats_resolved` RPC | Done (`021_tournament_stats_rpc.sql`, `/tournament-stats`; owner/admin can edit `placement`; **Career** links on tournament leaderboard) |
 | Game Summary Players / Team tab | Done (toggle on summary) |
 | `SportConfig.keyStats` + shared compact line helper | Done (`keyStatIds` on all sports + `statDisplay.ts`) |
 

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -191,6 +191,8 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 9.11 | Team stats → tournament row **Stats →** | Opens tournament stats; W/L and leaderboard when games have `tournament_id` |
 | 9.12 | Game Summary → **Team** tab | Only team totals tables + score card; **Players** shows full grid |
 | 9.13 | Team stats → **By opponent** | Table lists opponents with W-L-T and PF-PA when multiple finals exist |
+| 9.14 | Leaderboard: tap **Career** on a row (not the main row) | Opens `/career` with that `playerId` and the season’s sport |
+| 9.15 | Tournament stats (as owner/admin): **Placement** → enter place (e.g. 2) → **Save placement** | Record card shows placement (e.g. 2nd); blank + save clears placement |
 
 ---
 

--- a/docs/STAT_TRACKING_UI_PROGRESS.md
+++ b/docs/STAT_TRACKING_UI_PROGRESS.md
@@ -5,7 +5,7 @@ Parent plan: [DESIGN_STAT_TRACKING_UI.md](DESIGN_STAT_TRACKING_UI.md) · Seasons
 ## Done (this branch)
 
 - [x] Migration **`020_stat_tracking_ui_rpcs.sql`**: `get_player_game_log`, `get_career_stats_resolved`, `get_team_game_log`
-- [x] **Leaderboard**: season dropdown, URL `seasonId` + `teamId`, games played on rows, **Team stats →** link
+- [x] **Leaderboard**: season dropdown, URL `seasonId` + `teamId`, games played on rows, **Team stats →** link, **Career** link per row (opens `/career` with `playerId` + season sport)
 - [x] **Player profile**: season line in header, **Career →**, inline game log (RPC; N×`get_game_stats_resolved` fallback if RPC missing)
 - [x] **`/career`**: career totals + by-season list; multi-sport picker when needed
 - [x] **`/team-stats`**: W/L, tournaments list + placement, game-by-game (RPC or per-game fallback)
@@ -19,6 +19,7 @@ Parent plan: [DESIGN_STAT_TRACKING_UI.md](DESIGN_STAT_TRACKING_UI.md) · Seasons
 - [x] **`keyStatIds`** for baseball, football, hockey, soccer + `statDisplay` uses only configured keys (no bogus basketball ids)
 - [x] Team season summary: **By opponent** table (aggregated W-L-T, PF-PA, +/-)
 - [x] **Cloud Games** list: `teamDisplayName`, final score line via `get_game_stats_resolved`, **Tournament stats** link when `tournament_id` set
+- [x] **Tournament stats**: **Career** link per leaderboard row; team **owner/admin** can edit **placement** (`tournaments.placement`) in-app
 
 ## Latest slice (021 + UI)
 
@@ -32,6 +33,11 @@ Parent plan: [DESIGN_STAT_TRACKING_UI.md](DESIGN_STAT_TRACKING_UI.md) · Seasons
 - `statDisplay.ts`: score label helper; only iterate `keyStatIds` when set
 - `TeamStats.tsx`: **By opponent** section
 - `Games.tsx`: nickname + season in team query, score on final cards, tournament deep link
+
+## Slice: leaderboard career + editable tournament placement
+
+- `Leaderboard.tsx`: row layout with **Career** link (HashRouter-safe `Link`)
+- `TournamentStats.tsx`: same **Career** links on tournament leaderboard; **Placement** form for owners/admins (updates `tournaments.placement`, blank clears)
 
 ## Apply in Supabase
 

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, useCallback } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { sports, computePlayerScore } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
@@ -399,42 +399,51 @@ export default function Leaderboard() {
             ) : (
               <div className="space-y-2">
                 {leaderboardRows.map((row, idx) => (
-                  <button
+                  <div
                     key={row.player.id}
-                    type="button"
-                    onClick={() =>
-                      navigate(
-                        `/player?teamId=${selectedTeamId}&playerId=${row.player.id}&seasonId=${selectedSeasonId}`
-                      )
-                    }
-                    className="w-full text-left rounded-xl border border-slate-200 bg-white
-                               px-3 py-2 hover:border-blue-200 hover:bg-blue-50/50 transition-colors
-                               active:scale-[0.99]"
+                    className="flex items-stretch gap-1 rounded-xl border border-slate-200 bg-white overflow-hidden
+                               hover:border-blue-200 transition-colors"
                   >
-                    <div className="flex items-center justify-between gap-2">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <span className="text-slate-400 shrink-0 w-6">
-                          {idx + 1}.
-                        </span>
-                        <span className="text-slate-500 shrink-0">
-                          #{row.player.jersey_number || '—'}
-                        </span>
-                        <p className="font-medium text-slate-700 truncate">
-                          {playerDisplayName(row.player)}
-                        </p>
-                      </div>
-                      <div className="flex flex-col items-end shrink-0 text-right">
-                        {sport?.scoreLabel && (
-                          <span className="font-semibold text-slate-800">
-                            {row.score} {sport.scoreLabel}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        navigate(
+                          `/player?teamId=${selectedTeamId}&playerId=${row.player.id}&seasonId=${selectedSeasonId}`
+                        )
+                      }
+                      className="flex-1 text-left px-3 py-2 hover:bg-blue-50/50 active:scale-[0.99] min-w-0"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className="text-slate-400 shrink-0 w-6">
+                            {idx + 1}.
                           </span>
-                        )}
-                        <span className="text-xs text-slate-500">
-                          {row.gamesPlayed} GP
-                        </span>
+                          <span className="text-slate-500 shrink-0">
+                            #{row.player.jersey_number || '—'}
+                          </span>
+                          <p className="font-medium text-slate-700 truncate">
+                            {playerDisplayName(row.player)}
+                          </p>
+                        </div>
+                        <div className="flex flex-col items-end shrink-0 text-right">
+                          {sport?.scoreLabel && (
+                            <span className="font-semibold text-slate-800">
+                              {row.score} {sport.scoreLabel}
+                            </span>
+                          )}
+                          <span className="text-xs text-slate-500">
+                            {row.gamesPlayed} GP
+                          </span>
+                        </div>
                       </div>
-                    </div>
-                  </button>
+                    </button>
+                    <Link
+                      to={`/career?playerId=${encodeURIComponent(row.player.id)}&sport=${encodeURIComponent(selectedTeam.seasons.sport)}`}
+                      className="shrink-0 flex items-center px-2.5 text-xs font-semibold text-blue-600 bg-slate-50 border-l border-slate-100 hover:bg-blue-50"
+                    >
+                      Career
+                    </Link>
+                  </div>
                 ))}
               </div>
             )}

--- a/src/pages/TournamentStats.tsx
+++ b/src/pages/TournamentStats.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { sports, computePlayerScore } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
@@ -71,7 +71,7 @@ export default function TournamentStats() {
   const tournamentId = searchParams.get('tournamentId')
   const teamId = searchParams.get('teamId')
 
-  const { isConfigured } = useAuth()
+  const { isConfigured, user } = useAuth()
   const supabaseClient = supabase
 
   const [team, setTeam] = useState<TeamRow | null>(null)
@@ -84,6 +84,10 @@ export default function TournamentStats() {
   const [losses, setLosses] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [canEditPlacement, setCanEditPlacement] = useState(false)
+  const [placementDraft, setPlacementDraft] = useState<string>('')
+  const [savingPlacement, setSavingPlacement] = useState(false)
+  const [placementError, setPlacementError] = useState<string | null>(null)
 
   const sport = useMemo(
     () => (team ? sports.find(s => s.id === team.seasons.sport) ?? null : null),
@@ -244,6 +248,37 @@ export default function TournamentStats() {
     }
   }, [tournamentId, teamId, isConfigured, supabaseClient])
 
+  useEffect(() => {
+    if (!teamId || !user?.id || !supabaseClient) {
+      setCanEditPlacement(false)
+      return
+    }
+    let cancelled = false
+    const loadRole = async () => {
+      const { data } = await supabaseClient
+        .from('team_members')
+        .select('role')
+        .eq('team_id', teamId)
+        .eq('user_id', user.id)
+        .maybeSingle()
+      if (cancelled) return
+      const role = (data as { role?: string } | null)?.role
+      setCanEditPlacement(role === 'owner' || role === 'admin')
+    }
+    void loadRole()
+    return () => {
+      cancelled = true
+    }
+  }, [teamId, user?.id, supabaseClient])
+
+  useEffect(() => {
+    if (tournament?.placement != null) {
+      setPlacementDraft(String(tournament.placement))
+    } else {
+      setPlacementDraft('')
+    }
+  }, [tournament?.placement, tournament?.id])
+
   const playerStatMap = useMemo(() => {
     const m: Record<string, Record<string, number>> = {}
     for (const r of statRows) {
@@ -291,6 +326,32 @@ export default function TournamentStats() {
   }
 
   const gpTournament = games.length
+
+  const handleSavePlacement = async () => {
+    if (!supabaseClient || !tournamentId || !canEditPlacement) return
+    setPlacementError(null)
+    const trimmed = placementDraft.trim()
+    let value: number | null = null
+    if (trimmed !== '') {
+      const n = parseInt(trimmed, 10)
+      if (Number.isNaN(n) || n < 1) {
+        setPlacementError('Enter a positive whole number (1 = 1st), or leave blank to clear.')
+        return
+      }
+      value = n
+    }
+    setSavingPlacement(true)
+    const { error: upErr } = await supabaseClient
+      .from('tournaments')
+      .update({ placement: value })
+      .eq('id', tournamentId)
+    setSavingPlacement(false)
+    if (upErr) {
+      setPlacementError(upErr.message)
+      return
+    }
+    setTournament(prev => (prev ? { ...prev, placement: value } : prev))
+  }
 
   if (!tournamentId || !teamId) {
     return (
@@ -383,6 +444,43 @@ export default function TournamentStats() {
           )}
         </section>
 
+        {canEditPlacement && tournament && (
+          <section className="card space-y-2">
+            <h2 className="font-semibold text-slate-700">Placement</h2>
+            <p className="text-xs text-slate-500">
+              Set finish place for this tournament (1 = 1st, 2 = 2nd, …). Leave blank to clear.
+            </p>
+            <div className="flex flex-wrap items-end gap-2">
+              <div className="flex-1 min-w-[100px]">
+                <label htmlFor="tournament-placement" className="text-xs text-slate-500 block mb-1">
+                  Place
+                </label>
+                <input
+                  id="tournament-placement"
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={placementDraft}
+                  onChange={e => setPlacementDraft(e.target.value)}
+                  placeholder="e.g. 2"
+                  className="input-field"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => { void handleSavePlacement() }}
+                disabled={savingPlacement}
+                className="btn-primary py-2 px-4"
+              >
+                {savingPlacement ? 'Saving…' : 'Save placement'}
+              </button>
+            </div>
+            {placementError && (
+              <p className="text-xs text-red-600">{placementError}</p>
+            )}
+          </section>
+        )}
+
         {sport && Object.keys(tournamentTotalsByStat).length > 0 && (
           <section className="card space-y-3">
             <h2 className="font-semibold text-slate-700">Tournament totals</h2>
@@ -410,31 +508,43 @@ export default function TournamentStats() {
           ) : (
             <div className="space-y-2">
               {leaderboardRows.map((row, idx) => (
-                <button
+                <div
                   key={row.player.id}
-                  type="button"
-                  onClick={() =>
-                    navigate(
-                      `/player?teamId=${teamId}&playerId=${row.player.id}&seasonId=${team.season_id}`
-                    )
-                  }
-                  className="w-full text-left rounded-xl border border-slate-200 bg-white px-3 py-2
-                             hover:border-blue-200 hover:bg-blue-50/40 transition-colors"
+                  className="flex items-stretch gap-1 rounded-xl border border-slate-200 bg-white overflow-hidden
+                             hover:border-blue-200 transition-colors"
                 >
-                  <div className="flex justify-between gap-2">
-                    <span className="text-slate-500 w-6 shrink-0">{idx + 1}.</span>
-                    <div className="flex-1 min-w-0">
-                      <span className="text-slate-500 text-sm">#{row.player.jersey_number || '—'} </span>
-                      <span className="font-medium text-slate-800">{playerDisplayName(row.player)}</span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      navigate(
+                        `/player?teamId=${teamId}&playerId=${row.player.id}&seasonId=${team.season_id}`
+                      )
+                    }
+                    className="flex-1 text-left px-3 py-2 hover:bg-blue-50/40 min-w-0"
+                  >
+                    <div className="flex justify-between gap-2">
+                      <span className="text-slate-500 w-6 shrink-0">{idx + 1}.</span>
+                      <div className="flex-1 min-w-0">
+                        <span className="text-slate-500 text-sm">#{row.player.jersey_number || '—'} </span>
+                        <span className="font-medium text-slate-800">{playerDisplayName(row.player)}</span>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <p className="font-semibold text-slate-800">
+                          {row.score} {sport?.scoreLabel}
+                        </p>
+                        <p className="text-xs text-slate-500">{row.gp} GP</p>
+                      </div>
                     </div>
-                    <div className="text-right shrink-0">
-                      <p className="font-semibold text-slate-800">
-                        {row.score} {sport?.scoreLabel}
-                      </p>
-                      <p className="text-xs text-slate-500">{row.gp} GP</p>
-                    </div>
-                  </div>
-                </button>
+                  </button>
+                  {team && (
+                    <Link
+                      to={`/career?playerId=${encodeURIComponent(row.player.id)}&sport=${encodeURIComponent(team.seasons.sport)}`}
+                      className="shrink-0 flex items-center px-2.5 text-xs font-semibold text-blue-600 bg-slate-50 border-l border-slate-100 hover:bg-blue-50"
+                    >
+                      Career
+                    </Link>
+                  )}
+                </div>
               ))}
             </div>
           )}


### PR DESCRIPTION
- Leaderboard rows: Career link to /career with playerId and season sport
- Tournament stats: same Career links; owners/admins can set/clear tournaments.placement
- Docs: progress, regression steps, design table