### PR TITLE
feat(GameSetup): edit tournament URL for existing tournaments

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The dev server starts at `http://localhost:5173`.
    - `supabase/migrations/020_stat_tracking_ui_rpcs.sql` — career / player game log / team game log RPCs ([DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md))
    - `supabase/migrations/021_tournament_stats_rpc.sql` — `get_tournament_stats_resolved`
    - `supabase/migrations/022_games_is_exhibition_generated.sql` — optional generated `games.is_exhibition` (`tournament_id IS NULL`); see `supabase/scripts/normalize_exhibition_games.sql` for legacy row cleanup
-   - `supabase/migrations/023_tournaments_url.sql` — optional `tournaments.url` (bracket/registration link); set from Game Setup when creating a tournament
+   - `supabase/migrations/023_tournaments_url.sql` — optional `tournaments.url` (bracket/registration link); set or edit from Game Setup when creating or selecting a tournament
    > If you already applied earlier migrations, run only the new ones (e.g. only `018` for the seasons data model redesign).
    > Before **`019`**, run `supabase/scripts/audit_data_integrity_pre_019.sql` in the SQL Editor if you have existing data; migration `019` aborts if duplicate teams, invalid `seasons.sport`, duplicate active jersey numbers, or bad `games.tournament_id` links exist.
    > **Migration 018 is destructive**: it drops `teams.sport`, `teams.season`, `players.team_id`, `players.jersey_number`, `players.position`, and `players.is_active` columns after migrating data to the new `seasons`, `team_players`, and `player_guardians` tables. Back up your database before running.

--- a/src/pages/GameSetup.tsx
+++ b/src/pages/GameSetup.tsx
@@ -52,6 +52,8 @@ export default function GameSetup() {
   )
   const [newTournamentName, setNewTournamentName] = useState('')
   const [newTournamentUrl, setNewTournamentUrl] = useState('')
+  /** Draft URL when an existing tournament is selected (saved on Next if changed). */
+  const [existingTournamentUrlDraft, setExistingTournamentUrlDraft] = useState('')
   const [loadingTournaments, setLoadingTournaments] = useState(false)
   const [creatingTournament, setCreatingTournament] = useState(false)
   const [confirmDeleteTournament, setConfirmDeleteTournament] = useState<TournamentOption | null>(null)
@@ -171,6 +173,16 @@ export default function GameSetup() {
     return () => { cancelled = true }
   }, [isCloudFlow, teamMode, selectedTeamId, existingTournamentId])
 
+  // Keep URL draft in sync when user picks a different existing tournament
+  useEffect(() => {
+    if (selectedTournamentId === '' || selectedTournamentId === '__new__') {
+      setExistingTournamentUrlDraft('')
+      return
+    }
+    const t = tournaments.find(x => x.id === selectedTournamentId)
+    setExistingTournamentUrlDraft(t?.url?.trim() ? t.url : '')
+  }, [selectedTournamentId, tournaments])
+
   const handleDeleteTournament = async (tournament: TournamentOption) => {
     if (!supabase) return
     setDeletingTournamentId(tournament.id)
@@ -258,6 +270,27 @@ export default function GameSetup() {
         const found = tournaments.find(t => t.id === selectedTournamentId)
         resolvedTournamentId = selectedTournamentId
         resolvedTournamentName = found?.name ?? ''
+        if (supabase) {
+          const canonical = (found?.url ?? '').trim()
+          const draft = existingTournamentUrlDraft.trim()
+          if (draft !== canonical) {
+            setCreatingTournament(true)
+            const { error: urlErr } = await supabase
+              .from('tournaments')
+              .update({ url: draft === '' ? null : draft })
+              .eq('id', selectedTournamentId)
+            setCreatingTournament(false)
+            if (urlErr) {
+              setSetupError(urlErr.message)
+              return
+            }
+            setTournaments(prev =>
+              prev.map(row =>
+                row.id === selectedTournamentId ? { ...row, url: draft === '' ? null : draft } : row
+              )
+            )
+          }
+        }
       }
       // selectedTournamentId === '' means no tournament — both stay null/empty
     }
@@ -505,17 +538,40 @@ export default function GameSetup() {
                       <option value="__new__">+ Add new tournament…</option>
                     </select>
                     {selectedTournamentId && selectedTournamentId !== '__new__' && (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const t = tournaments.find(item => item.id === selectedTournamentId)
-                          if (t) setConfirmDeleteTournament(t)
-                        }}
-                        disabled={deletingTournamentId === selectedTournamentId}
-                        className="text-xs text-red-600 underline disabled:opacity-40"
-                      >
-                        {deletingTournamentId === selectedTournamentId ? 'Deleting...' : 'Delete this tournament'}
-                      </button>
+                      <>
+                        <div>
+                          <label
+                            htmlFor="existing-tournament-url"
+                            className="block text-xs font-medium text-slate-500 mb-1"
+                          >
+                            Tournament URL (optional)
+                          </label>
+                          <input
+                            id="existing-tournament-url"
+                            type="url"
+                            inputMode="url"
+                            value={existingTournamentUrlDraft}
+                            onChange={e => setExistingTournamentUrlDraft(e.target.value)}
+                            placeholder="https://…"
+                            className="input-field"
+                            autoComplete="off"
+                          />
+                          <p className="text-xs text-slate-400 mt-1">
+                            Saved when you continue to add players.
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const t = tournaments.find(item => item.id === selectedTournamentId)
+                            if (t) setConfirmDeleteTournament(t)
+                          }}
+                          disabled={deletingTournamentId === selectedTournamentId}
+                          className="text-xs text-red-600 underline disabled:opacity-40"
+                        >
+                          {deletingTournamentId === selectedTournamentId ? 'Deleting...' : 'Delete this tournament'}
+                        </button>
+                      </>
                     )}
                   </>
                 )}
@@ -586,7 +642,9 @@ export default function GameSetup() {
           disabled={!canProceed || creatingTournament}
           className="btn-primary w-full mt-8"
         >
-          {creatingTournament ? 'Creating tournament...' : 'Next: Add Players →'}
+          {creatingTournament
+            ? 'Saving tournament...'
+            : 'Next: Add Players →'}
         </button>
       </div>
     </div>


### PR DESCRIPTION
- Optional URL field when a tournament is selected; persists on Next (owner/admin RLS)
- Sync draft from loaded row when selection changes
- README: note URL can be set when selecting or creating