### PR TITLE
feat(admin): player merge entry + audit history; migration 025 RLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The dev server starts at `http://localhost:5173`.
    - `supabase/migrations/022_games_is_exhibition_generated.sql` — optional generated `games.is_exhibition` (`tournament_id IS NULL`); see `supabase/scripts/normalize_exhibition_games.sql` for legacy row cleanup
    - `supabase/migrations/023_tournaments_url.sql` — optional `tournaments.url` (bracket/registration link); set or edit from Game Setup when creating or selecting a tournament
    - `supabase/migrations/024_player_merge_rpcs.sql` — `merge_players_preview` / `merge_players_execute` + `player_merge_audit` ([DESIGN_PLAYER_MERGE.md](docs/DESIGN_PLAYER_MERGE.md))
+   - `supabase/migrations/025_player_merge_audit_select_policy.sql` — users can `SELECT` their own `player_merge_audit` rows (Admin merge history)
    > If you already applied earlier migrations, run only the new ones (e.g. only `018` for the seasons data model redesign).
    > Before **`019`**, run `supabase/scripts/audit_data_integrity_pre_019.sql` in the SQL Editor if you have existing data; migration `019` aborts if duplicate teams, invalid `seasons.sport`, duplicate active jersey numbers, or bad `games.tournament_id` links exist.
    > **Migration 018 is destructive**: it drops `teams.sport`, `teams.season`, `players.team_id`, `players.jersey_number`, `players.position`, and `players.is_active` columns after migrating data to the new `seasons`, `team_players`, and `player_guardians` tables. Back up your database before running.
@@ -201,7 +202,8 @@ supabase/
     ├── 021_tournament_stats_rpc.sql
     ├── 022_games_is_exhibition_generated.sql
     ├── 023_tournaments_url.sql
-    └── 024_player_merge_rpcs.sql
+    ├── 024_player_merge_rpcs.sql
+    └── 025_player_merge_audit_select_policy.sql
 
 supabase/scripts/
 ├── audit_data_integrity_pre_019.sql

--- a/docs/DESIGN_PLAYER_MERGE.md
+++ b/docs/DESIGN_PLAYER_MERGE.md
@@ -142,7 +142,7 @@ CREATE TABLE public.player_merge_audit (
 );
 ```
 
-RLS: restrictive; inserts only from `merge_players_execute` or service role.
+RLS: no direct client inserts; **`merge_players_execute`** inserts as `SECURITY DEFINER`. After migration **025**, authenticated users may **`SELECT`** rows where **`merged_by = auth.uid()`** (Admin “Your recent merges”).
 
 ### 4.3 App UI (`/teams`)
 
@@ -195,7 +195,7 @@ RLS: restrictive; inserts only from `merge_players_execute` or service role.
 | **1** | Migration **`024_player_merge_rpcs.sql`**: `player_merge_audit`, `merge_players_can_merge`, `merge_players_preview`, `merge_players_execute` — **done in repo** (apply in Supabase) |
 | **2** | Teams UI: wizard, conflict screens, typed confirm, error handling — **done** (`MergePlayerWizard` + Roster **Merge players** on `/teams` when owner/admin on selected team and ≥2 eligible players) |
 | **3** | `REGRESSION_TESTING.md` §4a (merge steps) + migrations note — **done**; README already lists `024` |
-| **4** | Optional: Admin-only mirror, analytics on audit table |
+| **4** | **Done:** Admin → **Player merge (advanced)** — same `MergePlayerWizard`, **Your recent merges** (reads `player_merge_audit` for `merged_by = auth.uid()`); migration **`025_player_merge_audit_select_policy.sql`** enables SELECT own rows |
 
 ---
 

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -85,8 +85,12 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4a.8 | Type **MERGE** (all caps) → **Merge players** | Success: modal closes; duplicate gone from candidate pool / roster lists after refresh |
 | 4a.9 | Teams → roster / Leaderboard / Player profile for **survivor** | Stats and games that belonged to duplicate now attribute to survivor (where applicable) |
 | 4a.10 | (Optional) Supabase Table Editor → `player_merge_audit` | New row with `duplicate_player_id`, `survivor_player_id`, `merged_by`, `resolutions` json |
+| 4a.11 | Settings (Admin) → expand **Player merge (advanced)** | Section opens; **Your recent merges** loads or shows migration **025** hint if RLS blocks reads |
+| 4a.12 | **Open merge wizard** from Admin (with ≥2 candidates) | Same modal as Teams; complete a test merge → row appears under **Your recent merges** (after **025** applied) |
 
 **Negative / edge:** If another user edits roster or stats between **Load conflicts** and **Merge players**, execute may error (resolution counts mismatch); run **Load conflicts** again from the pick step.
+
+**Migrations:** Merge UI works with **024** only; **Admin → recent merges** needs **025** (`player_merge_audit` readable for own `merged_by`).
 
 ---
 

--- a/src/components/MergePlayerWizard.tsx
+++ b/src/components/MergePlayerWizard.tsx
@@ -1,13 +1,9 @@
 import { useCallback, useMemo, useState } from 'react'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { playerDisplayName } from '../lib/display'
+import type { MergePlayerCandidate } from '../lib/mergePlayerScope'
 
-export interface MergePlayerOption {
-  id: string
-  first_name: string
-  last_name: string | null
-  nickname: string | null
-}
+export type MergePlayerOption = MergePlayerCandidate
 
 interface PreviewGameStat {
   game_id: string

--- a/src/lib/mergePlayerScope.ts
+++ b/src/lib/mergePlayerScope.ts
@@ -1,0 +1,59 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export interface MergePlayerCandidate {
+  id: string
+  first_name: string
+  last_name: string | null
+  nickname: string | null
+}
+
+/**
+ * Teams where the user is owner (teams.owner_id) or team_members owner/admin.
+ * Distinct players on those teams (for merge wizard candidate list).
+ */
+export async function fetchMergePlayerScope(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<{ teamIds: string[]; candidates: MergePlayerCandidate[] }> {
+  const adminTeamIds = new Set<string>()
+  const { data: memRows } = await supabase
+    .from('team_members')
+    .select('team_id')
+    .eq('user_id', userId)
+    .in('role', ['owner', 'admin'])
+  for (const row of (memRows ?? []) as { team_id: string }[]) {
+    adminTeamIds.add(row.team_id)
+  }
+  const { data: ownedRows } = await supabase.from('teams').select('id').eq('owner_id', userId)
+  for (const row of (ownedRows ?? []) as { id: string }[]) {
+    adminTeamIds.add(row.id)
+  }
+  const teamIds = [...adminTeamIds]
+  if (teamIds.length === 0) {
+    return { teamIds: [], candidates: [] }
+  }
+  const { data: tpRows, error: tpErr } = await supabase
+    .from('team_players')
+    .select('player_id, players!inner(id,first_name,last_name,nickname)')
+    .in('team_id', teamIds)
+  if (tpErr) {
+    return { teamIds, candidates: [] }
+  }
+  type TpJoin = {
+    player_id: string
+    players: { id: string; first_name: string; last_name: string | null; nickname: string | null }
+  }
+  const byId = new Map<string, MergePlayerCandidate>()
+  for (const row of (tpRows ?? []) as unknown as TpJoin[]) {
+    const p = row.players
+    if (!byId.has(p.id)) {
+      byId.set(p.id, {
+        id: p.id,
+        first_name: p.first_name,
+        last_name: p.last_name,
+        nickname: p.nickname,
+      })
+    }
+  }
+  return { teamIds, candidates: [...byId.values()] }
+}

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -7,6 +7,8 @@ import { useGame } from '../context/GameContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName } from '../lib/display'
 import ConfirmDialog from '../components/ConfirmDialog'
+import MergePlayerWizard from '../components/MergePlayerWizard'
+import { fetchMergePlayerScope, type MergePlayerCandidate } from '../lib/mergePlayerScope'
 
 interface AdminSeasonInfo {
   name: string
@@ -52,6 +54,14 @@ interface AdminSeasonRow {
   end_date: string | null
 }
 
+interface MergeAuditListRow {
+  id: string
+  merged_at: string
+  duplicate_player_id: string
+  survivor_player_id: string
+  merged_by: string | null
+}
+
 export default function Admin() {
   const navigate = useNavigate()
   const { isSportEnabled, toggleSport } = useSettings()
@@ -92,6 +102,14 @@ export default function Admin() {
   const [editSeasonEndDate, setEditSeasonEndDate] = useState('')
   const [confirmDeleteSeason, setConfirmDeleteSeason] = useState<AdminSeasonRow | null>(null)
 
+  const [showMergeTools, setShowMergeTools] = useState(false)
+  const [mergeWizardOpen, setMergeWizardOpen] = useState(false)
+  const [mergeCandidates, setMergeCandidates] = useState<MergePlayerCandidate[]>([])
+  const [mergeAuditRefresh, setMergeAuditRefresh] = useState(0)
+  const [mergeAuditRows, setMergeAuditRows] = useState<MergeAuditListRow[]>([])
+  const [loadingMergeAudit, setLoadingMergeAudit] = useState(false)
+  const [mergeAuditError, setMergeAuditError] = useState<string | null>(null)
+
   useEffect(() => {
     if (!showDataMgmt || !isConfigured || !userId || !supabaseClient) return
     let cancelled = false
@@ -119,6 +137,48 @@ export default function Admin() {
     void load()
     return () => { cancelled = true }
   }, [showDataMgmt, isConfigured, userId, supabaseClient])
+
+  useEffect(() => {
+    if (!showMergeTools || !isConfigured || !userId || !supabaseClient) return
+    let cancelled = false
+    const load = async () => {
+      const { candidates } = await fetchMergePlayerScope(supabaseClient, userId)
+      if (cancelled) return
+      setMergeCandidates(candidates)
+    }
+    void load()
+    return () => { cancelled = true }
+  }, [showMergeTools, isConfigured, userId, supabaseClient, mergeAuditRefresh])
+
+  useEffect(() => {
+    if (!showMergeTools || !isConfigured || !userId || !supabaseClient) return
+    let cancelled = false
+    const loadAudit = async () => {
+      setLoadingMergeAudit(true)
+      setMergeAuditError(null)
+      const { data, error } = await supabaseClient
+        .from('player_merge_audit')
+        .select('id,merged_at,duplicate_player_id,survivor_player_id,merged_by')
+        .order('merged_at', { ascending: false })
+        .limit(25)
+      if (cancelled) return
+      if (error) {
+        if (error.message.includes('does not exist') || error.code === '42P01') {
+          setMergeAuditError('Run migration 025 (or ensure player_merge_audit exists) to see merge history.')
+        } else if (error.code === '42501' || error.message.toLowerCase().includes('policy')) {
+          setMergeAuditError('Cannot read merge history (RLS). Apply migration 025_player_merge_audit_select_policy.sql.')
+        } else {
+          setMergeAuditError(error.message)
+        }
+        setMergeAuditRows([])
+      } else {
+        setMergeAuditRows((data ?? []) as MergeAuditListRow[])
+      }
+      setLoadingMergeAudit(false)
+    }
+    void loadAudit()
+    return () => { cancelled = true }
+  }, [showMergeTools, isConfigured, userId, supabaseClient, mergeAuditRefresh])
 
   useEffect(() => {
     if (!showDataMgmt || !selectedAdminTeamId || !supabaseClient) {
@@ -563,6 +623,92 @@ export default function Admin() {
               }}
               onCancel={() => setConfirmDeleteSeason(null)}
             />
+          </section>
+        )}
+
+        {isConfigured && user && (
+          <section className="mt-6">
+            <button
+              type="button"
+              onClick={() => setShowMergeTools(!showMergeTools)}
+              className="card w-full text-left border-amber-100 bg-amber-50/40"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-700">Player merge (advanced)</h2>
+                  <p className="text-sm text-slate-500">
+                    Combine duplicate player profiles (same flow as Teams). View merges you performed.
+                  </p>
+                </div>
+                <span className="text-slate-400 text-lg">{showMergeTools ? '▲' : '▼'}</span>
+              </div>
+            </button>
+
+            {showMergeTools && (
+              <div className="mt-3 space-y-4">
+                <p className="text-sm text-slate-600 card">
+                  You must be owner or admin on every team both players are on. Irreversible — use test data when
+                  learning the flow.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setMergeWizardOpen(true)}
+                  disabled={mergeCandidates.length < 2}
+                  className="btn-primary w-full disabled:opacity-50"
+                >
+                  Open merge wizard
+                </button>
+                {mergeCandidates.length < 2 && (
+                  <p className="text-xs text-slate-500 px-1">
+                    Need at least two players on teams where you are owner or admin. Add teams under Teams or become
+                    admin on another team.
+                  </p>
+                )}
+
+                <div className="card space-y-2">
+                  <h3 className="text-sm font-semibold text-slate-700">Your recent merges</h3>
+                  {loadingMergeAudit ? (
+                    <p className="text-sm text-slate-500 animate-pulse">Loading history…</p>
+                  ) : mergeAuditError ? (
+                    <p className="text-sm text-amber-800 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2">
+                      {mergeAuditError}
+                    </p>
+                  ) : mergeAuditRows.length === 0 ? (
+                    <p className="text-sm text-slate-500">No merge records yet (or none you performed).</p>
+                  ) : (
+                    <ul className="space-y-2 text-sm max-h-64 overflow-y-auto">
+                      {mergeAuditRows.map(row => (
+                        <li
+                          key={row.id}
+                          className="border border-slate-100 rounded-lg px-3 py-2 flex flex-col gap-0.5"
+                        >
+                          <span className="text-xs text-slate-400">
+                            {new Date(row.merged_at).toLocaleString()}
+                          </span>
+                          <span className="text-slate-700">
+                            Kept <code className="text-xs bg-slate-100 px-1 rounded">{row.survivor_player_id.slice(0, 8)}…</code>
+                            {' · '}
+                            removed{' '}
+                            <code className="text-xs bg-slate-100 px-1 rounded">{row.duplicate_player_id.slice(0, 8)}…</code>
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {mergeWizardOpen && supabaseClient && userId && (
+              <MergePlayerWizard
+                supabase={supabaseClient}
+                candidates={mergeCandidates}
+                onClose={() => setMergeWizardOpen(false)}
+                onMerged={() => {
+                  setMergeAuditRefresh(k => k + 1)
+                }}
+              />
+            )}
           </section>
         )}
 

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -7,6 +7,7 @@ import { supabase } from '../lib/supabase'
 import { teamDisplayName, playerDisplayName } from '../lib/display'
 import ConfirmDialog from '../components/ConfirmDialog'
 import MergePlayerWizard, { type MergePlayerOption } from '../components/MergePlayerWizard'
+import { fetchMergePlayerScope } from '../lib/mergePlayerScope'
 
 interface TeamRow {
   id: string
@@ -168,52 +169,10 @@ export default function Teams() {
     }
     let cancelled = false
     const loadMergeScope = async () => {
-      const adminTeamIds = new Set<string>()
-      const { data: memRows } = await supabaseClient
-        .from('team_members')
-        .select('team_id')
-        .eq('user_id', userId)
-        .in('role', ['owner', 'admin'])
-      for (const row of (memRows ?? []) as { team_id: string }[]) {
-        adminTeamIds.add(row.team_id)
-      }
-      const { data: ownedRows } = await supabaseClient.from('teams').select('id').eq('owner_id', userId)
-      for (const row of (ownedRows ?? []) as { id: string }[]) {
-        adminTeamIds.add(row.id)
-      }
-      const ids = [...adminTeamIds]
+      const { teamIds, candidates } = await fetchMergePlayerScope(supabaseClient, userId)
       if (cancelled) return
-      setMergeEligibleTeamIds(ids)
-      if (ids.length === 0) {
-        setMergeCandidates([])
-        return
-      }
-      const { data: tpRows, error: tpErr } = await supabaseClient
-        .from('team_players')
-        .select('player_id, players!inner(id,first_name,last_name,nickname)')
-        .in('team_id', ids)
-      if (cancelled) return
-      if (tpErr) {
-        setMergeCandidates([])
-        return
-      }
-      type TpJoin = {
-        player_id: string
-        players: { id: string; first_name: string; last_name: string | null; nickname: string | null }
-      }
-      const byId = new Map<string, MergePlayerOption>()
-      for (const row of (tpRows ?? []) as unknown as TpJoin[]) {
-        const p = row.players
-        if (!byId.has(p.id)) {
-          byId.set(p.id, {
-            id: p.id,
-            first_name: p.first_name,
-            last_name: p.last_name,
-            nickname: p.nickname,
-          })
-        }
-      }
-      setMergeCandidates([...byId.values()])
+      setMergeEligibleTeamIds(teamIds)
+      setMergeCandidates(candidates as MergePlayerOption[])
     }
     void loadMergeScope()
     return () => {

--- a/supabase/migrations/025_player_merge_audit_select_policy.sql
+++ b/supabase/migrations/025_player_merge_audit_select_policy.sql
@@ -1,0 +1,10 @@
+-- Allow users to read their own player merge audit rows (Admin / support UI).
+-- Inserts remain via merge_players_execute (SECURITY DEFINER).
+
+DROP POLICY IF EXISTS "player_merge_audit_no_select" ON public.player_merge_audit;
+
+CREATE POLICY "player_merge_audit_select_own" ON public.player_merge_audit
+  FOR SELECT USING (merged_by = (SELECT auth.uid()));
+
+COMMENT ON POLICY "player_merge_audit_select_own" ON public.player_merge_audit IS
+  'Users can list merges they performed (DESIGN_PLAYER_MERGE phase 4).';


### PR DESCRIPTION
- mergePlayerScope: shared fetchMergePlayerScope for Teams + Admin
- Admin: Player merge (advanced) section, MergePlayerWizard, recent merges list
- 025: SELECT player_merge_audit where merged_by = auth.uid()
- REGRESSION_TESTING 4a.11–4a.12; DESIGN_PLAYER_MERGE phase 4; README