### PR TITLE
fix(ui): roster-style labels in merge and add-existing selectors

### DIFF
--- a/src/components/MergePlayerWizard.tsx
+++ b/src/components/MergePlayerWizard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { playerDisplayName } from '../lib/display'
+import { playerRosterSelectLabel } from '../lib/display'
 import type { MergePlayerCandidate } from '../lib/mergePlayerScope'
 
 export type MergePlayerOption = MergePlayerCandidate
@@ -151,7 +151,7 @@ export default function MergePlayerWizard({ supabase, candidates, onClose, onMer
   const candidateOptions = useMemo(
     () =>
       [...candidates].sort((a, b) =>
-        playerDisplayName(a).localeCompare(playerDisplayName(b), undefined, { sensitivity: 'base' })
+        playerRosterSelectLabel(a).localeCompare(playerRosterSelectLabel(b), undefined, { sensitivity: 'base' })
       ),
     [candidates]
   )
@@ -212,7 +212,7 @@ export default function MergePlayerWizard({ supabase, candidates, onClose, onMer
                   <option value="">Select…</option>
                   {candidateOptions.map(p => (
                     <option key={p.id} value={p.id}>
-                      {playerDisplayName(p)}
+                      {playerRosterSelectLabel(p)}
                     </option>
                   ))}
                 </select>
@@ -229,7 +229,7 @@ export default function MergePlayerWizard({ supabase, candidates, onClose, onMer
                     .filter(p => p.id !== survivorId)
                     .map(p => (
                       <option key={p.id} value={p.id}>
-                        {playerDisplayName(p)}
+                        {playerRosterSelectLabel(p)}
                       </option>
                     ))}
                 </select>
@@ -251,8 +251,8 @@ export default function MergePlayerWizard({ supabase, candidates, onClose, onMer
           {step === 'resolve' && preview && (
             <div className="space-y-6">
               <p className="text-sm text-slate-600">
-                Keep: <strong>{survivor ? playerDisplayName(survivor) : '—'}</strong> · Remove:{' '}
-                <strong>{duplicate ? playerDisplayName(duplicate) : '—'}</strong>
+                Keep: <strong>{survivor ? playerRosterSelectLabel(survivor) : '—'}</strong> · Remove:{' '}
+                <strong>{duplicate ? playerRosterSelectLabel(duplicate) : '—'}</strong>
               </p>
 
               {preview.game_stats.length > 0 && (
@@ -452,8 +452,8 @@ export default function MergePlayerWizard({ supabase, candidates, onClose, onMer
           {step === 'confirm' && preview && survivor && duplicate && (
             <div className="space-y-4">
               <p className="text-sm text-slate-600">
-                Final check: <strong>{playerDisplayName(survivor)}</strong> remains;{' '}
-                <strong>{playerDisplayName(duplicate)}</strong> will be deleted.
+                Final check: <strong>{playerRosterSelectLabel(survivor)}</strong> remains;{' '}
+                <strong>{playerRosterSelectLabel(duplicate)}</strong> will be deleted.
               </p>
               {survivorFullName && (
                 <p className="text-xs text-slate-500">

--- a/src/lib/display.ts
+++ b/src/lib/display.ts
@@ -13,3 +13,14 @@ export function playerDisplayName(player: {
   return [player.first_name, player.last_name].filter(Boolean).join(' ').trim() || 'Player'
 }
 
+/** First + last always (for dropdowns where nicknames alone are ambiguous). Optional (nickname) suffix. */
+export function playerRosterSelectLabel(player: {
+  first_name: string
+  last_name?: string | null
+  nickname?: string | null
+}): string {
+  const base = [player.first_name, player.last_name].filter(Boolean).join(' ').trim() || 'Player'
+  const nick = player.nickname?.trim()
+  return nick ? `${base} (${nick})` : base
+}
+

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -4,7 +4,7 @@ import { sports } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
 import { supabase } from '../lib/supabase'
-import { teamDisplayName, playerDisplayName } from '../lib/display'
+import { teamDisplayName, playerDisplayName, playerRosterSelectLabel } from '../lib/display'
 import ConfirmDialog from '../components/ConfirmDialog'
 import MergePlayerWizard, { type MergePlayerOption } from '../components/MergePlayerWizard'
 import { fetchMergePlayerScope } from '../lib/mergePlayerScope'
@@ -1195,8 +1195,7 @@ export default function Teams() {
                         .filter(pp => !players.some(rp => rp.id === pp.id))
                         .map(pp => (
                           <option key={pp.id} value={pp.id}>
-                            {[pp.first_name, pp.last_name].filter(Boolean).join(' ')}
-                            {pp.nickname ? ` (${pp.nickname})` : ''}
+                            {playerRosterSelectLabel(pp)}
                           </option>
                         ))}
                     </select>


### PR DESCRIPTION
- playerRosterSelectLabel: always first + last; append (nickname) when set
- MergePlayerWizard dropdowns and summaries use it
- Teams Add Existing uses same helper