### PR TITLE
Team stats WU-1 + standalone home team score (home_team_score)

### DIFF
--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -1,17 +1,14 @@
 import { useGame } from '../context/GameContext'
-import { computePlayerScore } from '../config/sports'
+import { getDisplayedHomeScore } from '../lib/gameScore'
 
 export default function Scoreboard() {
   const { state, dispatch } = useGame()
-  const { sport, gameInfo, players, opponentScore, homeScoreAdjustment, cloudSync } = state
+  const { sport, gameInfo, players, opponentScore, homeTeamScore, homeScoreAdjustment, cloudSync } =
+    state
 
   if (!sport || !gameInfo) return null
 
-  const computedTeamScore = players.reduce(
-    (total, player) => total + computePlayerScore(sport, player.stats),
-    0
-  )
-  const teamScore = computedTeamScore + homeScoreAdjustment
+  const teamScore = getDisplayedHomeScore(sport, players, homeTeamScore, homeScoreAdjustment)
 
   const syncLabel = (() => {
     switch (cloudSync.status) {

--- a/src/config/sports.ts
+++ b/src/config/sports.ts
@@ -66,6 +66,36 @@ export const sports: SportConfig[] = [
         ],
       },
     ],
+    teamKeyStatIds: ['team_foul', 'team_to_used', 'team_tech'],
+    teamCategories: [
+      {
+        id: 'team_fouls',
+        name: 'Fouls',
+        color: 'rose',
+        actions: [
+          {
+            id: 'team_foul',
+            label: 'Team Foul',
+            shortLabel: 'TF',
+            periodScoped: true,
+          },
+        ],
+        showTotal: true,
+        totalLabel: 'Period Fouls',
+      },
+      {
+        id: 'team_misc',
+        name: 'Team',
+        color: 'slate',
+        columns: 2,
+        hideHeader: true,
+        actions: [
+          { id: 'team_to_used', label: 'Timeout', shortLabel: 'TO' },
+          { id: 'team_tech', label: 'Technical', shortLabel: 'TECH' },
+          { id: 'team_turnover', label: 'Turnover', shortLabel: 'TTO' },
+        ],
+      },
+    ],
   },
 
   {

--- a/src/config/teamStatsDefaults.ts
+++ b/src/config/teamStatsDefaults.ts
@@ -1,0 +1,70 @@
+import type { BasketballTeamStatsConfig, SportConfig, TeamStatsConfig } from '../types'
+
+/** NFHS-style defaults (halves, 1-and-1 at 7, double bonus at 10). */
+export const BASKETBALL_TEAM_STATS_DEFAULTS: BasketballTeamStatsConfig = {
+  periodsPerGame: 2,
+  periodLabels: ['1st Half', '2nd Half'],
+  bonusThreshold: 7,
+  doubleBonusThreshold: 10,
+  hasOneAndOne: true,
+  overtimeLabel: 'OT',
+  overtimeFoulsReset: true,
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Merge sport defaults with optional season JSON from `seasons.team_stats_config`.
+ * Returns null when the sport has no team-level tracking.
+ */
+export function resolveTeamStatsConfig(
+  sport: SportConfig,
+  seasonConfig: unknown
+): TeamStatsConfig | null {
+  if (!sport.teamCategories?.length) return null
+  if (sport.id !== 'basketball') return null
+
+  const base = { ...BASKETBALL_TEAM_STATS_DEFAULTS }
+  if (!isRecord(seasonConfig)) {
+    return base
+  }
+
+  const periodsPerGame =
+    typeof seasonConfig.periodsPerGame === 'number' && seasonConfig.periodsPerGame >= 1
+      ? seasonConfig.periodsPerGame
+      : base.periodsPerGame
+
+  let periodLabels = base.periodLabels
+  if (Array.isArray(seasonConfig.periodLabels)) {
+    const labels = seasonConfig.periodLabels.filter((x): x is string => typeof x === 'string')
+    if (labels.length === periodsPerGame) {
+      periodLabels = labels
+    }
+  }
+
+  return {
+    periodsPerGame,
+    periodLabels,
+    bonusThreshold:
+      typeof seasonConfig.bonusThreshold === 'number' && seasonConfig.bonusThreshold >= 1
+        ? seasonConfig.bonusThreshold
+        : base.bonusThreshold,
+    doubleBonusThreshold:
+      typeof seasonConfig.doubleBonusThreshold === 'number' &&
+      seasonConfig.doubleBonusThreshold >= 1
+        ? seasonConfig.doubleBonusThreshold
+        : base.doubleBonusThreshold,
+    hasOneAndOne:
+      typeof seasonConfig.hasOneAndOne === 'boolean' ? seasonConfig.hasOneAndOne : base.hasOneAndOne,
+    overtimeLabel:
+      typeof seasonConfig.overtimeLabel === 'string' && seasonConfig.overtimeLabel.length > 0
+        ? seasonConfig.overtimeLabel
+        : base.overtimeLabel,
+    overtimeFoulsReset:
+      typeof seasonConfig.overtimeFoulsReset === 'boolean'
+        ? seasonConfig.overtimeFoulsReset
+        : base.overtimeFoulsReset,
+  }
+}

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -24,6 +24,7 @@ import {
 } from '../lib/cloudSync'
 import { supabase } from '../lib/supabase'
 import { sports } from '../config/sports'
+import { getDisplayedHomeScore } from '../lib/gameScore'
 
 /** Persisted game state key; clear this when finalizing so the game no longer appears as in progress. */
 export const GAME_STORAGE_KEY = 'statkeeper_game'
@@ -78,6 +79,7 @@ function createInitialState(status: CloudSyncStatus = 'idle'): GameState {
     players: [],
     activePlayerId: null,
     opponentScore: 0,
+    homeTeamScore: null,
     homeScoreAdjustment: 0,
     notes: '',
     actionLog: [],
@@ -104,6 +106,7 @@ function buildSyncFingerprint(state: GameState): string {
     sportId: state.sport?.id ?? null,
     gameInfo: state.gameInfo,
     opponentScore: state.opponentScore,
+    homeTeamScore: state.homeTeamScore,
     homeScoreAdjustment: state.homeScoreAdjustment,
     notes: state.notes,
     players: state.players.map(player => ({
@@ -192,6 +195,7 @@ function buildHydratedStateFromCloudGame(
     players: cloudGame.players,
     activePlayerId: cloudGame.activePlayerId,
     opponentScore: cloudGame.opponentScore,
+    homeTeamScore: cloudGame.homeTeamScore,
     homeScoreAdjustment: cloudGame.homeScoreAdjustment,
     notes: cloudGame.notes,
     currentPeriod: 1,
@@ -343,15 +347,36 @@ function gameReducer(state: GameState, action: GameAction): GameState {
     }
 
     case 'INCREMENT_HOME_SCORE': {
+      if (state.homeTeamScore != null) {
+        const prev = state.homeTeamScore
+        const logEntry: ActionLogEntry = {
+          id: generateId(),
+          timestamp: Date.now(),
+          type: 'home_team_score_up',
+          previousValue: prev,
+          previousHomeTeamScore: prev,
+        }
+        return {
+          ...state,
+          homeTeamScore: prev + 1,
+          actionLog: [...state.actionLog, logEntry],
+        }
+      }
+      const sport = state.sport
+      if (!sport) return state
+      const baseline = getDisplayedHomeScore(sport, state.players, null, state.homeScoreAdjustment)
       const logEntry: ActionLogEntry = {
         id: generateId(),
         timestamp: Date.now(),
-        type: 'home_score_up',
-        previousValue: state.homeScoreAdjustment,
+        type: 'home_team_score_up',
+        previousValue: baseline,
+        previousHomeTeamScore: null,
+        previousHomeScoreAdjustment: state.homeScoreAdjustment,
       }
       return {
         ...state,
-        homeScoreAdjustment: state.homeScoreAdjustment + 1,
+        homeTeamScore: baseline + 1,
+        homeScoreAdjustment: 0,
         actionLog: [...state.actionLog, logEntry],
       }
     }
@@ -360,16 +385,38 @@ function gameReducer(state: GameState, action: GameAction): GameState {
       return { ...state, notes: action.notes }
 
     case 'DECREMENT_HOME_SCORE': {
-      if (state.homeScoreAdjustment <= 0) return state
+      if (state.homeTeamScore != null) {
+        if (state.homeTeamScore <= 0) return state
+        const prev = state.homeTeamScore
+        const logEntry: ActionLogEntry = {
+          id: generateId(),
+          timestamp: Date.now(),
+          type: 'home_team_score_down',
+          previousValue: prev,
+          previousHomeTeamScore: prev,
+        }
+        return {
+          ...state,
+          homeTeamScore: prev - 1,
+          actionLog: [...state.actionLog, logEntry],
+        }
+      }
+      const sport = state.sport
+      if (!sport) return state
+      const baseline = getDisplayedHomeScore(sport, state.players, null, state.homeScoreAdjustment)
+      if (baseline <= 0) return state
       const logEntry: ActionLogEntry = {
         id: generateId(),
         timestamp: Date.now(),
-        type: 'home_score_down',
-        previousValue: state.homeScoreAdjustment,
+        type: 'home_team_score_down',
+        previousValue: baseline,
+        previousHomeTeamScore: null,
+        previousHomeScoreAdjustment: state.homeScoreAdjustment,
       }
       return {
         ...state,
-        homeScoreAdjustment: state.homeScoreAdjustment - 1,
+        homeTeamScore: Math.max(0, baseline - 1),
+        homeScoreAdjustment: 0,
         actionLog: [...state.actionLog, logEntry],
       }
     }
@@ -398,6 +445,18 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         case 'home_score_up':
         case 'home_score_down':
           newState = { ...newState, homeScoreAdjustment: lastAction.previousValue }
+          break
+        case 'home_team_score_up':
+        case 'home_team_score_down':
+          if (lastAction.previousHomeTeamScore == null) {
+            newState = {
+              ...newState,
+              homeTeamScore: null,
+              homeScoreAdjustment: lastAction.previousHomeScoreAdjustment ?? 0,
+            }
+          } else {
+            newState = { ...newState, homeTeamScore: lastAction.previousHomeTeamScore }
+          }
           break
       }
       return newState
@@ -444,6 +503,7 @@ function loadState(): GameState {
   return {
     ...createInitialState(restoredStatus),
     ...parsed,
+    homeTeamScore: typeof parsed.homeTeamScore === 'number' ? parsed.homeTeamScore : null,
     homeScoreAdjustment: typeof parsed.homeScoreAdjustment === 'number' ? parsed.homeScoreAdjustment : 0,
     notes: typeof parsed.notes === 'string' ? parsed.notes : '',
     currentPeriod:

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -82,6 +82,8 @@ function createInitialState(status: CloudSyncStatus = 'idle'): GameState {
     notes: '',
     actionLog: [],
     cloudSync: createInitialCloudSyncState(status),
+    currentPeriod: 1,
+    teamStatsConfig: null,
   }
 }
 
@@ -192,6 +194,8 @@ function buildHydratedStateFromCloudGame(
     opponentScore: cloudGame.opponentScore,
     homeScoreAdjustment: cloudGame.homeScoreAdjustment,
     notes: cloudGame.notes,
+    currentPeriod: 1,
+    teamStatsConfig: null,
     actionLog: [],
     cloudSync: {
       ...createInitialCloudSyncState('synced'),
@@ -411,6 +415,15 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         },
       }
 
+    case 'SET_PERIOD': {
+      const next =
+        Number.isFinite(action.period) && action.period >= 1 ? Math.floor(action.period) : 1
+      return { ...state, currentPeriod: next }
+    }
+
+    case 'SET_TEAM_STATS_CONFIG':
+      return { ...state, teamStatsConfig: action.config }
+
     default:
       return state
   }
@@ -433,6 +446,11 @@ function loadState(): GameState {
     ...parsed,
     homeScoreAdjustment: typeof parsed.homeScoreAdjustment === 'number' ? parsed.homeScoreAdjustment : 0,
     notes: typeof parsed.notes === 'string' ? parsed.notes : '',
+    currentPeriod:
+      typeof parsed.currentPeriod === 'number' && parsed.currentPeriod >= 1
+        ? Math.floor(parsed.currentPeriod)
+        : 1,
+    teamStatsConfig: parsed.teamStatsConfig ?? null,
     players: Array.isArray(parsed.players) ? parsed.players : [],
     actionLog: Array.isArray(parsed.actionLog) ? parsed.actionLog : [],
     cloudSync: {

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -23,6 +23,8 @@ export interface HydratedCloudGame {
   players: Player[]
   activePlayerId: string | null
   opponentScore: number
+  /** Null = legacy scoring from stats + home_score_adjustment. */
+  homeTeamScore: number | null
   homeScoreAdjustment: number
   notes: string
   seasonId: string | null
@@ -41,6 +43,7 @@ type CloudGameRow = {
   season_id?: string | null
   game_date: string
   opponent_score: number | null
+  home_team_score?: number | null
   home_score_adjustment?: number | null
   notes?: string | null
   status: string
@@ -55,6 +58,11 @@ function isMissingLastOpenedColumnError(error: { message?: string } | null): boo
 function isMissingHomeScoreAdjustmentColumnError(error: { message?: string } | null): boolean {
   if (!error?.message) return false
   return error.message.includes('home_score_adjustment') && error.message.includes('column')
+}
+
+function isMissingHomeTeamScoreColumnError(error: { message?: string } | null): boolean {
+  if (!error?.message) return false
+  return error.message.includes('home_team_score') && error.message.includes('column')
 }
 
 function isMissingTournamentIdColumnError(error: { message?: string } | null): boolean {
@@ -251,6 +259,7 @@ async function ensureGame(
     ...(seasonIdForGame ? { season_id: seasonIdForGame } : {}),
     opponent_name: state.gameInfo!.opponentName,
     opponent_score: state.opponentScore,
+    home_team_score: state.homeTeamScore,
     home_score_adjustment: state.homeScoreAdjustment,
     tournament_name: state.gameInfo!.tournamentName || null,
     tournament_id: state.gameInfo!.tournamentId || null,
@@ -266,6 +275,7 @@ async function ensureGame(
     ...(seasonIdForGame ? { season_id: seasonIdForGame } : {}),
     opponent_name: state.gameInfo!.opponentName,
     opponent_score: state.opponentScore,
+    home_team_score: state.homeTeamScore,
     home_score_adjustment: state.homeScoreAdjustment,
     tournament_name: state.gameInfo!.tournamentName || null,
     tournament_id: state.gameInfo!.tournamentId || null,
@@ -275,6 +285,7 @@ async function ensureGame(
 
   // Fallback payload without optional columns that may not exist yet (pre-migration)
   function buildInsertFallbackPayload(
+    omitHomeTeamScore: boolean,
     omitHomeAdj: boolean,
     omitTournamentId: boolean,
     omitNotes: boolean,
@@ -285,6 +296,7 @@ async function ensureGame(
       ...(omitSeasonId || !seasonIdForGame ? {} : { season_id: seasonIdForGame }),
       opponent_name: state.gameInfo!.opponentName,
       opponent_score: state.opponentScore,
+      ...(omitHomeTeamScore ? {} : { home_team_score: state.homeTeamScore }),
       ...(omitHomeAdj ? {} : { home_score_adjustment: state.homeScoreAdjustment }),
       tournament_name: state.gameInfo!.tournamentName || null,
       ...(omitTournamentId ? {} : { tournament_id: state.gameInfo!.tournamentId || null }),
@@ -296,6 +308,7 @@ async function ensureGame(
   }
 
   function buildUpdateFallbackPayload(
+    omitHomeTeamScore: boolean,
     omitHomeAdj: boolean,
     omitTournamentId: boolean,
     omitNotes: boolean,
@@ -306,6 +319,7 @@ async function ensureGame(
       ...(omitSeasonId || !seasonIdForGame ? {} : { season_id: seasonIdForGame }),
       opponent_name: state.gameInfo!.opponentName,
       opponent_score: state.opponentScore,
+      ...(omitHomeTeamScore ? {} : { home_team_score: state.homeTeamScore }),
       ...(omitHomeAdj ? {} : { home_score_adjustment: state.homeScoreAdjustment }),
       tournament_name: state.gameInfo!.tournamentName || null,
       ...(omitTournamentId ? {} : { tournament_id: state.gameInfo!.tournamentId || null }),
@@ -331,18 +345,37 @@ async function ensureGame(
     let { error, data } = await run(payload)
     if (!error) return op === 'update' ? gameId! : (data!.id as string)
 
+    const missingHomeTeamScore = isMissingHomeTeamScoreColumnError(error)
     const missingHomeAdj = isMissingHomeScoreAdjustmentColumnError(error)
     const missingTournamentId = isMissingTournamentIdColumnError(error)
     const missingNotes = isMissingNotesColumnError(error)
     const missingSeasonId = isMissingSeasonIdColumnError(error)
-    if (!missingHomeAdj && !missingTournamentId && !missingNotes && !missingSeasonId) {
+    if (
+      !missingHomeTeamScore &&
+      !missingHomeAdj &&
+      !missingTournamentId &&
+      !missingNotes &&
+      !missingSeasonId
+    ) {
       throw new Error(`Game ${op} failed: ${error.message}`)
     }
 
     const fb =
       op === 'update'
-        ? buildUpdateFallbackPayload(missingHomeAdj, missingTournamentId, missingNotes, missingSeasonId)
-        : buildInsertFallbackPayload(missingHomeAdj, missingTournamentId, missingNotes, missingSeasonId)
+        ? buildUpdateFallbackPayload(
+            missingHomeTeamScore,
+            missingHomeAdj,
+            missingTournamentId,
+            missingNotes,
+            missingSeasonId
+          )
+        : buildInsertFallbackPayload(
+            missingHomeTeamScore,
+            missingHomeAdj,
+            missingTournamentId,
+            missingNotes,
+            missingSeasonId
+          )
     ;({ error, data } = await run(fb))
     if (error) throw new Error(`Game ${op} failed: ${error.message}`)
     return op === 'update' ? gameId! : (data!.id as string)
@@ -675,6 +708,8 @@ async function hydrateCloudGameFromRow(userId: string, gameRow: CloudGameRow): P
     players,
     activePlayerId: players[0]?.id ?? null,
     opponentScore: gameRow.opponent_score ?? 0,
+    homeTeamScore:
+      typeof gameRow.home_team_score === 'number' ? gameRow.home_team_score : null,
     homeScoreAdjustment: gameRow.home_score_adjustment ?? 0,
     notes: gameRow.notes ?? '',
     seasonId,
@@ -691,7 +726,7 @@ async function loadLatestGameRow(userId: string): Promise<CloudGameRow | null> {
   }
 
   // All optional columns (may not exist before their respective migrations)
-  const allOptional = 'home_score_adjustment,tournament_id,notes,last_opened_at,season_id'
+  const allOptional = 'home_team_score,home_score_adjustment,tournament_id,notes,last_opened_at,season_id'
   const baseColumns =
     'id,team_id,opponent_name,tournament_name,game_date,opponent_score,status,created_at'
 
@@ -712,12 +747,20 @@ async function loadLatestGameRow(userId: string): Promise<CloudGameRow | null> {
 
   // Detect which optional columns are missing and rebuild the select list.
   const missingLastOpened = isMissingLastOpenedColumnError(advanced.error)
+  const missingHomeTeamScore = isMissingHomeTeamScoreColumnError(advanced.error)
   const missingHomeAdjust = isMissingHomeScoreAdjustmentColumnError(advanced.error)
   const missingTournamentId = isMissingTournamentIdColumnError(advanced.error)
   const missingNotes = isMissingNotesColumnError(advanced.error)
   const missingSeasonId = isMissingSeasonIdColumnError(advanced.error)
 
-  if (!missingLastOpened && !missingHomeAdjust && !missingTournamentId && !missingNotes && !missingSeasonId) {
+  if (
+    !missingLastOpened &&
+    !missingHomeTeamScore &&
+    !missingHomeAdjust &&
+    !missingTournamentId &&
+    !missingNotes &&
+    !missingSeasonId
+  ) {
     throw new Error(`Game load failed: ${advanced.error.message}`)
   }
 
@@ -725,6 +768,7 @@ async function loadLatestGameRow(userId: string): Promise<CloudGameRow | null> {
 
   const selectColumns =
     baseColumns +
+    (!missingHomeTeamScore ? ',home_team_score' : '') +
     (!missingHomeAdjust ? ',home_score_adjustment' : '') +
     (!missingTournamentId ? ',tournament_id' : '') +
     (!missingNotes ? ',notes' : '') +
@@ -748,6 +792,7 @@ async function loadLatestGameRow(userId: string): Promise<CloudGameRow | null> {
   // Final fallback: base columns only (no optional columns at all).
   const isStillOptionalMissing =
     isMissingLastOpenedColumnError(retry.error) ||
+    isMissingHomeTeamScoreColumnError(retry.error) ||
     isMissingHomeScoreAdjustmentColumnError(retry.error) ||
     isMissingTournamentIdColumnError(retry.error) ||
     isMissingNotesColumnError(retry.error) ||
@@ -790,20 +835,28 @@ export async function loadCloudGameById(userId: string, gameId: string): Promise
 
   const { data: gameRow, error: gameError } = await supabase
     .from('games')
-    .select(`${baseById},home_score_adjustment,tournament_id,notes,season_id`)
+    .select(`${baseById},home_team_score,home_score_adjustment,tournament_id,notes,season_id`)
     .eq('id', gameId)
     .maybeSingle()
 
   if (gameError) {
+    const missingHomeTeamScore = isMissingHomeTeamScoreColumnError(gameError)
     const missingHomeAdj = isMissingHomeScoreAdjustmentColumnError(gameError)
     const missingTournamentId = isMissingTournamentIdColumnError(gameError)
     const missingNotes = isMissingNotesColumnError(gameError)
     const missingSeasonId = isMissingSeasonIdColumnError(gameError)
-    if (!missingHomeAdj && !missingTournamentId && !missingNotes && !missingSeasonId) {
+    if (
+      !missingHomeTeamScore &&
+      !missingHomeAdj &&
+      !missingTournamentId &&
+      !missingNotes &&
+      !missingSeasonId
+    ) {
       throw new Error(`Game load failed: ${gameError.message}`)
     }
     const fallbackSelect =
       baseById +
+      (!missingHomeTeamScore ? ',home_team_score' : '') +
       (!missingHomeAdj ? ',home_score_adjustment' : '') +
       (!missingTournamentId ? ',tournament_id' : '') +
       (!missingNotes ? ',notes' : '') +

--- a/src/lib/gameScore.ts
+++ b/src/lib/gameScore.ts
@@ -1,0 +1,29 @@
+import type { SportConfig } from '../types'
+import { computePlayerScore } from '../config/sports'
+
+/** Scoreboard / W–L home total: standalone when set, else legacy computed + adjustment. */
+export function getDisplayedHomeScore(
+  sport: SportConfig,
+  players: { stats: Record<string, number> }[],
+  homeTeamScore: number | null,
+  homeScoreAdjustment: number
+): number {
+  if (homeTeamScore != null) {
+    return homeTeamScore
+  }
+  const computed = players.reduce((t, p) => t + computePlayerScore(sport, p.stats), 0)
+  return computed + homeScoreAdjustment
+}
+
+/** Finalized game row + aggregated team stats (sum across players). */
+export function resolveFinalHomeScoreFromGameRow(
+  sport: SportConfig,
+  statsTotalsByStatId: Record<string, number>,
+  row: { home_team_score?: number | null; home_score_adjustment?: number | null }
+): number {
+  if (row.home_team_score != null) {
+    return row.home_team_score
+  }
+  const base = computePlayerScore(sport, statsTotalsByStatId)
+  return base + (row.home_score_adjustment ?? 0)
+}

--- a/src/pages/CareerStats.tsx
+++ b/src/pages/CareerStats.tsx
@@ -282,6 +282,8 @@ export default function CareerStats() {
         opponentScore: cloudGame.opponentScore,
         homeScoreAdjustment: cloudGame.homeScoreAdjustment,
         notes: cloudGame.notes,
+        currentPeriod: 1,
+        teamStatsConfig: null,
         actionLog: [],
         cloudSync: {
           seasonId: cloudGame.seasonId ?? null,

--- a/src/pages/CareerStats.tsx
+++ b/src/pages/CareerStats.tsx
@@ -280,6 +280,7 @@ export default function CareerStats() {
         players: cloudGame.players,
         activePlayerId: cloudGame.activePlayerId,
         opponentScore: cloudGame.opponentScore,
+        homeTeamScore: cloudGame.homeTeamScore,
         homeScoreAdjustment: cloudGame.homeScoreAdjustment,
         notes: cloudGame.notes,
         currentPeriod: 1,

--- a/src/pages/GameSummary.tsx
+++ b/src/pages/GameSummary.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGame, GAME_STORAGE_KEY } from '../context/GameContext'
-import { computePlayerScore, computeCategoryTotal } from '../config/sports'
+import { computeCategoryTotal } from '../config/sports'
+import { getDisplayedHomeScore } from '../lib/gameScore'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
 
@@ -27,7 +28,7 @@ export default function GameSummary() {
   const navigate = useNavigate()
   const { state, dispatch } = useGame()
   const { user, isConfigured } = useAuth()
-  const { sport, gameInfo, players, opponentScore, homeScoreAdjustment } = state
+  const { sport, gameInfo, players, opponentScore, homeTeamScore, homeScoreAdjustment } = state
   const [finalizing, setFinalizing] = useState(false)
   const [finalizeError, setFinalizeError] = useState<string | null>(null)
   const [resolvedStats, setResolvedStats] = useState<ResolvedStatsMap | null>(null)
@@ -297,11 +298,12 @@ export default function GameSummary() {
     return allSubmissions[remoteId]?.[statId] ?? []
   }
 
-  const computedTeamScore = players.reduce(
-    (total, player) => total + computePlayerScore(sport, getPlayerStats(player.id)),
-    0
+  const teamScore = getDisplayedHomeScore(
+    sport,
+    players.map(p => ({ stats: getPlayerStats(p.id) })),
+    homeTeamScore,
+    homeScoreAdjustment
   )
-  const teamScore = computedTeamScore + homeScoreAdjustment
 
   const allStatIds = sport.categories.flatMap(c => c.actions.map(a => a.id))
 
@@ -386,12 +388,27 @@ export default function GameSummary() {
       .update({
         status: 'final',
         opponent_score: opponentScore,
+        home_team_score: homeTeamScore,
         home_score_adjustment: homeScoreAdjustment,
       })
       .eq('id', state.cloudSync.gameId)
 
-    // Fallback for deployments missing migration 015 (no home_score_adjustment column).
     let finalizeError = initial.error
+    if (
+      finalizeError &&
+      finalizeError.message?.includes('home_team_score') &&
+      finalizeError.message?.includes('column')
+    ) {
+      const retry = await supabase!
+        .from('games')
+        .update({
+          status: 'final',
+          opponent_score: opponentScore,
+          home_score_adjustment: homeScoreAdjustment,
+        })
+        .eq('id', state.cloudSync.gameId)
+      finalizeError = retry.error ?? null
+    }
     if (
       finalizeError &&
       finalizeError.message?.includes('home_score_adjustment') &&
@@ -642,7 +659,12 @@ export default function GameSummary() {
                 <p className="text-2xl font-bold text-slate-800">{opponentScore}</p>
               </div>
             </div>
-            {homeScoreAdjustment !== 0 && (
+            {homeTeamScore != null && (
+              <p className="text-xs text-slate-500 text-center mb-2">
+                Scoreboard total (not from player stats)
+              </p>
+            )}
+            {homeTeamScore == null && homeScoreAdjustment !== 0 && (
               <p className="text-xs text-slate-500 text-center mb-2">
                 Score adjustment: {homeScoreAdjustment >= 0 ? '+' : ''}{homeScoreAdjustment}
               </p>

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -4,7 +4,8 @@ import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
 import { supabase } from '../lib/supabase'
 import { loadCloudGameById, touchCloudGameLastOpened } from '../lib/cloudSync'
-import { sports, computePlayerScore } from '../config/sports'
+import { sports } from '../config/sports'
+import { resolveFinalHomeScoreFromGameRow } from '../lib/gameScore'
 import type { GameState } from '../types'
 import ConfirmDialog from '../components/ConfirmDialog'
 import { teamDisplayName } from '../lib/display'
@@ -16,6 +17,7 @@ interface GameRow {
   opponent_score: number
   tournament_name: string | null
   tournament_id: string | null
+  home_team_score: number | null
   home_score_adjustment: number | null
   game_date: string
   status: string
@@ -87,7 +89,7 @@ export default function Games() {
       const { data: gameRows, error: gamesError } = await supabaseClient
         .from('games')
         .select(
-          'id,team_id,opponent_name,opponent_score,tournament_name,tournament_id,home_score_adjustment,game_date,status,created_at'
+          'id,team_id,opponent_name,opponent_score,tournament_name,tournament_id,home_team_score,home_score_adjustment,game_date,status,created_at'
         )
         .eq('created_by', userId)
         .order('created_at', { ascending: false })
@@ -168,9 +170,7 @@ export default function Games() {
         for (const row of (data ?? []) as { stat_id: string; value: number }[]) {
           byStat[row.stat_id] = (byStat[row.stat_id] ?? 0) + Number(row.value)
         }
-        const base = computePlayerScore(sport, byStat)
-        const adj = g.home_score_adjustment ?? 0
-        const home = base + adj
+        const home = resolveFinalHomeScoreFromGameRow(sport, byStat, g)
         next[g.id] = `${home}–${g.opponent_score}`
       }
       if (!cancelled) setFinalScoreLines(next)
@@ -227,6 +227,7 @@ export default function Games() {
       players: cloudGame.players,
       activePlayerId: cloudGame.activePlayerId,
       opponentScore: cloudGame.opponentScore,
+      homeTeamScore: cloudGame.homeTeamScore,
       homeScoreAdjustment: cloudGame.homeScoreAdjustment,
       notes: cloudGame.notes,
       currentPeriod: 1,

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -229,6 +229,8 @@ export default function Games() {
       opponentScore: cloudGame.opponentScore,
       homeScoreAdjustment: cloudGame.homeScoreAdjustment,
       notes: cloudGame.notes,
+      currentPeriod: 1,
+      teamStatsConfig: null,
       actionLog: [],
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -278,6 +278,7 @@ export default function PlayerProfile() {
       players: cloudGame.players,
       activePlayerId: cloudGame.activePlayerId,
       opponentScore: cloudGame.opponentScore,
+      homeTeamScore: cloudGame.homeTeamScore,
       homeScoreAdjustment: cloudGame.homeScoreAdjustment,
       notes: cloudGame.notes,
       currentPeriod: 1,

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -280,6 +280,8 @@ export default function PlayerProfile() {
       opponentScore: cloudGame.opponentScore,
       homeScoreAdjustment: cloudGame.homeScoreAdjustment,
       notes: cloudGame.notes,
+      currentPeriod: 1,
+      teamStatsConfig: null,
       actionLog: [],
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,

--- a/src/pages/TeamStats.tsx
+++ b/src/pages/TeamStats.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams, Link } from 'react-router-dom'
-import { sports, computePlayerScore } from '../config/sports'
+import { sports } from '../config/sports'
+import { resolveFinalHomeScoreFromGameRow } from '../lib/gameScore'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName } from '../lib/display'
@@ -19,6 +20,7 @@ interface GameMeta {
   game_date: string
   opponent_name: string
   opponent_score: number
+  home_team_score: number | null
   home_score_adjustment: number | null
   tournament_id: string | null
 }
@@ -28,6 +30,7 @@ interface TeamLogRow {
   game_date: string
   opponent_name: string
   opponent_score: number
+  home_team_score: number | null
   home_score_adjustment: number
   stat_id: string
   team_total: number
@@ -84,7 +87,9 @@ export default function TeamStats() {
           .single(),
         supabaseClient
           .from('games')
-          .select('id,game_date,opponent_name,opponent_score,home_score_adjustment,tournament_id')
+          .select(
+            'id,game_date,opponent_name,opponent_score,home_team_score,home_score_adjustment,tournament_id'
+          )
           .eq('team_id', teamId)
           .eq('status', 'final')
           .order('game_date', { ascending: false }),
@@ -122,6 +127,7 @@ export default function TeamStats() {
               game_date: g.game_date,
               opponent_name: g.opponent_name,
               opponent_score: g.opponent_score,
+              home_team_score: g.home_team_score ?? null,
               home_score_adjustment: adj,
               stat_id: statId,
               team_total,
@@ -164,6 +170,7 @@ export default function TeamStats() {
               game_date: row.game_date,
               opponent_name: row.opponent_name,
               opponent_score: row.opponent_score,
+              home_team_score: row.home_team_score,
               home_score_adjustment: row.home_score_adjustment,
               tournament_id: null,
             },
@@ -195,9 +202,13 @@ export default function TeamStats() {
     for (const g of games) {
       const entry = byGame.get(g.id)
       const stats = entry?.stats ?? {}
-      const base = sport ? computePlayerScore(sport, stats) : 0
-      const homeAdj = entry?.homeAdj ?? g.home_score_adjustment ?? 0
-      const homeScore = base + homeAdj
+      const meta = entry?.meta ?? g
+      const homeScore = sport
+        ? resolveFinalHomeScoreFromGameRow(sport, stats, {
+            home_team_score: meta.home_team_score,
+            home_score_adjustment: entry?.homeAdj ?? meta.home_score_adjustment ?? 0,
+          })
+        : 0
       const won = homeScore > g.opponent_score
       if (homeScore !== g.opponent_score) {
         if (won) wins++

--- a/src/pages/TournamentStats.tsx
+++ b/src/pages/TournamentStats.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { sports, computePlayerScore } from '../config/sports'
+import { resolveFinalHomeScoreFromGameRow } from '../lib/gameScore'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName, playerDisplayName } from '../lib/display'
@@ -27,6 +28,7 @@ interface GameMeta {
   game_date: string
   opponent_name: string
   opponent_score: number
+  home_team_score: number | null
   home_score_adjustment: number | null
 }
 
@@ -115,7 +117,7 @@ export default function TournamentStats() {
           .single(),
         supabaseClient
           .from('games')
-          .select('id,game_date,opponent_name,opponent_score,home_score_adjustment')
+          .select('id,game_date,opponent_name,opponent_score,home_team_score,home_score_adjustment')
           .eq('team_id', teamId)
           .eq('tournament_id', tournamentId)
           .eq('status', 'final')
@@ -219,9 +221,7 @@ export default function TournamentStats() {
               byStat[row.stat_id] = (byStat[row.stat_id] ?? 0) + Number(row.value)
             }
           }
-          const base = computePlayerScore(sportCfg, byStat)
-          const adj = g.home_score_adjustment ?? 0
-          const homeScore = base + adj
+          const homeScore = resolveFinalHomeScoreFromGameRow(sportCfg, byStat, g)
           const opp = g.opponent_score
           const decided = homeScore !== opp
           const won = homeScore > opp

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,10 +72,21 @@ export interface Player {
 export interface ActionLogEntry {
   id: string
   timestamp: number
-  type: 'increment' | 'decrement' | 'opponent_score_up' | 'opponent_score_down' | 'home_score_up' | 'home_score_down'
+  type:
+    | 'increment'
+    | 'decrement'
+    | 'opponent_score_up'
+    | 'opponent_score_down'
+    | 'home_score_up'
+    | 'home_score_down'
+    | 'home_team_score_up'
+    | 'home_team_score_down'
   playerId?: string
   statId?: string
   previousValue: number
+  /** For home_team_score_* undo: snapshot before the change. */
+  previousHomeTeamScore?: number | null
+  previousHomeScoreAdjustment?: number
 }
 
 /** Resolved basketball team-stat rules (season defaults merged in). */
@@ -98,7 +109,14 @@ export interface GameState {
   players: Player[]
   activePlayerId: string | null
   opponentScore: number
-  /** Additive adjustment to home score (computed from player stats). Displayed home = computed + this. */
+  /**
+   * Standalone scoreboard home total (not derived from player scoring stats).
+   * When null, displayed home score uses legacy: sum of player scoring stats + homeScoreAdjustment.
+   */
+  homeTeamScore: number | null
+  /**
+   * Legacy additive tweak when homeTeamScore is null; ignored when homeTeamScore is set.
+   */
   homeScoreAdjustment: number
   /** Free-text game notes entered during or after the game. */
   notes: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export interface StatAction {
   /** Set on miss/attempt actions: the id of the corresponding made stat.
    *  Used in Game Summary to merge made+miss into a single M/A column. */
   madeStatId?: string
+  /** Team stats: actual stat id becomes `${id}_p${currentPeriod}` in GameTracker. */
+  periodScoped?: boolean
 }
 
 export interface StatCategory {
@@ -39,9 +41,13 @@ export interface SportConfig {
   icon: string
   theme: SportTheme
   categories: StatCategory[]
+  /** Team pseudo-player stat categories (optional per sport). */
+  teamCategories?: StatCategory[]
   scoreLabel: string
   /** Stat ids for compact per-game lines (e.g. game log). Optional; falls back to score + common stats. */
   keyStatIds?: string[]
+  /** Compact keys when summarizing team-level stats. */
+  teamKeyStatIds?: string[]
 }
 
 export interface GameInfo {
@@ -58,6 +64,9 @@ export interface Player {
   name: string
   number: string
   stats: Record<string, number>
+  /** True for home/opponent team pseudo-players (team-level stat tracking). */
+  isTeamPlayer?: boolean
+  teamSide?: 'home' | 'opponent'
 }
 
 export interface ActionLogEntry {
@@ -68,6 +77,20 @@ export interface ActionLogEntry {
   statId?: string
   previousValue: number
 }
+
+/** Resolved basketball team-stat rules (season defaults merged in). */
+export interface BasketballTeamStatsConfig {
+  periodsPerGame: number
+  periodLabels: string[]
+  bonusThreshold: number
+  doubleBonusThreshold: number
+  hasOneAndOne: boolean
+  overtimeLabel: string
+  overtimeFoulsReset: boolean
+}
+
+/** Union placeholder for future per-sport team config shapes. */
+export type TeamStatsConfig = BasketballTeamStatsConfig
 
 export interface GameState {
   sport: SportConfig | null
@@ -81,6 +104,10 @@ export interface GameState {
   notes: string
   actionLog: ActionLogEntry[]
   cloudSync: CloudSyncState
+  /** 1-based period index for period-scoped team stats (e.g. half 1 vs 2). */
+  currentPeriod: number
+  /** Season team-stat rules; null until loaded from season or derived from defaults. */
+  teamStatsConfig: TeamStatsConfig | null
 }
 
 export type CloudSyncStatus =
@@ -119,3 +146,5 @@ export type GameAction =
   | { type: 'UNDO' }
   | { type: 'RESET_GAME' }
   | { type: 'SET_CLOUD_SYNC_STATE'; cloudSync: Partial<CloudSyncState> }
+  | { type: 'SET_PERIOD'; period: number }
+  | { type: 'SET_TEAM_STATS_CONFIG'; config: TeamStatsConfig | null }

--- a/supabase/migrations/027_home_team_score.sql
+++ b/supabase/migrations/027_home_team_score.sql
@@ -1,0 +1,54 @@
+-- Standalone scoreboard home total: not derived from player scoring stats.
+-- When null, clients use legacy: sum(scoring stats) + home_score_adjustment.
+
+alter table public.games
+  add column if not exists home_team_score int null;
+
+comment on column public.games.home_team_score is
+  'Manual home team score for the scoreboard. When null, displayed home score = sum of player scoring stats from game_stats + COALESCE(home_score_adjustment, 0).';
+
+-- Team game log: expose home_team_score for W/L and summaries (DESIGN_STAT_TRACKING_UI).
+drop function if exists public.get_team_game_log(uuid);
+
+create function public.get_team_game_log(p_team_id uuid)
+returns table (
+  game_id uuid,
+  game_date date,
+  opponent_name text,
+  opponent_score int,
+  home_team_score int,
+  home_score_adjustment int,
+  stat_id text,
+  team_total bigint
+)
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  select
+    g.id as game_id,
+    g.game_date,
+    g.opponent_name,
+    g.opponent_score,
+    g.home_team_score,
+    coalesce(g.home_score_adjustment, 0)::int as home_score_adjustment,
+    r.stat_id,
+    sum(r.value)::bigint as team_total
+  from public.games g
+  cross join lateral public.get_game_stats_resolved(g.id) r
+  where g.team_id = p_team_id
+    and g.status = 'final'
+  group by
+    g.id,
+    g.game_date,
+    g.opponent_name,
+    g.opponent_score,
+    g.home_team_score,
+    g.home_score_adjustment,
+    r.stat_id
+  order by g.game_date desc, r.stat_id;
+$$;
+
+comment on function public.get_team_game_log(uuid) is
+  'Per-game team stat totals from resolved stats; includes home_team_score for scoreboard (migration 027).';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **WU-1** team-stats foundation (types, basketball `teamCategories`, period state) and **standalone home team score** aligned with product direction: scoreboard home total is **not** derived from player scoring stats once the user edits it; cloud stores `games.home_team_score` (nullable for legacy rows).

## Team stats (WU-1)

- Types: `isTeamPlayer`, `periodScoped`, `teamCategories`, `currentPeriod`, `teamStatsConfig`, actions.
- `src/config/teamStatsDefaults.ts`, basketball `teamCategories` in `sports.ts`.

## Standalone home score

- `GameState.homeTeamScore`: `null` = legacy display = sum(player scoring stats) + `homeScoreAdjustment`.
- First **+** or **−** on the scoreboard transitions to an explicit total (undo restores prior legacy mode when applicable).
- `src/lib/gameScore.ts`: `getDisplayedHomeScore`, `resolveFinalHomeScoreFromGameRow` for W/L and lists.
- **Migration `027_home_team_score.sql`**: `games.home_team_score` (nullable); replaces `get_team_game_log` to return `home_team_score` (RPC shape change — apply on UAT).

## Base branch

Targeting **`stattracker`** (UAT).

## Supabase

Apply **`027_home_team_score.sql`** on the UAT project. Until then, the app falls back if the column is missing (sync/load).

## How to test

- `pnpm build` / `pnpm lint`
- Scoreboard: legacy game shows computed+adj; after +/−, score is explicit; opponent unchanged.
- After migration: finalize sets `home_team_score`; Team Stats / Tournament W-L use stored total when set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

