### PR TITLE
feat: team stat categories with period toggle and scoped stat ids (WU-4)

### DIFF
--- a/src/components/StatButton.tsx
+++ b/src/components/StatButton.tsx
@@ -24,6 +24,8 @@ interface StatButtonProps {
   value: number
   color: StatColor
   pointValue?: number
+  /** Optional line under the header row (e.g. game total for period-scoped team stats). */
+  subtitle?: string
   onIncrement: () => void
   onDecrement: () => void
   /** If provided, renders a middle "A" (attempt/miss) button between − and +. */
@@ -38,6 +40,7 @@ export default function StatButton({
   value,
   color,
   pointValue,
+  subtitle,
   onIncrement,
   onDecrement,
   onAttempt,
@@ -81,6 +84,9 @@ export default function StatButton({
           {hasAttempt ? `${value}/${totalAttempts}` : value}
         </span>
       </div>
+      {subtitle ? (
+        <p className="text-[11px] text-slate-500 mb-2 leading-tight">{subtitle}</p>
+      ) : null}
       <div className="flex gap-1.5">
         <button
           onClick={(e) => { e.stopPropagation(); onDecrement() }}

--- a/src/components/team-stats/PeriodToggle.tsx
+++ b/src/components/team-stats/PeriodToggle.tsx
@@ -1,0 +1,60 @@
+import type { SportTheme } from '../../types'
+
+export interface PeriodToggleProps {
+  /** Total number of selectable periods (base halves/quarters + any OT added). */
+  periods: number
+  periodLabels: string[]
+  currentPeriod: number
+  onPeriodChange: (period: number) => void
+  onAddOvertime: () => void
+  sportTheme: SportTheme
+  /** Label for the add-OT control (e.g. "+ OT"). */
+  addOvertimeLabel: string
+}
+
+export default function PeriodToggle({
+  periods,
+  periodLabels,
+  currentPeriod,
+  onPeriodChange,
+  onAddOvertime,
+  sportTheme,
+  addOvertimeLabel,
+}: PeriodToggleProps) {
+  return (
+    <div className="flex flex-wrap gap-2 items-center justify-center py-2">
+      {Array.from({ length: periods }, (_, i) => {
+        const p = i + 1
+        const label = periodLabels[i] ?? `Period ${p}`
+        const active = p === currentPeriod
+        return (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onPeriodChange(p)}
+            className={`
+              rounded-lg px-3 py-2 text-xs font-semibold transition-all active:scale-95
+              border
+              ${active
+                ? `${sportTheme.bg} text-white border-transparent shadow-sm`
+                : 'bg-white text-slate-600 border-slate-200 hover:bg-slate-50'
+              }
+            `}
+          >
+            {label}
+          </button>
+        )
+      })}
+      <button
+        type="button"
+        onClick={onAddOvertime}
+        className={`
+          rounded-lg px-3 py-2 text-xs font-semibold border border-dashed transition-all active:scale-95
+          ${sportTheme.border} ${sportTheme.text} bg-white hover:bg-slate-50
+        `}
+      >
+        {addOvertimeLabel}
+      </button>
+    </div>
+  )
+}

--- a/src/pages/GameTracker.tsx
+++ b/src/pages/GameTracker.tsx
@@ -1,10 +1,12 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGame } from '../context/GameContext'
 import { computeCategoryTotal } from '../config/sports'
-import type { Player, StatCategory } from '../types'
+import { resolveTeamStatsConfig } from '../config/teamStatsDefaults'
+import type { Player, StatAction, StatCategory } from '../types'
 import Scoreboard from '../components/Scoreboard'
 import StatButton from '../components/StatButton'
+import PeriodToggle from '../components/team-stats/PeriodToggle'
 import {
   isTeamPseudoPlayer,
   TEAM_PLAYER_HOME_ID,
@@ -21,25 +23,96 @@ function sortTeamPlayersFirst(players: Player[]): Player[] {
   return [...orderedTeams, ...individuals]
 }
 
+/** Strip `_pN` suffix for config lookup (undo log stores scoped ids). */
+function baseStatId(statId: string): string {
+  return statId.replace(/_p\d+$/, '')
+}
+
 function findStatShortLabel(categories: StatCategory[] | undefined, statId: string | undefined): string {
   if (!statId) return ''
+  const base = baseStatId(statId)
   for (const cat of categories ?? []) {
     for (const action of cat.actions) {
-      if (action.id === statId) return action.shortLabel
+      if (action.id === base) return action.shortLabel
     }
   }
   return statId
 }
 
+function hasPeriodScopedActions(categories: StatCategory[] | undefined): boolean {
+  if (!categories) return false
+  return categories.some(cat => cat.actions.some(a => a.periodScoped))
+}
+
+/** Sum stats for `baseId_p1`, `baseId_p2`, ... */
+function sumPeriodScopedStats(stats: Record<string, number>, baseId: string): number {
+  const prefix = `${baseId}_p`
+  let sum = 0
+  for (const [key, val] of Object.entries(stats)) {
+    if (key.startsWith(prefix)) sum += val
+  }
+  return sum
+}
+
+function actualStatId(action: StatAction, currentPeriod: number): string {
+  return action.periodScoped ? `${action.id}_p${currentPeriod}` : action.id
+}
+
 export default function GameTracker() {
   const navigate = useNavigate()
   const { state, dispatch, flushCloudSync } = useGame()
-  const { sport, players, activePlayerId, actionLog, notes, gameInfo } = state
+  const { sport, players, activePlayerId, actionLog, notes, gameInfo, currentPeriod, teamStatsConfig } =
+    state
 
   const [showAddPlayer, setShowAddPlayer] = useState(false)
   const [newName, setNewName] = useState('')
   const [newNumber, setNewNumber] = useState('')
   const [localNotes, setLocalNotes] = useState(notes)
+
+  const teamRules = useMemo(
+    () => (sport ? resolveTeamStatsConfig(sport, teamStatsConfig) : null),
+    [sport, teamStatsConfig]
+  )
+
+  const basePeriodCount = teamRules?.periodsPerGame ?? 2
+  const [periodButtonCount, setPeriodButtonCount] = useState(basePeriodCount)
+
+  useEffect(() => {
+    setPeriodButtonCount(basePeriodCount)
+  }, [basePeriodCount, sport?.id])
+
+  useEffect(() => {
+    if (currentPeriod > periodButtonCount) {
+      setPeriodButtonCount(currentPeriod)
+    }
+  }, [currentPeriod, periodButtonCount])
+
+  const periodSegmentLabels = useMemo(() => {
+    const labels = teamRules?.periodLabels ?? []
+    const ot = teamRules?.overtimeLabel ?? 'OT'
+    const out: string[] = []
+    for (let i = 0; i < periodButtonCount; i++) {
+      if (i < labels.length) {
+        out.push(labels[i]!)
+      } else if (labels.length > 0) {
+        out.push(`${ot} ${i - labels.length + 1}`)
+      } else {
+        out.push(`Period ${i + 1}`)
+      }
+    }
+    return out
+  }, [periodButtonCount, teamRules])
+
+  const addOvertimeLabel = useMemo(() => {
+    const ot = teamRules?.overtimeLabel ?? 'OT'
+    return `+ ${ot}`
+  }, [teamRules])
+
+  const handleAddOvertime = useCallback(() => {
+    const nextCount = periodButtonCount + 1
+    setPeriodButtonCount(nextCount)
+    dispatch({ type: 'SET_PERIOD', period: nextCount })
+  }, [dispatch, periodButtonCount])
 
   // Flush cloud sync when leaving Game Tracker so latest stats are saved (must run before any early return)
   useEffect(() => {
@@ -96,6 +169,11 @@ export default function GameTracker() {
   }
 
   const activePlayer = players.find(p => p.id === activePlayerId) || players[0]
+  const showTeamStatGrid = Boolean(activePlayer.isTeamPlayer && sport.teamCategories?.length)
+  const showPeriodToggle =
+    showTeamStatGrid && hasPeriodScopedActions(sport.teamCategories)
+
+  const gridCategories = showTeamStatGrid ? sport.teamCategories! : sport.categories
 
   const handleUndo = () => {
     dispatch({ type: 'UNDO' })
@@ -242,29 +320,46 @@ export default function GameTracker() {
         )}
       </div>
 
+      {showPeriodToggle && teamRules && (
+        <div className="px-3 max-w-lg mx-auto w-full">
+          <PeriodToggle
+            periods={periodButtonCount}
+            periodLabels={periodSegmentLabels}
+            currentPeriod={currentPeriod}
+            onPeriodChange={p => dispatch({ type: 'SET_PERIOD', period: p })}
+            onAddOvertime={handleAddOvertime}
+            sportTheme={sport.theme}
+            addOvertimeLabel={addOvertimeLabel}
+          />
+        </div>
+      )}
+
       {/* Stats grid */}
       <div className="flex-1 overflow-y-auto px-3 pb-20 max-w-lg mx-auto w-full">
         <div className="space-y-4 mt-2">
-          {sport.categories.map(category => {
-            // Build miss-action lookup: madeStatId → miss StatAction
+          {gridCategories.map(category => {
             const missMap: Record<string, typeof category.actions[0]> = {}
             for (const a of category.actions) {
               if (a.madeStatId) missMap[a.madeStatId] = a
             }
-            // Only render made/standalone actions; miss actions are embedded into their card
             const visibleActions = category.actions.filter(a => !a.madeStatId)
 
-            const catTotal = computeCategoryTotal(category, activePlayer.stats)
             let displayTotal: number | null = null
-
             if (category.showTotal) {
-              if (category.actions.some(a => a.pointValue)) {
+              if (showTeamStatGrid) {
+                let sum = 0
+                for (const a of visibleActions) {
+                  const sid = actualStatId(a, currentPeriod)
+                  sum += activePlayer.stats[sid] || 0
+                }
+                displayTotal = sum
+              } else if (category.actions.some(a => a.pointValue)) {
                 displayTotal = category.actions.reduce(
-                  (sum, a) => sum + (activePlayer.stats[a.id] || 0) * (a.pointValue || 0),
+                  (s, a) => s + (activePlayer.stats[a.id] || 0) * (a.pointValue || 0),
                   0
                 )
               } else {
-                displayTotal = catTotal
+                displayTotal = computeCategoryTotal(category, activePlayer.stats)
               }
             }
 
@@ -297,26 +392,37 @@ export default function GameTracker() {
                 }`}>
                   {visibleActions.map(action => {
                     const missAction = missMap[action.id]
+                    const scopedId = actualStatId(action, currentPeriod)
+                    const periodTotal =
+                      action.periodScoped
+                        ? sumPeriodScopedStats(activePlayer.stats, action.id)
+                        : null
+                    const subtitle =
+                      action.periodScoped && periodTotal !== null
+                        ? `Total: ${periodTotal}`
+                        : undefined
+
                     return (
                       <StatButton
-                        key={action.id}
+                        key={action.periodScoped ? `${action.id}_p${currentPeriod}` : action.id}
                         label={action.label}
                         shortLabel={action.shortLabel}
-                        value={activePlayer.stats[action.id] || 0}
+                        value={activePlayer.stats[scopedId] || 0}
                         color={action.color ?? category.color}
                         pointValue={action.pointValue}
+                        subtitle={subtitle}
                         onIncrement={() =>
                           dispatch({
                             type: 'INCREMENT_STAT',
                             playerId: activePlayer.id,
-                            statId: action.id,
+                            statId: scopedId,
                           })
                         }
                         onDecrement={() =>
                           dispatch({
                             type: 'DECREMENT_STAT',
                             playerId: activePlayer.id,
-                            statId: action.id,
+                            statId: scopedId,
                           })
                         }
                         onAttempt={missAction ? () =>


### PR DESCRIPTION
- PeriodToggle: segments + add OT; labels from resolveTeamStatsConfig defaults
- GameTracker: teamCategories when team player active; team_foul_pN read/write
- StatButton optional subtitle for period-scoped game total; undo label strips _pN