### PR TITLE
WU-8: Season team stats config UI (Admin)

### DIFF
--- a/src/components/SeasonTeamStatsEditor.tsx
+++ b/src/components/SeasonTeamStatsEditor.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react'
+import type { BasketballTeamStatsConfig } from '../types'
+import {
+  BASKETBALL_TEAM_STATS_DEFAULTS,
+  BASKETBALL_PRESETS,
+  getDefaultPeriodLabels,
+} from '../config/teamStatsDefaults'
+
+type Props = {
+  value: BasketballTeamStatsConfig
+  onChange: (next: BasketballTeamStatsConfig) => void
+}
+
+function mergePresetIntoDefaults(
+  base: BasketballTeamStatsConfig,
+  partial: Partial<BasketballTeamStatsConfig>
+): BasketballTeamStatsConfig {
+  const periodsPerGame =
+    typeof partial.periodsPerGame === 'number' && partial.periodsPerGame >= 1
+      ? Math.floor(partial.periodsPerGame)
+      : base.periodsPerGame
+  let periodLabels = base.periodLabels
+  if (Array.isArray(partial.periodLabels) && partial.periodLabels.length === periodsPerGame) {
+    periodLabels = partial.periodLabels
+  } else if (partial.periodsPerGame != null) {
+    periodLabels = getDefaultPeriodLabels(periodsPerGame)
+  }
+  return {
+    ...base,
+    ...partial,
+    periodsPerGame,
+    periodLabels,
+    bonusThreshold:
+      typeof partial.bonusThreshold === 'number' && partial.bonusThreshold >= 1
+        ? partial.bonusThreshold
+        : base.bonusThreshold,
+    doubleBonusThreshold:
+      typeof partial.doubleBonusThreshold === 'number' && partial.doubleBonusThreshold >= 1
+        ? partial.doubleBonusThreshold
+        : base.doubleBonusThreshold,
+    hasOneAndOne:
+      typeof partial.hasOneAndOne === 'boolean' ? partial.hasOneAndOne : base.hasOneAndOne,
+    overtimeLabel:
+      typeof partial.overtimeLabel === 'string' && partial.overtimeLabel.length > 0
+        ? partial.overtimeLabel
+        : base.overtimeLabel,
+    overtimeFoulsReset:
+      typeof partial.overtimeFoulsReset === 'boolean'
+        ? partial.overtimeFoulsReset
+        : base.overtimeFoulsReset,
+    timeoutsPerPeriod:
+      partial.timeoutsPerPeriod !== undefined ? partial.timeoutsPerPeriod : base.timeoutsPerPeriod,
+    timeoutsPerOvertime:
+      partial.timeoutsPerOvertime !== undefined ? partial.timeoutsPerOvertime : base.timeoutsPerOvertime,
+  }
+}
+
+export default function SeasonTeamStatsEditor({ value, onChange }: Props) {
+  const [presetSelectKey, setPresetSelectKey] = useState(0)
+
+  const setPeriodLabel = (index: number, label: string) => {
+    const next = [...value.periodLabels]
+    next[index] = label
+    onChange({ ...value, periodLabels: next })
+  }
+
+  return (
+    <div className="space-y-3 pt-2 border-t border-slate-100">
+      <p className="text-xs text-slate-500">
+        Used for team fouls, timeouts, and period controls during games in this season.
+      </p>
+
+      <div>
+        <label className="block text-xs font-medium text-slate-600 mb-1">Rules preset</label>
+        <select
+          key={presetSelectKey}
+          className="input-field"
+          value=""
+          aria-label="Apply basketball team stats preset"
+          onChange={e => {
+            const id = e.target.value
+            if (!id) return
+            const preset = BASKETBALL_PRESETS.find(p => p.id === id)
+            if (preset) {
+              onChange(mergePresetIntoDefaults({ ...BASKETBALL_TEAM_STATS_DEFAULTS }, preset.config))
+            }
+            setPresetSelectKey(k => k + 1)
+          }}
+        >
+          <option value="">Apply a preset…</option>
+          {BASKETBALL_PRESETS.map(p => (
+            <option key={p.id} value={p.id}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-slate-600 mb-1">Regulation periods</label>
+        <input
+          type="number"
+          min={1}
+          max={8}
+          className="input-field"
+          value={value.periodsPerGame}
+          onChange={e => {
+            const n = Math.min(8, Math.max(1, Math.floor(Number(e.target.value) || 1)))
+            onChange({
+              ...value,
+              periodsPerGame: n,
+              periodLabels: getDefaultPeriodLabels(n),
+            })
+          }}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-xs font-medium text-slate-600">Period labels</p>
+        {value.periodLabels.map((label, i) => (
+          <input
+            key={i}
+            type="text"
+            className="input-field"
+            value={label}
+            onChange={e => setPeriodLabel(i, e.target.value)}
+            aria-label={`Period ${i + 1} label`}
+          />
+        ))}
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="block text-xs font-medium text-slate-600 mb-1">Bonus fouls</label>
+          <input
+            type="number"
+            min={1}
+            max={99}
+            className="input-field"
+            value={value.bonusThreshold}
+            onChange={e =>
+              onChange({
+                ...value,
+                bonusThreshold: Math.max(1, Math.floor(Number(e.target.value) || 1)),
+              })
+            }
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-slate-600 mb-1">Double bonus</label>
+          <input
+            type="number"
+            min={1}
+            max={99}
+            className="input-field"
+            value={value.doubleBonusThreshold}
+            onChange={e =>
+              onChange({
+                ...value,
+                doubleBonusThreshold: Math.max(1, Math.floor(Number(e.target.value) || 1)),
+              })
+            }
+          />
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm text-slate-700">
+        <input
+          type="checkbox"
+          checked={value.hasOneAndOne}
+          onChange={e => onChange({ ...value, hasOneAndOne: e.target.checked })}
+        />
+        1-and-1 before double bonus
+      </label>
+
+      <div>
+        <label className="block text-xs font-medium text-slate-600 mb-1">Overtime label</label>
+        <input
+          type="text"
+          className="input-field"
+          value={value.overtimeLabel}
+          onChange={e => onChange({ ...value, overtimeLabel: e.target.value || 'OT' })}
+        />
+      </div>
+
+      <label className="flex items-center gap-2 text-sm text-slate-700">
+        <input
+          type="checkbox"
+          checked={value.overtimeFoulsReset}
+          onChange={e => onChange({ ...value, overtimeFoulsReset: e.target.checked })}
+        />
+        Reset team fouls each overtime
+      </label>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="block text-xs font-medium text-slate-600 mb-1">Timeouts / period</label>
+          <input
+            type="number"
+            min={0}
+            className="input-field"
+            placeholder="Unlimited"
+            value={value.timeoutsPerPeriod ?? ''}
+            onChange={e => {
+              const raw = e.target.value
+              onChange({
+                ...value,
+                timeoutsPerPeriod: raw === '' ? null : Math.max(0, Math.floor(Number(raw))),
+              })
+            }}
+          />
+          <p className="text-[10px] text-slate-400 mt-0.5">Blank = no limit</p>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-slate-600 mb-1">Timeouts / OT</label>
+          <input
+            type="number"
+            min={0}
+            className="input-field"
+            placeholder="Same as reg."
+            value={value.timeoutsPerOvertime ?? ''}
+            onChange={e => {
+              const raw = e.target.value
+              onChange({
+                ...value,
+                timeoutsPerOvertime: raw === '' ? null : Math.max(0, Math.floor(Number(raw))),
+              })
+            }}
+          />
+          <p className="text-[10px] text-slate-400 mt-0.5">Blank = same as regulation</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/config/teamStatsDefaults.ts
+++ b/src/config/teamStatsDefaults.ts
@@ -151,3 +151,23 @@ export function resolveTeamStatsConfig(
         : base.timeoutsPerOvertime,
   }
 }
+
+/** Serialize resolved basketball team rules for `seasons.team_stats_config` (jsonb). */
+export function seasonTeamStatsConfigToJson(config: TeamStatsConfig): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    periodsPerGame: config.periodsPerGame,
+    periodLabels: config.periodLabels,
+    bonusThreshold: config.bonusThreshold,
+    doubleBonusThreshold: config.doubleBonusThreshold,
+    hasOneAndOne: config.hasOneAndOne,
+    overtimeLabel: config.overtimeLabel,
+    overtimeFoulsReset: config.overtimeFoulsReset,
+  }
+  if (config.timeoutsPerPeriod != null) {
+    out.timeoutsPerPeriod = config.timeoutsPerPeriod
+  }
+  if (config.timeoutsPerOvertime != null) {
+    out.timeoutsPerOvertime = config.timeoutsPerOvertime
+  }
+  return out
+}

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { sports } from '../config/sports'
+import type { BasketballTeamStatsConfig } from '../types'
+import {
+  BASKETBALL_TEAM_STATS_DEFAULTS,
+  resolveTeamStatsConfig,
+  seasonTeamStatsConfigToJson,
+} from '../config/teamStatsDefaults'
+import SeasonTeamStatsEditor from '../components/SeasonTeamStatsEditor'
 import { useSettings } from '../context/SettingsContext'
 import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
@@ -52,6 +59,12 @@ interface AdminSeasonRow {
   sport: string
   start_date: string | null
   end_date: string | null
+  team_stats_config?: unknown
+}
+
+function isMissingTeamStatsConfigColumnError(error: { message?: string } | null): boolean {
+  if (!error?.message) return false
+  return error.message.includes('team_stats_config') && error.message.includes('column')
 }
 
 interface MergeAuditListRow {
@@ -101,6 +114,12 @@ export default function Admin() {
   const [editSeasonStartDate, setEditSeasonStartDate] = useState('')
   const [editSeasonEndDate, setEditSeasonEndDate] = useState('')
   const [confirmDeleteSeason, setConfirmDeleteSeason] = useState<AdminSeasonRow | null>(null)
+  const [seasonsTeamStatsColumnMissing, setSeasonsTeamStatsColumnMissing] = useState(false)
+  const [teamStatsSeasonId, setTeamStatsSeasonId] = useState<string | null>(null)
+  const [teamStatsDraft, setTeamStatsDraft] = useState<BasketballTeamStatsConfig | null>(null)
+  const [savingTeamStatsId, setSavingTeamStatsId] = useState<string | null>(null)
+
+  const basketballSport = sports.find(s => s.id === 'basketball') ?? null
 
   const [showMergeTools, setShowMergeTools] = useState(false)
   const [mergeWizardOpen, setMergeWizardOpen] = useState(false)
@@ -270,13 +289,31 @@ export default function Admin() {
     if (!supabaseClient) return
     setLoadingSeasons(true)
     setSeasonsError(null)
-    const { data, error } = await supabaseClient
+    const withConfig = await supabaseClient
       .from('seasons')
-      .select('id,name,sport,start_date,end_date')
+      .select('id,name,sport,start_date,end_date,team_stats_config')
       .order('created_at', { ascending: false })
+    if (withConfig.error && isMissingTeamStatsConfigColumnError(withConfig.error)) {
+      setSeasonsTeamStatsColumnMissing(true)
+      const { data, error } = await supabaseClient
+        .from('seasons')
+        .select('id,name,sport,start_date,end_date')
+        .order('created_at', { ascending: false })
+      setLoadingSeasons(false)
+      if (error) {
+        setSeasonsError(error.message)
+        return
+      }
+      setSeasonsList((data ?? []) as AdminSeasonRow[])
+      return
+    }
     setLoadingSeasons(false)
-    if (error) { setSeasonsError(error.message); return }
-    setSeasonsList((data ?? []) as AdminSeasonRow[])
+    if (withConfig.error) {
+      setSeasonsError(withConfig.error.message)
+      return
+    }
+    setSeasonsTeamStatsColumnMissing(false)
+    setSeasonsList((withConfig.data ?? []) as AdminSeasonRow[])
   }
 
   useEffect(() => {
@@ -327,6 +364,45 @@ export default function Admin() {
     setDeletingId(null)
     if (error) { setSeasonsError(error.message); return }
     setSeasonsList(prev => prev.filter(s => s.id !== season.id))
+    if (teamStatsSeasonId === season.id) {
+      setTeamStatsSeasonId(null)
+      setTeamStatsDraft(null)
+    }
+  }
+
+  const openTeamStatsEditor = (season: AdminSeasonRow) => {
+    if (!basketballSport) return
+    const resolved = resolveTeamStatsConfig(basketballSport, season.team_stats_config)
+    setTeamStatsDraft(resolved ?? { ...BASKETBALL_TEAM_STATS_DEFAULTS })
+    setTeamStatsSeasonId(season.id)
+  }
+
+  const handleSaveTeamStatsConfig = async () => {
+    if (!supabaseClient || !teamStatsSeasonId || !teamStatsDraft) return
+    setSeasonsError(null)
+    setSavingTeamStatsId(teamStatsSeasonId)
+    const json = seasonTeamStatsConfigToJson(teamStatsDraft)
+    const { error } = await supabaseClient
+      .from('seasons')
+      .update({ team_stats_config: json })
+      .eq('id', teamStatsSeasonId)
+    setSavingTeamStatsId(null)
+    if (error) {
+      if (isMissingTeamStatsConfigColumnError(error)) {
+        setSeasonsError(
+          'Database is missing seasons.team_stats_config. Apply Supabase migration 030 (team stats schema).'
+        )
+      } else {
+        setSeasonsError(error.message)
+      }
+      return
+    }
+    if (gameState.cloudSync.seasonId === teamStatsSeasonId) {
+      gameDispatch({ type: 'SET_TEAM_STATS_CONFIG', config: json })
+    }
+    setTeamStatsSeasonId(null)
+    setTeamStatsDraft(null)
+    void loadSeasons()
   }
 
   return (
@@ -507,9 +583,18 @@ export default function Admin() {
                   <p className="text-sm text-slate-500 card">No seasons yet.</p>
                 ) : (
                   <div className="space-y-2">
+                    {seasonsTeamStatsColumnMissing && (
+                      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-2">
+                        Team stat rules need migration 030 (
+                        <code className="text-[10px]">seasons.team_stats_config</code>). Season list still
+                        loads without it.
+                      </p>
+                    )}
                     {seasonsList.map(season => {
                       const sportCfg = sports.find(s => s.id === season.sport)
                       const isEditing = editingSeasonId === season.id
+                      const isBasketballSeason = season.sport === 'basketball'
+                      const teamStatsOpen = teamStatsSeasonId === season.id && teamStatsDraft !== null
 
                       if (isEditing) {
                         return (
@@ -557,49 +642,154 @@ export default function Admin() {
                                 Cancel
                               </button>
                             </div>
+                            {isBasketballSeason && !seasonsTeamStatsColumnMissing && (
+                              <button
+                                type="button"
+                                onClick={() => openTeamStatsEditor(season)}
+                                className="btn-secondary w-full text-sm"
+                              >
+                                Team stat rules (basketball)…
+                              </button>
+                            )}
                           </div>
                         )
                       }
 
                       return (
-                        <div key={season.id} className="card flex items-center justify-between py-3">
-                          <div className="min-w-0">
-                            <div className="flex items-center gap-2">
-                              <span className="text-lg">{sportCfg?.icon ?? '🏟️'}</span>
-                              <span className="font-medium text-slate-700 truncate">{season.name}</span>
+                        <div key={season.id} className="space-y-2">
+                          <div className="card flex items-center justify-between py-3">
+                            <div className="min-w-0">
+                              <div className="flex items-center gap-2">
+                                <span className="text-lg">{sportCfg?.icon ?? '🏟️'}</span>
+                                <span className="font-medium text-slate-700 truncate">{season.name}</span>
+                              </div>
+                              <p className="text-xs text-slate-400 mt-0.5">
+                                {sportCfg?.name ?? season.sport}
+                                {(season.start_date || season.end_date) && ' · '}
+                                {season.start_date ?? ''}
+                                {season.start_date && season.end_date && ' → '}
+                                {season.end_date ?? ''}
+                              </p>
                             </div>
-                            <p className="text-xs text-slate-400 mt-0.5">
-                              {sportCfg?.name ?? season.sport}
-                              {(season.start_date || season.end_date) && ' · '}
-                              {season.start_date ?? ''}
-                              {season.start_date && season.end_date && ' → '}
-                              {season.end_date ?? ''}
-                            </p>
+                            <div className="flex items-center gap-1 shrink-0">
+                              {isBasketballSeason && !seasonsTeamStatsColumnMissing && (
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    if (teamStatsOpen) {
+                                      setTeamStatsSeasonId(null)
+                                      setTeamStatsDraft(null)
+                                    } else {
+                                      openTeamStatsEditor(season)
+                                    }
+                                  }}
+                                  className="text-slate-400 hover:text-blue-500 p-1 text-xs font-medium px-2"
+                                  title="Team stat rules"
+                                >
+                                  🏀
+                                </button>
+                              )}
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setEditingSeasonId(season.id)
+                                  setEditSeasonName(season.name)
+                                  setEditSeasonStartDate(season.start_date ?? '')
+                                  setEditSeasonEndDate(season.end_date ?? '')
+                                }}
+                                className="text-slate-400 hover:text-blue-500 p-1"
+                                title="Edit season"
+                              >
+                                ✏️
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setConfirmDeleteSeason(season)}
+                                disabled={deletingId === season.id}
+                                className="text-slate-400 hover:text-red-500 p-1"
+                                title="Delete season"
+                              >
+                                🗑️
+                              </button>
+                            </div>
                           </div>
-                          <div className="flex items-center gap-1 shrink-0">
-                            <button
-                              type="button"
-                              onClick={() => {
-                                setEditingSeasonId(season.id)
-                                setEditSeasonName(season.name)
-                                setEditSeasonStartDate(season.start_date ?? '')
-                                setEditSeasonEndDate(season.end_date ?? '')
-                              }}
-                              className="text-slate-400 hover:text-blue-500 p-1"
-                              title="Edit season"
-                            >
-                              ✏️
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => setConfirmDeleteSeason(season)}
-                              disabled={deletingId === season.id}
-                              className="text-slate-400 hover:text-red-500 p-1"
-                              title="Delete season"
-                            >
-                              🗑️
-                            </button>
-                          </div>
+                          {teamStatsOpen && (
+                            <div className="card space-y-3 border-blue-100 bg-slate-50/80">
+                              <div className="flex items-center justify-between gap-2">
+                                <h4 className="text-sm font-semibold text-slate-700">
+                                  Basketball team stat rules
+                                </h4>
+                                <button
+                                  type="button"
+                                  className="text-xs text-slate-500 underline"
+                                  onClick={() => {
+                                    setTeamStatsSeasonId(null)
+                                    setTeamStatsDraft(null)
+                                  }}
+                                >
+                                  Close
+                                </button>
+                              </div>
+                              <SeasonTeamStatsEditor value={teamStatsDraft} onChange={setTeamStatsDraft} />
+                              <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+                                <button
+                                  type="button"
+                                  className="btn-primary flex-1"
+                                  disabled={savingTeamStatsId === season.id}
+                                  onClick={() => void handleSaveTeamStatsConfig()}
+                                >
+                                  {savingTeamStatsId === season.id ? 'Saving…' : 'Save rules'}
+                                </button>
+                                <button
+                                  type="button"
+                                  className="btn-secondary flex-1"
+                                  onClick={() => setTeamStatsDraft({ ...BASKETBALL_TEAM_STATS_DEFAULTS })}
+                                >
+                                  Reset form to defaults
+                                </button>
+                                <button
+                                  type="button"
+                                  className="btn-secondary flex-1"
+                                  onClick={() => openTeamStatsEditor(season)}
+                                >
+                                  Revert to saved
+                                </button>
+                                <button
+                                  type="button"
+                                  className="btn-secondary flex-1 text-red-700 border-red-100"
+                                  disabled={savingTeamStatsId === season.id}
+                                  onClick={async () => {
+                                    if (!supabaseClient) return
+                                    setSeasonsError(null)
+                                    setSavingTeamStatsId(season.id)
+                                    const { error } = await supabaseClient
+                                      .from('seasons')
+                                      .update({ team_stats_config: {} })
+                                      .eq('id', season.id)
+                                    setSavingTeamStatsId(null)
+                                    if (error) {
+                                      if (isMissingTeamStatsConfigColumnError(error)) {
+                                        setSeasonsError(
+                                          'Missing seasons.team_stats_config column (migration 030).'
+                                        )
+                                      } else {
+                                        setSeasonsError(error.message)
+                                      }
+                                      return
+                                    }
+                                    if (gameState.cloudSync.seasonId === season.id) {
+                                      gameDispatch({ type: 'SET_TEAM_STATS_CONFIG', config: null })
+                                    }
+                                    setTeamStatsSeasonId(null)
+                                    setTeamStatsDraft(null)
+                                    void loadSeasons()
+                                  }}
+                                >
+                                  Clear saved rules
+                                </button>
+                              </div>
+                            </div>
+                          )}
                         </div>
                       )
                     })}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Settings → Seasons** UI to view and edit **basketball** team stat rules stored in `seasons.team_stats_config` (periods, labels, bonus thresholds, 1-and-1, OT options, timeout caps). Uses existing `BASKETBALL_PRESETS` and persists via new `seasonTeamStatsConfigToJson`.

## Details

- **`seasonTeamStatsConfigToJson`** in `teamStatsDefaults.ts` — serializes resolved config for Supabase jsonb (omits null timeout fields).
- **`SeasonTeamStatsEditor`** — preset dropdown, numeric fields, period labels, checkboxes.
- **`Admin.tsx`** — loads `team_stats_config` with fallback if column missing (warns about migration 030); basketball seasons get 🏀 / inline panel; **Save** updates DB and dispatches `SET_TEAM_STATS_CONFIG` when the edited season matches the active game; **Clear saved rules** writes `{}` and clears in-memory config for that season.

## Testing

`pnpm build`, `pnpm lint` (no new errors).

## Supabase

Requires `seasons.team_stats_config` (migration 030). UI degrades gracefully without it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

