### PR TITLE
WU-9: Config-driven period labels and bonus foul counts

### DIFF
--- a/src/components/team-stats/PeriodToggle.tsx
+++ b/src/components/team-stats/PeriodToggle.tsx
@@ -21,8 +21,9 @@ export default function PeriodToggle({
   sportTheme,
   addOvertimeLabel,
 }: PeriodToggleProps) {
+  const compact = periods >= 6
   return (
-    <div className="flex flex-wrap gap-2 items-center justify-center py-2">
+    <div className="flex flex-wrap gap-2 items-center justify-center py-2 max-w-full">
       {Array.from({ length: periods }, (_, i) => {
         const p = i + 1
         const label = periodLabels[i] ?? `Period ${p}`
@@ -33,8 +34,9 @@ export default function PeriodToggle({
             type="button"
             onClick={() => onPeriodChange(p)}
             className={`
-              rounded-lg px-3 py-2 text-xs font-semibold transition-all active:scale-95
+              rounded-lg font-semibold transition-all active:scale-95
               border
+              ${compact ? 'px-2 py-1.5 text-[10px] leading-tight' : 'px-3 py-2 text-xs'}
               ${active
                 ? `${sportTheme.bg} text-white border-transparent shadow-sm`
                 : 'bg-white text-slate-600 border-slate-200 hover:bg-slate-50'

--- a/src/config/sports.ts
+++ b/src/config/sports.ts
@@ -67,6 +67,7 @@ export const sports: SportConfig[] = [
       },
     ],
     teamKeyStatIds: ['team_foul', 'team_to_used', 'team_tech'],
+    teamFoulBaseStatId: 'team_foul',
     teamCategories: [
       {
         id: 'team_fouls',

--- a/src/lib/teamStatsPeriods.ts
+++ b/src/lib/teamStatsPeriods.ts
@@ -1,0 +1,58 @@
+import type { BasketballTeamStatsConfig } from '../types'
+import { getDefaultPeriodLabels } from '../config/teamStatsDefaults'
+
+export function periodScopedStatKey(baseId: string, periodIndex: number): string {
+  return `${baseId}_p${periodIndex}`
+}
+
+/**
+ * Foul count that drives the bonus banner for the current segment.
+ * Regulation: fouls in that period only.
+ * OT with reset: fouls in that OT only.
+ * OT without reset: cumulative team fouls from OT1 through the current OT.
+ */
+export function getBonusFoulCountForPeriod(
+  stats: Record<string, number>,
+  baseId: string,
+  currentPeriod: number,
+  rules: BasketballTeamStatsConfig
+): number {
+  if (currentPeriod <= 0) return 0
+  if (currentPeriod <= rules.periodsPerGame) {
+    return stats[periodScopedStatKey(baseId, currentPeriod)] ?? 0
+  }
+  if (!rules.overtimeFoulsReset) {
+    let sum = 0
+    for (let p = rules.periodsPerGame + 1; p <= currentPeriod; p++) {
+      sum += stats[periodScopedStatKey(baseId, p)] ?? 0
+    }
+    return sum
+  }
+  return stats[periodScopedStatKey(baseId, currentPeriod)] ?? 0
+}
+
+/**
+ * Labels for each selectable period segment (regulation from config, OT uses overtimeLabel).
+ */
+export function buildPeriodSegmentLabels(
+  rules: BasketballTeamStatsConfig,
+  periodButtonCount: number
+): string[] {
+  const reg = Math.max(1, rules.periodsPerGame)
+  const defaults = getDefaultPeriodLabels(reg)
+  const stored = rules.periodLabels
+  const ot = rules.overtimeLabel.trim() || 'OT'
+  const out: string[] = []
+
+  for (let i = 0; i < periodButtonCount; i++) {
+    const p = i + 1
+    if (p <= reg) {
+      const label = stored[i] ?? defaults[i] ?? `Period ${p}`
+      out.push(label)
+    } else {
+      const otIndex = p - reg
+      out.push(otIndex === 1 ? ot : `${ot} ${otIndex}`)
+    }
+  }
+  return out
+}

--- a/src/pages/GameTracker.tsx
+++ b/src/pages/GameTracker.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useGame } from '../context/GameContext'
 import { computeCategoryTotal } from '../config/sports'
 import { resolveTeamStatsConfig } from '../config/teamStatsDefaults'
+import { buildPeriodSegmentLabels, getBonusFoulCountForPeriod } from '../lib/teamStatsPeriods'
 import type { BasketballTeamStatsConfig, Player, StatAction, StatCategory } from '../types'
 import Scoreboard from '../components/Scoreboard'
 import StatButton from '../components/StatButton'
@@ -102,19 +103,10 @@ export default function GameTracker() {
     }
   }, [currentPeriod, periodButtonCount])
 
-  const periodSegmentLabels = useMemo(() => {
-    const labels = teamRules?.periodLabels ?? []
-    const ot = teamRules?.overtimeLabel ?? 'OT'
-    const out: string[] = []
-    for (let i = 0; i < periodButtonCount; i++) {
-      if (i < labels.length) {
-        out.push(labels[i]!)
-      } else {
-        out.push(ot)
-      }
-    }
-    return out
-  }, [periodButtonCount, teamRules])
+  const periodSegmentLabels = useMemo(
+    () => (teamRules ? buildPeriodSegmentLabels(teamRules, periodButtonCount) : []),
+    [periodButtonCount, teamRules]
+  )
 
   const addOvertimeLabel = useMemo(() => {
     const ot = teamRules?.overtimeLabel ?? 'OT'
@@ -186,13 +178,14 @@ export default function GameTracker() {
 
   const gridCategories = showTeamStatGrid ? sport.teamCategories! : sport.categories
 
+  const foulBaseForBonus = sport.teamFoulBaseStatId ?? null
   const teamFoulCountThisPeriod =
-    showTeamStatGrid && sport.id === 'basketball' && teamRules
-      ? activePlayer.stats[`team_foul_p${currentPeriod}`] ?? 0
+    showTeamStatGrid && foulBaseForBonus && teamRules
+      ? getBonusFoulCountForPeriod(activePlayer.stats, foulBaseForBonus, currentPeriod, teamRules)
       : 0
 
   const showBonusBanner =
-    showTeamStatGrid && sport.id === 'basketball' && teamRules !== null
+    showTeamStatGrid && Boolean(foulBaseForBonus) && teamRules !== null
 
   const handleUndo = () => {
     dispatch({ type: 'UNDO' })

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,11 @@ export interface SportConfig {
   keyStatIds?: string[]
   /** Compact keys when summarizing team-level stats. */
   teamKeyStatIds?: string[]
+  /**
+   * Base stat id for period-scoped team fouls (suffix `_pN` in tracker). Used for bonus banner counts.
+   * Basketball sets `team_foul`.
+   */
+  teamFoulBaseStatId?: string
 }
 
 export interface GameInfo {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes **WU-9** integration polish: period toggle labels and bonus foul counts now follow resolved season config (`resolveTeamStatsConfig`), including **`overtimeFoulsReset`** behavior from the design docs.

## Changes

- **`src/lib/teamStatsPeriods.ts`** (new)
  - `buildPeriodSegmentLabels` — regulation labels from `periodLabels` with fallback to `getDefaultPeriodLabels`; OT segments use `overtimeLabel` and `OT 2`, `OT 3`, … when multiple.
  - `getBonusFoulCountForPeriod` — regulation: fouls in current period only; OT with reset: current OT only; OT without reset: cumulative fouls across OT periods.
- **`SportConfig.teamFoulBaseStatId`** — basketball sets `team_foul`; `GameTracker` uses it for the bonus banner instead of hardcoding `sport.id === 'basketball'`.
- **`PeriodToggle`** — slightly smaller buttons when `periods >= 6` so 4Q + multiple OT fits better on mobile.

## Testing

`pnpm build`, `pnpm lint` (no new issues).

## Manual checks

- NBA preset: Q1–Q4, 5th foul → BONUS (no 1-and-1).
- NFHS: halves labels, 7th → 1-and-1, 10th → double bonus.
- Toggle **Reset team fouls each overtime** off → OT bonus uses cumulative OT fouls.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

