### PR TITLE
WU-11: Checkout UI and setup for team stat pseudo-players

### DIFF
--- a/src/pages/GameCheckout.tsx
+++ b/src/pages/GameCheckout.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useLayoutEffect, useState, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGame } from '../context/GameContext'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
+import { isTeamPseudoPlayer, TEAM_PLAYER_HOME_ID, TEAM_PLAYER_OPP_ID } from '../lib/teamPlayers'
 
 interface CheckoutRow {
   player_id: string
@@ -12,7 +13,7 @@ interface CheckoutRow {
 
 export default function GameCheckout() {
   const navigate = useNavigate()
-  const { state, flushCloudSync } = useGame()
+  const { state, dispatch, flushCloudSync } = useGame()
   const { user, isConfigured } = useAuth()
   const gameId = state.cloudSync.gameId
   const playerIdMap = state.cloudSync.playerIdMap
@@ -25,6 +26,39 @@ export default function GameCheckout() {
   const [toggling, setToggling] = useState<string | null>(null)
 
   const myId = user?.id ?? null
+
+  const teamCheckoutPlayers = players.filter(isTeamPseudoPlayer)
+  const rosterCheckoutPlayers = players.filter(p => !isTeamPseudoPlayer(p))
+
+  useLayoutEffect(() => {
+    if (!sport?.teamCategories?.length || !gameInfo) return
+    const hasHome = players.some(p => p.id === TEAM_PLAYER_HOME_ID)
+    const hasOpp = players.some(p => p.id === TEAM_PLAYER_OPP_ID)
+    if (hasHome && hasOpp) return
+    const homeTeamPlayer = {
+      id: TEAM_PLAYER_HOME_ID,
+      name: gameInfo.teamName,
+      number: '★',
+      stats: {},
+      isTeamPlayer: true as const,
+      teamSide: 'home' as const,
+    }
+    const oppTeamPlayer = {
+      id: TEAM_PLAYER_OPP_ID,
+      name: gameInfo.opponentName,
+      number: '★',
+      stats: {},
+      isTeamPlayer: true as const,
+      teamSide: 'opponent' as const,
+    }
+    const without = players.filter(
+      p => p.id !== TEAM_PLAYER_HOME_ID && p.id !== TEAM_PLAYER_OPP_ID
+    )
+    dispatch({
+      type: 'SET_PLAYERS',
+      players: [homeTeamPlayer, oppTeamPlayer, ...without],
+    })
+  }, [sport, gameInfo, players, dispatch])
 
   // If we have no gameId yet (first time), trigger sync so game is created
   useEffect(() => {
@@ -177,7 +211,67 @@ export default function GameCheckout() {
           <div className="card text-slate-500 animate-pulse">Loading...</div>
         ) : (
           <div className="space-y-2 mb-6">
-            {players.map(player => {
+            {teamCheckoutPlayers.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide px-0.5">
+                  Team stats
+                </p>
+                {teamCheckoutPlayers.map(player => {
+                  const remoteId = playerIdMap[player.id] ?? player.id
+                  const mine = isCheckedOutByMe(remoteId)
+                  const other = claimedByOther(remoteId)
+
+                  return (
+                    <button
+                      key={player.id}
+                      type="button"
+                      onClick={() => { void handleToggle(player.id) }}
+                      disabled={toggling === player.id}
+                      className={`card w-full flex items-center justify-between py-3 text-left transition-colors
+                        border-2 border-dashed border-slate-300/90
+                        bg-gradient-to-br from-slate-50 to-slate-100/70
+                        ${mine ? 'ring-2 ring-blue-400 bg-blue-50/80' : 'hover:from-slate-100 hover:to-slate-100'}`}
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        <span
+                          className="shrink-0 w-10 h-10 rounded-full border-2 border-dashed border-slate-400
+                                     bg-white text-slate-600 flex items-center justify-center text-lg leading-none"
+                          aria-hidden
+                        >
+                          ★
+                        </span>
+                        <div className="min-w-0">
+                          <p className="font-medium text-slate-800 truncate">
+                            {player.name}
+                            <span className="font-normal text-slate-500"> (Team Stats)</span>
+                          </p>
+                          {other && (
+                            <p className="text-xs text-slate-500">Primary: {other}</p>
+                          )}
+                        </div>
+                      </div>
+                      <span className="text-2xl shrink-0">{mine ? '✓' : '○'}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+
+            {teamCheckoutPlayers.length > 0 && rosterCheckoutPlayers.length > 0 && (
+              <div
+                className="flex items-center gap-3 py-2"
+                role="separator"
+                aria-label="Roster players"
+              >
+                <div className="h-px flex-1 bg-slate-200" />
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+                  Roster
+                </span>
+                <div className="h-px flex-1 bg-slate-200" />
+              </div>
+            )}
+
+            {rosterCheckoutPlayers.map(player => {
               const remoteId = playerIdMap[player.id] ?? player.id
               const mine = isCheckedOutByMe(remoteId)
               const other = claimedByOther(remoteId)

--- a/src/pages/PlayerSetup.tsx
+++ b/src/pages/PlayerSetup.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useGame } from '../context/GameContext'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
+import { TEAM_PLAYER_HOME_ID, TEAM_PLAYER_OPP_ID } from '../lib/teamPlayers'
 
 function generateLocalId(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 7)
@@ -35,9 +36,43 @@ export default function PlayerSetup() {
   const [saving, setSaving] = useState(false)
   const cloudRosterLoadedRef = useRef(false)
 
+  /** Team pseudo-players for checkout + tracker when the sport defines team categories. */
+  useEffect(() => {
+    if (!sport?.teamCategories?.length || !state.gameInfo) return
+    const hasHome = state.players.some(p => p.id === TEAM_PLAYER_HOME_ID)
+    const hasOpp = state.players.some(p => p.id === TEAM_PLAYER_OPP_ID)
+    if (hasHome && hasOpp) return
+    const homeTeamPlayer = {
+      id: TEAM_PLAYER_HOME_ID,
+      name: state.gameInfo.teamName,
+      number: '★',
+      stats: {},
+      isTeamPlayer: true as const,
+      teamSide: 'home' as const,
+    }
+    const oppTeamPlayer = {
+      id: TEAM_PLAYER_OPP_ID,
+      name: state.gameInfo.opponentName,
+      number: '★',
+      stats: {},
+      isTeamPlayer: true as const,
+      teamSide: 'opponent' as const,
+    }
+    const without = state.players.filter(
+      p => p.id !== TEAM_PLAYER_HOME_ID && p.id !== TEAM_PLAYER_OPP_ID
+    )
+    dispatch({
+      type: 'SET_PLAYERS',
+      players: [homeTeamPlayer, oppTeamPlayer, ...without],
+    })
+  }, [sport, state.gameInfo, state.players, dispatch])
+
   useEffect(() => {
     if (!isCloudRoster || !cloudTeamId || cloudRosterLoadedRef.current) return
-    if (state.players.length > 0) {
+    const hasRosterRows = state.players.some(
+      p => p.id !== TEAM_PLAYER_HOME_ID && p.id !== TEAM_PLAYER_OPP_ID
+    )
+    if (hasRosterRows) {
       cloudRosterLoadedRef.current = true
       setRosterLoading(false)
       return
@@ -62,12 +97,38 @@ export default function PlayerSetup() {
       }
 
       type RosterRow = { player_id: string; jersey_number: string | null; players: { id: string; first_name: string; last_name: string | null } }
-      const loadedPlayers = ((data ?? []) as unknown as RosterRow[]).map(row => ({
+      let loadedPlayers = ((data ?? []) as unknown as RosterRow[]).map(row => ({
         id: row.player_id,
         name: `${row.players.first_name ?? ''} ${row.players.last_name ?? ''}`.trim(),
         number: row.jersey_number ?? '',
         stats: {},
       }))
+
+      if (sport?.teamCategories?.length && state.gameInfo) {
+        const homeTeamPlayer = {
+          id: TEAM_PLAYER_HOME_ID,
+          name: state.gameInfo.teamName,
+          number: '★',
+          stats: {},
+          isTeamPlayer: true as const,
+          teamSide: 'home' as const,
+        }
+        const oppTeamPlayer = {
+          id: TEAM_PLAYER_OPP_ID,
+          name: state.gameInfo.opponentName,
+          number: '★',
+          stats: {},
+          isTeamPlayer: true as const,
+          teamSide: 'opponent' as const,
+        }
+        loadedPlayers = [
+          homeTeamPlayer,
+          oppTeamPlayer,
+          ...loadedPlayers.filter(
+            p => p.id !== TEAM_PLAYER_HOME_ID && p.id !== TEAM_PLAYER_OPP_ID
+          ),
+        ]
+      }
 
       const idMap = loadedPlayers.reduce<Record<string, string>>((map, player) => {
         map[player.id] = player.id
@@ -94,7 +155,16 @@ export default function PlayerSetup() {
     return () => {
       cancelled = true
     }
-  }, [cloudTeamId, dispatch, isCloudRoster, state.activePlayerId, state.players.length])
+    // Intentionally omit state.players: we only need initial cloud roster fetch when list is empty of roster rows.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- see above
+  }, [
+    cloudTeamId,
+    dispatch,
+    isCloudRoster,
+    sport?.teamCategories?.length,
+    state.activePlayerId,
+    state.gameInfo,
+  ])
 
   const handleAddPlayer = async () => {
     if (!name.trim()) return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**WU-11** checkout screen now separates **team stat** pseudo-players from roster players with distinct styling and a divider. Team rows use the same `player_checkouts` toggle as individuals.

## GameCheckout

- `isTeamPseudoPlayer` splits the list: **Team stats** block (dashed border, gradient, ★ circle, name + `(Team Stats)`), then **Roster** separator, then normal jersey circles.
- `useLayoutEffect` prepends `__team_home__` / `__team_opp__` when missing so the first paint includes them (basketball / any sport with `teamCategories`).

## PlayerSetup (supporting)

- Injects the same two placeholders for sports with `teamCategories` so checkout is never roster-only.
- Cloud roster load no longer bails when `players.length > 0` if that length is only placeholders—fetch still runs so real roster rows load.

## Testing

`pnpm build`, `pnpm lint` (no new errors).

## Manual check

Cloud team → add players → Continue → checkout: see home + opponent team rows on top, divider, roster below; toggles insert/delete `player_checkouts` for mapped cloud placeholder ids after first sync.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

