### PR TITLE
WU-12: Game Summary team stats (fouls, bonus events, other)

### DIFF
--- a/src/components/team-stats/TeamStatSummary.tsx
+++ b/src/components/team-stats/TeamStatSummary.tsx
@@ -1,0 +1,196 @@
+import type { Player, SportConfig, TeamStatsConfig } from '../../types'
+import {
+  deriveBonusEvents,
+  foulCountForPeriod,
+  hasTrackedTeamSide,
+  maxTeamStatPeriodIndex,
+  teamStatActionRows,
+  valueForTeamAction,
+} from '../../lib/teamStatsSummary'
+
+export interface TeamStatSummaryProps {
+  homeTeamPlayer: Player | undefined
+  oppTeamPlayer: Player | undefined
+  homeTeamName: string
+  oppTeamName: string
+  config: TeamStatsConfig
+  sport: SportConfig
+  foulBaseStatId: string
+}
+
+export default function TeamStatSummary({
+  homeTeamPlayer,
+  oppTeamPlayer,
+  homeTeamName,
+  oppTeamName,
+  config,
+  sport,
+  foulBaseStatId,
+}: TeamStatSummaryProps) {
+  const homeStats = homeTeamPlayer?.stats ?? {}
+  const oppStats = oppTeamPlayer?.stats ?? {}
+
+  const homeTracked = hasTrackedTeamSide(homeStats, sport)
+  const oppTracked = hasTrackedTeamSide(oppStats, sport)
+
+  const periodCount = maxTeamStatPeriodIndex(homeStats, oppStats, foulBaseStatId)
+  const periodLabels: string[] = []
+  for (let p = 1; p <= periodCount; p++) {
+    if (p <= config.periodsPerGame) {
+      periodLabels.push(config.periodLabels[p - 1] ?? `Period ${p}`)
+    } else {
+      const otIndex = p - config.periodsPerGame
+      const ot = config.overtimeLabel.trim() || 'OT'
+      periodLabels.push(otIndex === 1 ? ot : `${ot} ${otIndex}`)
+    }
+  }
+
+  const homeBonus = deriveBonusEvents(homeStats, config, foulBaseStatId, periodCount, homeTeamName)
+  const oppBonus = deriveBonusEvents(oppStats, config, foulBaseStatId, periodCount, oppTeamName)
+  const allBonus = [...homeBonus, ...oppBonus].sort((a, b) => {
+    if (a.periodIndex !== b.periodIndex) return a.periodIndex - b.periodIndex
+    return a.teamLabel.localeCompare(b.teamLabel)
+  })
+
+  const otherActions = teamStatActionRows(sport).filter(a => a.id !== foulBaseStatId)
+
+  const bonusEventLabel = (e: (typeof allBonus)[0]): string => {
+    if (e.type === 'one_and_one') {
+      return `${e.teamLabel}: 1-and-1 in ${e.periodLabel} (${e.foulCount}${ordinal(e.foulCount)} foul)`
+    }
+    if (e.type === 'bonus_nba') {
+      return `${e.teamLabel}: Bonus in ${e.periodLabel} (${e.foulCount}${ordinal(e.foulCount)} foul)`
+    }
+    return `${e.teamLabel}: Double bonus in ${e.periodLabel} (${e.foulCount}${ordinal(e.foulCount)} foul)`
+  }
+
+  const homeFoulTotal = Array.from({ length: periodCount }, (_, i) =>
+    foulCountForPeriod(homeStats, foulBaseStatId, i + 1)
+  ).reduce((a, b) => a + b, 0)
+  const oppFoulTotal = Array.from({ length: periodCount }, (_, i) =>
+    foulCountForPeriod(oppStats, foulBaseStatId, i + 1)
+  ).reduce((a, b) => a + b, 0)
+
+  return (
+    <div className="space-y-6">
+      <div className="card border-slate-200">
+        <h3 className="text-sm font-semibold text-slate-600 mb-3">Team fouls by period</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200">
+                <th className="text-left py-2 pr-3 font-semibold text-slate-600">Period</th>
+                <th className="text-center py-2 px-2 font-semibold text-slate-600">{homeTeamName}</th>
+                <th className="text-center py-2 px-2 font-semibold text-slate-600">{oppTeamName}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: periodCount }, (_, i) => {
+                const p = i + 1
+                const h = foulCountForPeriod(homeStats, foulBaseStatId, p)
+                const o = foulCountForPeriod(oppStats, foulBaseStatId, p)
+                return (
+                  <tr key={p} className="border-b border-slate-100">
+                    <td className="py-2 pr-3 text-slate-700">{periodLabels[i] ?? `Period ${p}`}</td>
+                    <td className="text-center py-2 px-2 tabular-nums">
+                      {homeTracked ? h : <span className="text-slate-400 italic">—</span>}
+                    </td>
+                    <td className="text-center py-2 px-2 tabular-nums">
+                      {oppTracked ? o : <span className="text-slate-400 italic">—</span>}
+                    </td>
+                  </tr>
+                )
+              })}
+              <tr className="bg-slate-50 font-semibold">
+                <td className="py-2 pr-3">Total</td>
+                <td className="text-center py-2 px-2 tabular-nums">
+                  {homeTracked ? (
+                    homeFoulTotal
+                  ) : (
+                    <span className="text-slate-400 italic font-normal">Not tracked</span>
+                  )}
+                </td>
+                <td className="text-center py-2 px-2 tabular-nums">
+                  {oppTracked ? (
+                    oppFoulTotal
+                  ) : (
+                    <span className="text-slate-400 italic font-normal">Not tracked</span>
+                  )}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {allBonus.length > 0 && (
+        <div className="card border-slate-200">
+          <h3 className="text-sm font-semibold text-slate-600 mb-2">Bonus events</h3>
+          <p className="text-xs text-slate-500 mb-2">Derived from foul counts and season rules.</p>
+          <ul className="list-disc list-inside text-sm text-slate-700 space-y-1">
+            {allBonus.map((e, idx) => (
+              <li key={`${e.teamLabel}-${e.periodIndex}-${e.type}-${idx}`}>{bonusEventLabel(e)}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {otherActions.length > 0 && (
+        <div className="card border-slate-200">
+          <h3 className="text-sm font-semibold text-slate-600 mb-3">Timeouts / other</h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200">
+                  <th className="text-left py-2 pr-3 font-semibold text-slate-600">Stat</th>
+                  <th className="text-center py-2 px-2 font-semibold text-slate-600">{homeTeamName}</th>
+                  <th className="text-center py-2 px-2 font-semibold text-slate-600">{oppTeamName}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {otherActions.map(action => {
+                  const hv = valueForTeamAction(homeStats, action)
+                  const ov = valueForTeamAction(oppStats, action)
+                  return (
+                    <tr key={action.id} className="border-b border-slate-100">
+                      <td className="py-2 pr-3">{action.shortLabel}</td>
+                      <td className="text-center py-2 px-2 tabular-nums">
+                        {homeTracked ? (
+                          hv
+                        ) : (
+                          <span className="text-slate-400 italic">Not tracked</span>
+                        )}
+                      </td>
+                      <td className="text-center py-2 px-2 tabular-nums">
+                        {oppTracked ? (
+                          ov
+                        ) : (
+                          <span className="text-slate-400 italic">Not tracked</span>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ordinal(n: number): string {
+  const v = n % 100
+  if (v >= 11 && v <= 13) return 'th'
+  switch (n % 10) {
+    case 1:
+      return 'st'
+    case 2:
+      return 'nd'
+    case 3:
+      return 'rd'
+    default:
+      return 'th'
+  }
+}

--- a/src/lib/teamStatsSummary.ts
+++ b/src/lib/teamStatsSummary.ts
@@ -1,0 +1,123 @@
+import type { BasketballTeamStatsConfig, SportConfig, StatAction } from '../types'
+import { buildPeriodSegmentLabels, periodScopedStatKey } from './teamStatsPeriods'
+
+export type TeamBonusEventType = 'one_and_one' | 'double_bonus' | 'bonus_nba'
+
+export interface TeamBonusEvent {
+  periodIndex: number
+  periodLabel: string
+  type: TeamBonusEventType
+  foulCount: number
+  teamLabel: string
+}
+
+function maxPeriodIndexForBase(stats: Record<string, number>, baseId: string): number {
+  const re = new RegExp(`^${baseId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}_p(\\d+)$`)
+  let max = 0
+  for (const key of Object.keys(stats)) {
+    const m = key.match(re)
+    if (m) max = Math.max(max, parseInt(m[1]!, 10))
+  }
+  return max
+}
+
+export function maxTeamStatPeriodIndex(
+  homeStats: Record<string, number>,
+  oppStats: Record<string, number>,
+  foulBaseId: string
+): number {
+  return Math.max(
+    maxPeriodIndexForBase(homeStats, foulBaseId),
+    maxPeriodIndexForBase(oppStats, foulBaseId),
+    1
+  )
+}
+
+export function foulCountForPeriod(
+  stats: Record<string, number>,
+  foulBaseId: string,
+  periodIndex: number
+): number {
+  return stats[periodScopedStatKey(foulBaseId, periodIndex)] ?? 0
+}
+
+/**
+ * Derive bonus milestone events per period (design: DESIGN_TEAM_STATS_BASKETBALL §6.3).
+ */
+export function deriveBonusEvents(
+  stats: Record<string, number>,
+  config: BasketballTeamStatsConfig,
+  foulBaseId: string,
+  periodCount: number,
+  teamLabel: string
+): TeamBonusEvent[] {
+  const events: TeamBonusEvent[] = []
+  const labels = buildPeriodSegmentLabels(config, Math.max(periodCount, config.periodsPerGame))
+
+  for (let p = 1; p <= periodCount; p++) {
+    const fouls = foulCountForPeriod(stats, foulBaseId, p)
+    const periodLabel = labels[p - 1] ?? `Period ${p}`
+
+    if (config.hasOneAndOne && fouls >= config.bonusThreshold) {
+      events.push({
+        periodIndex: p,
+        periodLabel,
+        type: 'one_and_one',
+        foulCount: config.bonusThreshold,
+        teamLabel,
+      })
+    }
+    if (!config.hasOneAndOne && fouls >= config.bonusThreshold) {
+      events.push({
+        periodIndex: p,
+        periodLabel,
+        type: 'bonus_nba',
+        foulCount: config.bonusThreshold,
+        teamLabel,
+      })
+    }
+    if (fouls >= config.doubleBonusThreshold) {
+      events.push({
+        periodIndex: p,
+        periodLabel,
+        type: 'double_bonus',
+        foulCount: config.doubleBonusThreshold,
+        teamLabel,
+      })
+    }
+  }
+  return events
+}
+
+export function sumPeriodScopedStat(stats: Record<string, number>, baseId: string): number {
+  let sum = 0
+  const prefix = `${baseId}_p`
+  for (const [k, v] of Object.entries(stats)) {
+    if (k.startsWith(prefix)) sum += v
+  }
+  return sum
+}
+
+export function valueForTeamAction(stats: Record<string, number>, action: StatAction): number {
+  if (action.periodScoped) {
+    return sumPeriodScopedStat(stats, action.id)
+  }
+  return stats[action.id] ?? 0
+}
+
+export function hasTrackedTeamSide(stats: Record<string, number>, sport: SportConfig): boolean {
+  const bases =
+    sport.teamCategories?.flatMap(c => c.actions.filter(a => !a.madeStatId).map(a => a.id)) ?? []
+  if (bases.length === 0) return false
+  const baseSet = new Set(bases)
+  for (const [k, v] of Object.entries(stats)) {
+    if (v <= 0) continue
+    const base = k.replace(/_p\d+$/, '')
+    if (baseSet.has(base)) return true
+  }
+  return false
+}
+
+export function teamStatActionRows(sport: SportConfig): StatAction[] {
+  return sport.teamCategories?.flatMap(c => c.actions.filter(a => !a.madeStatId)) ?? []
+}

--- a/src/pages/GameSummary.tsx
+++ b/src/pages/GameSummary.tsx
@@ -3,7 +3,10 @@ import { useNavigate } from 'react-router-dom'
 import { useGame, GAME_STORAGE_KEY } from '../context/GameContext'
 import { computeCategoryTotal } from '../config/sports'
 import { getDisplayedHomeScore } from '../lib/gameScore'
-import { isTeamPseudoPlayer } from '../lib/teamPlayers'
+import { isTeamPseudoPlayer, TEAM_PLAYER_HOME_ID, TEAM_PLAYER_OPP_ID } from '../lib/teamPlayers'
+import { resolveTeamStatsConfig } from '../config/teamStatsDefaults'
+import { hasTrackedTeamSide } from '../lib/teamStatsSummary'
+import TeamStatSummary from '../components/team-stats/TeamStatSummary'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
 
@@ -48,8 +51,12 @@ export default function GameSummary() {
   const [savingCorrection, setSavingCorrection] = useState(false)
   const [resolvedKey, setResolvedKey] = useState(0)
   const [viewMode, setViewMode] = useState<'primary' | 'all'>('primary')
-  /** Players vs Team layout for stat tables (design: Game Summary split). */
-  const [summaryTab, setSummaryTab] = useState<'players' | 'team'>('players')
+  /** Players vs scores vs team-level stat summary (fouls, timeouts). */
+  const [summaryTab, setSummaryTab] = useState<'players' | 'team' | 'team_stats'>('players')
+  /** Final games: overlay from get_game_team_stats (resolved placeholder stats). */
+  const [teamTrackedStatsByRemoteId, setTeamTrackedStatsByRemoteId] = useState<
+    Record<string, Record<string, number>> | null
+  >(null)
   const [allSubmissions, setAllSubmissions] = useState<AllSubmissionsMap | null>(null)
   const [checkoutsByPlayer, setCheckoutsByPlayer] = useState<CheckoutsByPlayerMap | null>(null)
   const [settingPrimaryFor, setSettingPrimaryFor] = useState<string | null>(null)
@@ -64,6 +71,156 @@ export default function GameSummary() {
     () => players.filter(p => !isTeamPseudoPlayer(p)),
     [players]
   )
+
+  const homeTeamPseudo = useMemo(
+    () =>
+      players.find(
+        p => p.id === TEAM_PLAYER_HOME_ID || (p.isTeamPlayer && p.teamSide === 'home')
+      ),
+    [players]
+  )
+  const oppTeamPseudo = useMemo(
+    () =>
+      players.find(
+        p => p.id === TEAM_PLAYER_OPP_ID || (p.isTeamPlayer && p.teamSide === 'opponent')
+      ),
+    [players]
+  )
+
+  const teamStatHomeStats = useMemo(() => {
+    const local = homeTeamPseudo?.stats ?? {}
+    const remote = playerIdMap[TEAM_PLAYER_HOME_ID]
+    if (isFinalCloudGame && remote && teamTrackedStatsByRemoteId?.[remote]) {
+      return teamTrackedStatsByRemoteId[remote]
+    }
+    if (isFinalCloudGame && remote && resolvedStats?.[remote]) {
+      return Object.fromEntries(
+        Object.entries(resolvedStats[remote]).map(([k, e]) => [k, e.value])
+      )
+    }
+    return local
+  }, [
+    homeTeamPseudo?.stats,
+    isFinalCloudGame,
+    playerIdMap,
+    resolvedStats,
+    teamTrackedStatsByRemoteId,
+  ])
+
+  const teamStatOppStats = useMemo(() => {
+    const local = oppTeamPseudo?.stats ?? {}
+    const remote = playerIdMap[TEAM_PLAYER_OPP_ID]
+    if (isFinalCloudGame && remote && teamTrackedStatsByRemoteId?.[remote]) {
+      return teamTrackedStatsByRemoteId[remote]
+    }
+    if (isFinalCloudGame && remote && resolvedStats?.[remote]) {
+      return Object.fromEntries(
+        Object.entries(resolvedStats[remote]).map(([k, e]) => [k, e.value])
+      )
+    }
+    return local
+  }, [
+    oppTeamPseudo?.stats,
+    isFinalCloudGame,
+    playerIdMap,
+    resolvedStats,
+    teamTrackedStatsByRemoteId,
+  ])
+
+  const showTeamStatsTab = Boolean(
+    sport?.teamCategories?.length &&
+      (hasTrackedTeamSide(teamStatHomeStats, sport) || hasTrackedTeamSide(teamStatOppStats, sport))
+  )
+
+  useEffect(() => {
+    if (!showTeamStatsTab && summaryTab === 'team_stats') {
+      setSummaryTab('players')
+    }
+  }, [showTeamStatsTab, summaryTab])
+
+  const teamStatsSummaryEl = useMemo(() => {
+    if (!sport || !gameInfo || !showTeamStatsTab || summaryTab !== 'team_stats') return null
+    const foulBase = sport.teamFoulBaseStatId
+    if (!foulBase) return null
+    const cfg = resolveTeamStatsConfig(sport, state.teamStatsConfig)
+    if (!cfg) return null
+    const homeP =
+      homeTeamPseudo != null
+        ? { ...homeTeamPseudo, stats: teamStatHomeStats }
+        : {
+            id: TEAM_PLAYER_HOME_ID,
+            name: gameInfo.teamName,
+            number: '★',
+            stats: teamStatHomeStats,
+            isTeamPlayer: true as const,
+            teamSide: 'home' as const,
+          }
+    const oppP =
+      oppTeamPseudo != null
+        ? { ...oppTeamPseudo, stats: teamStatOppStats }
+        : {
+            id: TEAM_PLAYER_OPP_ID,
+            name: gameInfo.opponentName,
+            number: '★',
+            stats: teamStatOppStats,
+            isTeamPlayer: true as const,
+            teamSide: 'opponent' as const,
+          }
+    return (
+      <TeamStatSummary
+        homeTeamPlayer={homeP}
+        oppTeamPlayer={oppP}
+        homeTeamName={gameInfo.teamName}
+        oppTeamName={gameInfo.opponentName}
+        config={cfg}
+        sport={sport}
+        foulBaseStatId={foulBase}
+      />
+    )
+  }, [
+    sport,
+    gameInfo,
+    showTeamStatsTab,
+    summaryTab,
+    state.teamStatsConfig,
+    homeTeamPseudo,
+    oppTeamPseudo,
+    teamStatHomeStats,
+    teamStatOppStats,
+  ])
+
+  useEffect(() => {
+    const client = supabase
+    if (!isFinalCloudGame || !gameId || !client) {
+      setTeamTrackedStatsByRemoteId(null)
+      return
+    }
+    let cancelled = false
+    const load = async () => {
+      const { data, error } = await client.rpc('get_game_team_stats', {
+        p_game_id: gameId,
+      })
+      if (cancelled) return
+      if (error) {
+        setTeamTrackedStatsByRemoteId(null)
+        return
+      }
+      const byPlayer: Record<string, Record<string, number>> = {}
+      for (const row of (data ?? []) as Array<{
+        player_id: string
+        stat_id: string
+        value: number
+      }>) {
+        if (!byPlayer[row.player_id]) byPlayer[row.player_id] = {}
+        byPlayer[row.player_id][row.stat_id] = row.value
+      }
+      setTeamTrackedStatsByRemoteId(byPlayer)
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [isFinalCloudGame, gameId, resolvedKey])
 
   const loadResolved = useCallback(async () => {
     const client = supabase
@@ -606,7 +763,7 @@ export default function GameSummary() {
         )}
 
         <div className="mb-4 flex flex-wrap items-center gap-2">
-          <div className="flex rounded-lg border border-slate-200 bg-white p-0.5">
+          <div className="flex rounded-lg border border-slate-200 bg-white p-0.5 flex-wrap">
             <button
               type="button"
               onClick={() => setSummaryTab('players')}
@@ -623,10 +780,21 @@ export default function GameSummary() {
                 summaryTab === 'team' ? 'bg-slate-700 text-white' : 'text-slate-600 hover:bg-slate-100'
               }`}
             >
-              Team
+              Scores
             </button>
+            {showTeamStatsTab && (
+              <button
+                type="button"
+                onClick={() => setSummaryTab('team_stats')}
+                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                  summaryTab === 'team_stats' ? 'bg-slate-700 text-white' : 'text-slate-600 hover:bg-slate-100'
+                }`}
+              >
+                Team stats
+              </button>
+            )}
           </div>
-        {isFinalCloudGame && (
+        {isFinalCloudGame && summaryTab === 'players' && (
           <>
             <div className="flex rounded-lg border border-slate-200 bg-white p-0.5">
               <button
@@ -665,6 +833,8 @@ export default function GameSummary() {
           </>
         )}
         </div>
+
+        {teamStatsSummaryEl}
 
         {summaryTab === 'team' && (
           <div className="card mb-6 border-slate-200">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the **Team stats** tab on Game Summary (basketball / any sport with `teamCategories`) with per-period fouls, derived bonus events, and a side-by-side table for other team stats (timeouts, techs, etc.). Renames the scoreboard tab to **Scores** to avoid confusion with the new tab.

## New files

- `src/lib/teamStatsSummary.ts` — period index detection, scoped stat sums, `hasTrackedTeamSide`, `deriveBonusEvents` (aligned with design §6.3).
- `src/components/team-stats/TeamStatSummary.tsx` — presentation tables + bonus list.

## GameSummary

- Finds home/opp pseudo-players (`__team_home__` / `__team_opp__` or `isTeamPlayer` + `teamSide`).
- **Team stats** tab appears only when at least one side has tracked team-category stats (non-zero keys matching configured team stat ids).
- **Final cloud games**: loads `get_game_team_stats` when the RPC exists; falls back to `resolvedStats` for placeholder remote ids. Local/in-progress uses `player.stats`.
- Primary / All submissions / review controls only show on **Players** tab (unchanged data paths).

## Supabase

Uses existing `get_game_team_stats` (migration 031). If RPC fails, summary still works from `resolvedStats` or local state.

## Testing

`pnpm build`, `pnpm lint`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

