### PR TITLE
chore: remove stale WU references from team-stats comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,4 @@ See `package.json` scripts. Standard commands:
 - The app uses `HashRouter` (`/#/path`), not `BrowserRouter`. URLs in the browser will look like `http://localhost:5173/#/game`.
 - Game state persists in `localStorage` under key `statkeeper_game`. To reset state, either use the "New Game" flow in the UI or clear localStorage.
 - Sport configurations live in `src/config/sports.ts`. Adding a new sport means adding a `SportConfig` entry to the array — the UI auto-discovers it.
+- **Team-level stats (basketball):** Optional `teamCategories` on `SportConfig`; local pseudo-player ids `__team_home__` / `__team_opp__` (`src/lib/teamPlayers.ts`). Season rules: `seasons.team_stats_config`, edited in **Settings → Seasons** (`SeasonTeamStatsEditor`). Cloud: placeholder rows on `players`, `games.home_team_player_id` / `opp_team_player_id`, RPC `get_game_team_stats`. Game Summary tab **Team stats** when any team stat exists. Design: `docs/DESIGN_TEAM_STATS_*.md`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ A mobile-first Progressive Web App for tracking sports game statistics in real t
 - **Live Stat Tracking** — tap-friendly increment/decrement buttons organized by stat category; missed-shot tracking with made/attempted display
 - **Minutes Played** — per-player minute counter for sports that track playing time (basketball, hockey, soccer, football)
 - **Game Notes** — free-text notes field in Game Tracker and Game Summary; synced to cloud
-- **Live Scoreboard** — auto-computed team score from player stats + editable home score adjustment; manual opponent score
+- **Live Scoreboard** — home total can be a standalone scoreboard value or computed from player scoring stats + optional adjustment; manual opponent score
+- **Basketball team stats** — home/opponent “team” rows in Game Tracker for fouls (per period), timeouts, techs, turnovers; period toggle, bonus indicators, and season rules from `seasons.team_stats_config` (edit under **Settings → Seasons**). Cloud games sync placeholder `players` + `game_stats`; **Game Summary** includes a **Team stats** tab (fouls by period, bonus events, other team stats). See [docs/DESIGN_TEAM_STATS_TRACKING.md](docs/DESIGN_TEAM_STATS_TRACKING.md)
 - **Undo Support** — undo any stat action instantly
 - **Game Summary** — per-player and team totals in organized tables; M/A (%) columns for shooting stats
 - **Delete Entities** — delete seasons, teams, players, games, and tournaments with confirmation prompts; centralized Data Management in Settings
@@ -99,6 +100,11 @@ The dev server starts at `http://localhost:5173`.
    - `supabase/migrations/024_player_merge_rpcs.sql` — `merge_players_preview` / `merge_players_execute` + `player_merge_audit` ([DESIGN_PLAYER_MERGE.md](docs/DESIGN_PLAYER_MERGE.md))
    - `supabase/migrations/025_player_merge_audit_select_policy.sql` — users can `SELECT` their own `player_merge_audit` rows (Admin merge history)
    - `supabase/migrations/026_player_stat_high_games.sql` — `get_player_stat_high_games` / `get_player_stat_high_games_for_team` for career & season “Best game” links to game summary
+   - `supabase/migrations/027_home_team_score.sql` — optional `games.home_team_score` + `get_team_game_log` column
+   - `supabase/migrations/028_team_placeholder_players.sql` — `players.is_team_placeholder`; aggregate RPCs exclude placeholders
+   - `supabase/migrations/029_merge_block_team_placeholders.sql` — merge RPCs reject placeholder players
+   - `supabase/migrations/030_team_stats_schema.sql` — `games.home_team_player_id`, `opp_team_player_id`, `seasons.team_stats_config`, display views, `get_game_team_stats` (see file for notes on `get_game_stats_resolved`)
+   - `supabase/migrations/031_get_game_team_stats.sql` — repair: `get_game_team_stats` only if needed
    > If you already applied earlier migrations, run only the new ones (e.g. only `018` for the seasons data model redesign).
    > Before **`019`**, run `supabase/scripts/audit_data_integrity_pre_019.sql` in the SQL Editor if you have existing data; migration `019` aborts if duplicate teams, invalid `seasons.sport`, duplicate active jersey numbers, or bad `games.tournament_id` links exist.
    > **Migration 018 is destructive**: it drops `teams.sport`, `teams.season`, `players.team_id`, `players.jersey_number`, `players.position`, and `players.is_active` columns after migrating data to the new `seasons`, `team_players`, and `player_guardians` tables. Back up your database before running.
@@ -146,11 +152,16 @@ pnpm remove sharp
 src/
 ├── lib/
 │   ├── supabase.ts        # Supabase client init (graceful fallback if not configured)
-│   ├── cloudSync.ts       # Cloud game snapshot sync, hydration, and resume logic
+│   ├── cloudSync.ts       # Cloud game snapshot sync, hydration, resume, team placeholders
 │   ├── display.ts         # Shared display name helpers (teams, players)
-│   └── statDisplay.ts     # Compact stat lines for game logs (sport-aware)
+│   ├── statDisplay.ts     # Compact stat lines for game logs (sport-aware)
+│   ├── gameScore.ts       # Display/final home score (standalone vs computed from player stats)
+│   ├── teamPlayers.ts     # Team pseudo-player ids and isTeamPseudoPlayer helper
+│   ├── teamStatsPeriods.ts   # Period labels, bonus foul counts vs season rules
+│   └── teamStatsSummary.ts   # Game Summary team tab: fouls, bonus events, aggregates
 ├── config/
-│   └── sports.ts          # Sport definitions (stats, categories, scoring rules)
+│   ├── sports.ts          # Sport definitions (stats, categories, scoring rules)
+│   └── teamStatsDefaults.ts  # Basketball team-stat defaults, presets, resolveTeamStatsConfig
 ├── context/
 │   ├── AuthContext.tsx     # Auth state (sign up, sign in, sign out, session)
 │   ├── GameContext.tsx     # Game state management (reducer + localStorage)
@@ -174,7 +185,9 @@ src/
 ├── components/
 │   ├── ConfirmDialog.tsx  # Reusable confirmation modal (delete prompts)
 │   ├── Scoreboard.tsx     # Live score display
-│   └── StatButton.tsx     # Reusable stat increment/decrement button
+│   ├── StatButton.tsx     # Reusable stat increment/decrement button
+│   ├── SeasonTeamStatsEditor.tsx  # Admin: season team-stat rules (basketball)
+│   └── team-stats/        # PeriodToggle, BasketballBonusIndicator, TeamStatSummary
 ├── types.ts               # TypeScript interfaces
 ├── App.tsx                # Router + providers + auth gate
 ├── main.tsx               # Entry point
@@ -207,7 +220,12 @@ supabase/
     ├── 023_tournaments_url.sql
     ├── 024_player_merge_rpcs.sql
     ├── 025_player_merge_audit_select_policy.sql
-    └── 026_player_stat_high_games.sql
+    ├── 026_player_stat_high_games.sql
+    ├── 027_home_team_score.sql
+    ├── 028_team_placeholder_players.sql
+    ├── 029_merge_block_team_placeholders.sql
+    ├── 030_team_stats_schema.sql
+    └── 031_get_game_team_stats.sql
 
 supabase/scripts/
 ├── audit_data_integrity_pre_019.sql
@@ -225,6 +243,11 @@ docs/
 ├── DESIGN_USER_PERMISSIONS_AND_ROLES.md  # Placeholder: granular permissions (R → CRUD), personas TBD
 ├── DATA_INTEGRITY_AND_CREATION_PLAN.md  # Plan: DB/app enforcement, season/team creation alignment
 ├── DESIGN_PLAYER_MERGE.md  # Plan: merge duplicate players (RPC, conflicts, UI)
+├── DESIGN_TEAM_STATS_TRACKING.md      # Team-level stats (pseudo-players, UI) — **shipped**
+├── DESIGN_TEAM_STATS_BASKETBALL.md    # Basketball fouls, bonus, periods — **shipped**
+├── DESIGN_TEAM_STATS_SEASON_CONFIG.md # Season JSON rules — **shipped**
+├── DESIGN_TEAM_STATS_DATA_MODEL.md    # DB placeholders, RPCs, sync — **shipped**
+├── DESIGN_TEAM_STATS_IMPLEMENTATION.md # Work-unit plan (historical); feature complete
 └── REGRESSION_TESTING.md  # High-level test scripts for all features
 ```
 
@@ -284,11 +307,11 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 - [x] Player pool — "Add Existing" mode on roster: pick from players you created or are guardian of; no duplicate player records when moving between teams/seasons
 - [x] Supabase admin display views — 9 human-readable SQL views (`_display` suffix) with `security_invoker = true` for safe FK browsing in Supabase table browser
 - [x] Tournament placement — `tournaments.placement` column for finish position (1st, 2nd, 3rd, etc.)
+- [x] **Team-level stat tracking (basketball)** — pseudo-players `__team_home__` / `__team_opp__`, `teamCategories` in `sports.ts`, period-scoped stat ids (`team_foul_p1`, …), bonus UI, season rules in `seasons.team_stats_config` (Admin → Seasons), cloud placeholder players + `get_game_team_stats`, checkout + Game Summary **Team stats** tab (design: [DESIGN_TEAM_STATS_TRACKING.md](docs/DESIGN_TEAM_STATS_TRACKING.md))
 
 ### What's Next
 
 - [ ] Stat view redesign: career stats page, tournament stats page, team season summary, inline game stat lines on player profile (design: [DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md))
-- [ ] Game Summary Players/Team tab toggle
 - [ ] Team collaboration invites: multi-parent workflows, invite links (design: [DESIGN_MULTI_PARENT_INVITE_LINKS.md](docs/DESIGN_MULTI_PARENT_INVITE_LINKS.md))
 - [ ] Per-sport stat refinements and additional stats (minutes for hockey/soccer/football, missed shots for hockey)
 - [ ] Player transfer UI: search/autocomplete for adding existing players to new teams

--- a/docs/DESIGN_TEAM_STATS_BASKETBALL.md
+++ b/docs/DESIGN_TEAM_STATS_BASKETBALL.md
@@ -4,7 +4,7 @@ Basketball-specific team stat categories, foul/bonus rules, half tracking, and U
 
 **Parent doc:** [DESIGN_TEAM_STATS_TRACKING.md](DESIGN_TEAM_STATS_TRACKING.md)
 
-**Status:** Design phase.
+**Status:** **Implemented** (matches current app behavior; minor UX differences possible).
 
 ---
 

--- a/docs/DESIGN_TEAM_STATS_DATA_MODEL.md
+++ b/docs/DESIGN_TEAM_STATS_DATA_MODEL.md
@@ -6,7 +6,7 @@ Database schema changes, cloud sync strategy, and migration plan for team-level 
 
 **Related:** [DESIGN_SEASONS_DATA_MODEL.md](DESIGN_SEASONS_DATA_MODEL.md), [INTEGRATION_PLAN.md](INTEGRATION_PLAN.md)
 
-**Status:** Design phase.
+**Status:** **Implemented** — migrations `027`–`031` (see repo `supabase/migrations/`). `get_game_stats_resolved` return type was not extended for `is_team_placeholder`; filtering uses `players.is_team_placeholder` in RPCs and `get_game_team_stats` for game-level team rows.
 
 ---
 

--- a/docs/DESIGN_TEAM_STATS_IMPLEMENTATION.md
+++ b/docs/DESIGN_TEAM_STATS_IMPLEMENTATION.md
@@ -2,6 +2,21 @@
 
 Step-by-step implementation plan for the team stats feature, broken into small work units with clear test breakpoints, dependency ordering, and guidance on which units can be assigned to parallel agents.
 
+**Status (2026):** Work units **WU-1 through WU-12** are **done** on the `stattracker` branch. Treat the sections below as a **historical checklist** and architecture reference, not pending tasks.
+
+**Shipped surface (quick ref):**
+
+| Area | Location / notes |
+|------|------------------|
+| Types & reducer | `src/types.ts`, `src/context/GameContext.tsx` (`currentPeriod`, `teamStatsConfig`, `SET_PERIOD`, `SET_TEAM_STATS_CONFIG`) |
+| Basketball config | `src/config/sports.ts` (`teamCategories`, `teamFoulBaseStatId`), `src/config/teamStatsDefaults.ts` |
+| Tracker UI | `src/pages/GameTracker.tsx`, `src/components/team-stats/*` |
+| Season rules UI | `src/components/SeasonTeamStatsEditor.tsx`, `src/pages/Admin.tsx` (Seasons) — not a standalone `SeasonSettings` route |
+| Cloud | `src/lib/cloudSync.ts` — placeholder `players`, `games.home_team_player_id` / `opp_team_player_id`, `game_stats` |
+| Checkout | `src/pages/GameCheckout.tsx`, `src/pages/PlayerSetup.tsx` (inject placeholders) |
+| Summary | `src/pages/GameSummary.tsx` — tabs **Players** / **Scores** / **Team stats**; `TeamStatSummary.tsx`, `get_game_team_stats` RPC |
+| DB | `supabase/migrations/027_*.sql` … `031_*.sql` |
+
 **Design docs implemented by this plan:**
 - [DESIGN_TEAM_STATS_TRACKING.md](DESIGN_TEAM_STATS_TRACKING.md) — core architecture (pseudo-players, injection, category switching)
 - [DESIGN_TEAM_STATS_BASKETBALL.md](DESIGN_TEAM_STATS_BASKETBALL.md) — basketball-specific stats, bonus indicators, period toggle
@@ -196,7 +211,7 @@ Add `isTeamPlayer` filters to prevent team pseudo-players from corrupting indivi
    - Renders a segmented control: `[1st Half] [2nd Half] [+ OT]`
    - Active period highlighted with sport theme color
    - `+ OT` adds a new period (increments period count in local component state; dispatches `SET_PERIOD` with new number)
-   - Use default labels from `BASKETBALL_TEAM_STATS_DEFAULTS` for now (config-driven labels come in WU-9)
+   - Period labels are config-driven via `resolveTeamStatsConfig` (season JSON + defaults)
 
 3. **`src/pages/GameTracker.tsx`** — Show `PeriodToggle` between player selector and stat grid, but only when `activePlayer.isTeamPlayer === true`.
 
@@ -240,7 +255,7 @@ Add `isTeamPlayer` filters to prevent team pseudo-players from corrupting indivi
 2. **`src/pages/GameTracker.tsx`** — When team player is active and sport is `basketball`:
    - Read current period's foul count from `activePlayer.stats[team_foul_p${currentPeriod}]`
    - Render `BasketballBonusIndicator` between the period toggle and the stat grid
-   - Pass default thresholds for now (7, 10, true) — config-driven values come in WU-9
+   - Pass thresholds from `resolveTeamStatsConfig(sport, state.teamStatsConfig)`
 
 **Files touched:** new `src/components/team-stats/BasketballBonusIndicator.tsx`, `src/pages/GameTracker.tsx`
 
@@ -265,25 +280,18 @@ Add `isTeamPlayer` filters to prevent team pseudo-players from corrupting indivi
 
 **Blocks:** WU-8, WU-10
 
-**What to do:**
+**What to do (shipped across 027–031):**
 
-1. **New: `supabase/migrations/027_team_stats_schema.sql`** — Full migration as specified in [DATA_MODEL §6.1](DESIGN_TEAM_STATS_DATA_MODEL.md):
-   - `ALTER TABLE players ADD COLUMN is_team_placeholder boolean NOT NULL DEFAULT false`
-   - `ALTER TABLE games ADD COLUMN home_team_player_id uuid REFERENCES players(id) ON DELETE SET NULL`
-   - `ALTER TABLE games ADD COLUMN opp_team_player_id uuid REFERENCES players(id) ON DELETE SET NULL`
-   - `ALTER TABLE seasons ADD COLUMN team_stats_config jsonb DEFAULT '{}'::jsonb`
-   - Partial index on `players.is_team_placeholder`
-   - Update `players_display` view to include `is_team_placeholder`
-   - Create `get_game_team_stats` RPC
-   - Update `get_season_stats_resolved` to exclude team placeholders (read current RPC definition first and modify carefully)
-   - Update `get_team_game_log` to exclude team placeholders
+1. **Migrations in repo** — `027_home_team_score.sql`, `028_team_placeholder_players.sql`, `029_merge_block_team_placeholders.sql`, `030_team_stats_schema.sql`, `031_get_game_team_stats.sql`. Together they cover placeholders, `games` FKs, `seasons.team_stats_config`, display views, `get_game_team_stats`, and aggregate RPC filters. **`get_game_stats_resolved`** was not given a new return shape (Postgres limitation); clients join `players` or use `get_game_team_stats` for placeholder-only stats.
 
-2. **Validate against existing RPCs** — Before modifying `get_season_stats_resolved`, read the current definition in `supabase/migrations/010_resolved_stats_rpcs.sql` (and any later overrides in `020_stat_tracking_ui_rpcs.sql`) to understand how to add the filter without breaking the function signature.
+2. **Original single-file sketch** — [DATA_MODEL §6.1](DESIGN_TEAM_STATS_DATA_MODEL.md) listed one migration; the repo split this for safer rollout.
 
-**Files touched:** new `supabase/migrations/027_team_stats_schema.sql`
+3. **Validate against existing RPCs** — When adding filters, read current definitions in `010`, `020`, `028`, etc.
+
+**Files touched:** `supabase/migrations/027_*.sql` through `031_*.sql` (as in repo).
 
 **Test breakpoint:**
-- Migration applies cleanly to Supabase (or local Supabase instance)
+- Migrations apply cleanly to Supabase (or local Supabase instance)
 - Existing RPCs still return correct results for games with no team stats
 - `get_game_team_stats` returns empty for existing games (no team placeholders yet)
 - `players_display` view includes `is_team_placeholder` column
@@ -334,7 +342,9 @@ Add `isTeamPlayer` filters to prevent team pseudo-players from corrupting indivi
 
 **What to do:**
 
-1. **New: `src/pages/SeasonSettings.tsx`** — Season configuration screen:
+1. **Shipped as Admin Seasons panel** — Use `SeasonTeamStatsEditor` from **`src/pages/Admin.tsx`** (expand Seasons → basketball season → team stat rules). The standalone **`src/pages/SeasonSettings.tsx`** route described here was **not** added.
+
+2. **Original sketch (historical):** `SeasonSettings.tsx` season configuration screen:
    - Load the season's current `team_stats_config` from Supabase
    - Preset dropdown (NFHS, NCAA, NBA, FIBA, Youth Rec, Custom)
    - Selecting a preset fills form fields; editing any field switches to "Custom"
@@ -349,20 +359,17 @@ Add `isTeamPlayer` filters to prevent team pseudo-players from corrupting indivi
    - Save button → upsert `seasons.team_stats_config`
    - Toast or inline confirmation on save
 
-2. **`src/App.tsx`** — Add route `/season-settings` → `SeasonSettings`
+3. **`src/App.tsx`** — Route `/season-settings` was **not** added (use Admin instead).
 
-3. **Navigation entry point** — Add a "Season Settings" or gear icon link from:
-   - `src/pages/Teams.tsx` — next to the season name/header
-   - Optionally: `src/pages/GameSetup.tsx` — small "League Rules" link
+4. **Navigation** — Team stat rules are reached from **Settings → Seasons**, not from Teams/Game Setup as originally sketched.
 
-**Files touched:** new `src/pages/SeasonSettings.tsx`, `src/App.tsx`, `src/pages/Teams.tsx`
+**Files touched (actual):** `src/components/SeasonTeamStatsEditor.tsx`, `src/pages/Admin.tsx`
 
 **Test breakpoint:**
-- Navigate to Teams → tap gear icon next to a season → Season Settings page loads
+- **Settings (Admin) → Seasons** → expand basketball season → open team stat rules
 - Select "NBA" preset → fields show: 4 quarters, no 1-and-1, bonus at 5
-- Edit bonus threshold manually → preset switches to "Custom"
-- Save → reload page → saved config persists
-- Validation: set double bonus < bonus → error message shown, save blocked
+- Save → reload → config persists on the season row
+- *(Optional / future: strict validation double bonus < bonus is not necessarily enforced in UI.)*
 
 **Commit message:** `feat: add Season Settings UI for team stat rules (presets, bonus config)`
 
@@ -670,14 +677,14 @@ After each phase merge, verify these invariants:
 
 4. **Don't break the existing flow.** The most important invariant is that existing player-level stat tracking works identically. Every WU's test checklist starts with "existing flow still works."
 
-5. **New files go in `src/components/team-stats/`.** This directory doesn't exist yet — create it in WU-4 or WU-5 (whichever lands first).
+5. **`src/components/team-stats/`** — Present in repo (`PeriodToggle`, `BasketballBonusIndicator`, `TeamStatSummary`, …).
 
-6. **Migration numbering.** As of this writing, the latest migration is `026_player_stat_high_games.sql`. The team stats migration should be `027`. If another migration lands first, renumber accordingly.
+6. **Migration numbering** — Team stats land in **`027`–`031`** alongside `027_home_team_score.sql` (standalone home score). Apply all listed files in order.
 
-7. **Cloud sync is the trickiest part.** WU-10 modifies `cloudSync.ts`, which is the most complex file in the app. Read the entire file before starting. The team pseudo-player handling should be a clear, isolated code path — not interleaved with the existing player sync logic.
+7. **Cloud sync** — Team placeholders are handled in **`cloudSync.ts`** (`ensureTeamPlaceholderPlayer`, `linkGameTeamPlaceholderIds`, hydrate merge).
 
 8. **Tailwind classes.** The app uses Tailwind 3 with a mobile-first approach. New components should match the existing design language: `rounded-xl`, `shadow-md`, `card` utility class, sport theme colors via `sport.theme.*`.
 
 ---
 
-*Document version: 0.1*
+*Document version: 0.2 — marked shipped; Admin vs SeasonSettings; migration file names aligned to repo.*

--- a/docs/DESIGN_TEAM_STATS_SEASON_CONFIG.md
+++ b/docs/DESIGN_TEAM_STATS_SEASON_CONFIG.md
@@ -4,7 +4,7 @@ Season-level configuration for team stat rules: timeout limits, bonus thresholds
 
 **Parent doc:** [DESIGN_TEAM_STATS_TRACKING.md](DESIGN_TEAM_STATS_TRACKING.md)
 
-**Status:** Design phase.
+**Status:** **Implemented** — rules are edited under **Settings (Admin) → Seasons** for basketball seasons (`team_stats_config` JSON). There is no separate `/season-settings` route.
 
 ---
 

--- a/docs/DESIGN_TEAM_STATS_TRACKING.md
+++ b/docs/DESIGN_TEAM_STATS_TRACKING.md
@@ -2,7 +2,7 @@
 
 Track stats at the **team** level (fouls, timeouts, turnovers, etc.) alongside existing per-player tracking. A coach or assistant can select a "team player" in the same Game Tracker UI and record stats that make sense as aggregate team events — not attributable to any individual.
 
-**Status:** Design phase. Not yet implemented.
+**Status:** **Implemented** (basketball on `stattracker`). Opponent column is optional; other sports can add `teamCategories` later.
 
 **Related docs:**
 - [DESIGN_TEAM_STATS_BASKETBALL.md](DESIGN_TEAM_STATS_BASKETBALL.md) — basketball-specific team stat categories, foul/bonus rules, half tracking

--- a/src/config/teamStatsDefaults.ts
+++ b/src/config/teamStatsDefaults.ts
@@ -21,7 +21,7 @@ export interface BasketballTeamStatsPreset {
 }
 
 /**
- * Named rulesets for season UI (WU-8) and docs. Values are approximate; leagues vary.
+ * Named rulesets for Admin season team-stat rules and docs. Values are approximate; leagues vary.
  * "NFHS" entry matches {@link BASKETBALL_TEAM_STATS_DEFAULTS}.
  */
 export const BASKETBALL_PRESETS: BasketballTeamStatsPreset[] = [

--- a/src/lib/teamPlayers.ts
+++ b/src/lib/teamPlayers.ts
@@ -1,6 +1,6 @@
 import type { Player } from '../types'
 
-/** Local deterministic ids for team pseudo-players (cloud maps these in WU-10). */
+/** Local deterministic ids for team pseudo-players (mapped to cloud `players` rows in sync). */
 export const TEAM_PLAYER_HOME_ID = '__team_home__' as const
 export const TEAM_PLAYER_OPP_ID = '__team_opp__' as const
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

1. **Comment cleanup** — Remove stale WU-10 / WU-8 references from `teamPlayers.ts` and `teamStatsDefaults.ts` (neutral wording).

2. **Documentation (team stats MVP)**  
   - **README.md** — Team stats in Features; migrations `027`–`031`; `lib/` + `config/teamStatsDefaults.ts` + `components/team-stats/` in project structure; docs index entries; removed obsolete "Game Summary Players/Team tab toggle" from What's Next; What's Done checkbox for team tracking.  
   - **AGENTS.md** — Short agent pointers (pseudo-player ids, Admin season rules, `get_game_team_stats`, Summary tab).  
   - **DESIGN_TEAM_STATS_TRACKING.md**, **BASKETBALL**, **SEASON_CONFIG**, **DATA_MODEL** — Status set to **implemented** with brief notes (Admin vs standalone Season Settings, migration split).  
   - **DESIGN_TEAM_STATS_IMPLEMENTATION.md** — v0.2: shipped banner + quick-ref table; WU-6/WU-8/WU-9 text aligned to repo; notes section updated.

## Testing

Docs-only + prior comment edits; `pnpm build` not required for markdown but branch is based on current `stattracker` merge target.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d196a33c-8dc3-4f04-971e-dcebb7eb4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

