### PR TITLE
feat: SC-1 — Basketball court SVG component and shot geometry utilities

### DIFF
--- a/src/components/shot-chart/BasketballCourt.tsx
+++ b/src/components/shot-chart/BasketballCourt.tsx
@@ -1,0 +1,217 @@
+import type { ShotRecord } from '../../types'
+import {
+  COURT_WIDTH,
+  HALF_COURT_DEPTH,
+  PAINT_WIDTH,
+  PAINT_DEPTH,
+  FT_CIRCLE_RADIUS,
+  RESTRICTED_RADIUS,
+  THREE_POINT_RADIUS,
+  CORNER_THREE_X,
+  BASKET_RADIUS,
+  BACKBOARD_WIDTH,
+} from './courtGeometry'
+
+interface BasketballCourtProps {
+  shots: ShotRecord[]
+  onCourtTap?: (x: number, y: number) => void
+  className?: string
+}
+
+const LINE_COLOR = '#8B6914'
+const LINE_WIDTH = 0.3
+const COURT_BG = '#e8d5b7'
+
+/**
+ * Three-point arc path from left corner to right corner.
+ * The arc sits at radius 23.75 ft from the basket (origin).
+ * Corner threes are straight verticals at x = ±22 from y = 0 up to where the arc begins.
+ */
+function threePointArcPath(): string {
+  const r = THREE_POINT_RADIUS
+  const cx = CORNER_THREE_X
+
+  // y where the arc starts (at x = ±22): y = sqrt(r^2 - 22^2)
+  const arcStartY = Math.sqrt(r * r - cx * cx)
+
+  // Left corner vertical: from (−22, 0) up to (−22, arcStartY)
+  // Then arc from (−22, arcStartY) around to (22, arcStartY)
+  // Then right corner vertical: from (22, arcStartY) down to (22, 0)
+  return [
+    `M ${-cx} 0`,
+    `L ${-cx} ${arcStartY}`,
+    `A ${r} ${r} 0 0 1 ${cx} ${arcStartY}`,
+    `L ${cx} 0`,
+  ].join(' ')
+}
+
+/** Restricted area: semicircle at radius 4 ft from basket (0,0), from left to right. */
+function restrictedAreaPath(): string {
+  const r = RESTRICTED_RADIUS
+  return `M ${-r} 0 A ${r} ${r} 0 0 1 ${r} 0`
+}
+
+/** Free throw circle top half (solid) — semicircle above y = 19 */
+function ftCircleTopPath(): string {
+  const r = FT_CIRCLE_RADIUS
+  const cy = PAINT_DEPTH
+  return `M ${-r} ${cy} A ${r} ${r} 0 0 1 ${r} ${cy}`
+}
+
+/** Free throw circle bottom half (dashed) — semicircle below y = 19 */
+function ftCircleBottomPath(): string {
+  const r = FT_CIRCLE_RADIUS
+  const cy = PAINT_DEPTH
+  return `M ${-r} ${cy} A ${r} ${r} 0 0 0 ${r} ${cy}`
+}
+
+/** Half-court circle bottom half — at (0, 47), radius 6 ft */
+function halfCourtCirclePath(): string {
+  const r = FT_CIRCLE_RADIUS
+  const cy = HALF_COURT_DEPTH
+  return `M ${-r} ${cy} A ${r} ${r} 0 0 0 ${r} ${cy}`
+}
+
+function handlePointerDown(
+  e: React.PointerEvent<SVGRectElement>,
+  onCourtTap: (x: number, y: number) => void
+) {
+  const svg = e.currentTarget.ownerSVGElement
+  if (!svg) return
+  const pt = svg.createSVGPoint()
+  pt.x = e.clientX
+  pt.y = e.clientY
+  const ctm = svg.getScreenCTM()
+  if (!ctm) return
+  const svgPt = pt.matrixTransform(ctm.inverse())
+  onCourtTap(
+    Math.round(svgPt.x * 10) / 10,
+    Math.round(svgPt.y * 10) / 10
+  )
+}
+
+export default function BasketballCourt({ shots, onCourtTap, className }: BasketballCourtProps) {
+  const interactive = Boolean(onCourtTap)
+  const halfW = COURT_WIDTH / 2
+  const padding = 2
+
+  return (
+    <svg
+      viewBox={`${-halfW - padding} ${-padding} ${COURT_WIDTH + padding * 2} ${HALF_COURT_DEPTH + padding * 2}`}
+      preserveAspectRatio="xMidYMid meet"
+      className={className}
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      {/* Court background */}
+      <rect
+        x={-halfW}
+        y={0}
+        width={COURT_WIDTH}
+        height={HALF_COURT_DEPTH}
+        fill={COURT_BG}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+
+      <g stroke={LINE_COLOR} strokeWidth={LINE_WIDTH} fill="none">
+        {/* Paint / lane */}
+        <rect
+          x={-PAINT_WIDTH / 2}
+          y={0}
+          width={PAINT_WIDTH}
+          height={PAINT_DEPTH}
+        />
+
+        {/* Free throw circle — top half solid */}
+        <path d={ftCircleTopPath()} />
+
+        {/* Free throw circle — bottom half dashed */}
+        <path
+          d={ftCircleBottomPath()}
+          strokeDasharray="1.0 0.8"
+        />
+
+        {/* Restricted area arc */}
+        <path d={restrictedAreaPath()} />
+
+        {/* Three-point arc + corner lines */}
+        <path d={threePointArcPath()} />
+
+        {/* Half-court line */}
+        <line
+          x1={-halfW}
+          y1={HALF_COURT_DEPTH}
+          x2={halfW}
+          y2={HALF_COURT_DEPTH}
+        />
+
+        {/* Half-court circle (bottom half only, visible inside the court) */}
+        <path d={halfCourtCirclePath()} />
+
+        {/* Backboard */}
+        <line
+          x1={-BACKBOARD_WIDTH / 2}
+          y1={-0.5}
+          x2={BACKBOARD_WIDTH / 2}
+          y2={-0.5}
+          strokeWidth={0.4}
+        />
+
+        {/* Basket (rim) */}
+        <circle cx={0} cy={0} r={BASKET_RADIUS} strokeWidth={0.25} />
+
+        {/* Connector from backboard to rim */}
+        <line x1={0} y1={-0.5} x2={0} y2={-BASKET_RADIUS} strokeWidth={0.15} />
+      </g>
+
+      {/* Shot markers */}
+      {shots.map(shot =>
+        shot.made ? (
+          <circle
+            key={shot.id}
+            cx={shot.x}
+            cy={shot.y}
+            r={0.8}
+            fill="rgba(34,197,94,0.8)"
+            stroke="rgba(22,163,74,0.9)"
+            strokeWidth={0.15}
+          />
+        ) : (
+          <g key={shot.id}>
+            <line
+              x1={shot.x - 0.6}
+              y1={shot.y - 0.6}
+              x2={shot.x + 0.6}
+              y2={shot.y + 0.6}
+              stroke="rgba(239,68,68,0.8)"
+              strokeWidth={0.3}
+              strokeLinecap="round"
+            />
+            <line
+              x1={shot.x + 0.6}
+              y1={shot.y - 0.6}
+              x2={shot.x - 0.6}
+              y2={shot.y + 0.6}
+              stroke="rgba(239,68,68,0.8)"
+              strokeWidth={0.3}
+              strokeLinecap="round"
+            />
+          </g>
+        )
+      )}
+
+      {/* Transparent tap target overlay */}
+      {interactive && onCourtTap && (
+        <rect
+          x={-halfW - padding}
+          y={-padding}
+          width={COURT_WIDTH + padding * 2}
+          height={HALF_COURT_DEPTH + padding * 2}
+          fill="transparent"
+          onPointerDown={e => handlePointerDown(e, onCourtTap)}
+          style={{ touchAction: 'none', cursor: 'crosshair' }}
+        />
+      )}
+    </svg>
+  )
+}

--- a/src/components/shot-chart/courtGeometry.ts
+++ b/src/components/shot-chart/courtGeometry.ts
@@ -1,0 +1,30 @@
+import type { ShotZone } from '../../types'
+
+export const COURT_WIDTH = 50
+export const HALF_COURT_DEPTH = 47
+export const THREE_POINT_RADIUS = 23.75
+export const CORNER_THREE_X = 22
+export const CORNER_THREE_Y = 14
+export const RESTRICTED_RADIUS = 4
+export const PAINT_WIDTH = 12
+export const PAINT_DEPTH = 19
+export const FT_LINE_Y = 19
+export const FT_CIRCLE_RADIUS = 6
+export const BASKET_RADIUS = 0.75
+export const BACKBOARD_WIDTH = 6
+
+export function isThreePointer(x: number, y: number): boolean {
+  if (Math.abs(x) >= CORNER_THREE_X && y <= CORNER_THREE_Y) {
+    return true
+  }
+  const distFromBasket = Math.sqrt(x * x + y * y)
+  return distFromBasket > THREE_POINT_RADIUS
+}
+
+export function classifyShotZone(x: number, y: number): ShotZone {
+  const dist = Math.sqrt(x * x + y * y)
+  if (dist <= RESTRICTED_RADIUS) return 'restricted'
+  if (Math.abs(x) <= PAINT_WIDTH / 2 && y <= PAINT_DEPTH) return 'paint'
+  if (isThreePointer(x, y)) return 'three'
+  return 'mid_range'
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,16 @@
+export type ShotZone = 'restricted' | 'paint' | 'mid_range' | 'three'
+
+export interface ShotRecord {
+  id: string
+  x: number
+  y: number
+  made: boolean
+  shotType: '2pt' | '3pt'
+  zone: ShotZone
+  playerId: string
+  timestamp: number
+}
+
 export interface StatAction {
   id: string
   label: string
@@ -53,6 +66,7 @@ export interface SportConfig {
    * Basketball sets `team_foul`.
    */
   teamFoulBaseStatId?: string
+  hasShotChart?: boolean
 }
 
 export interface GameInfo {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **SC-1** from the [shot chart implementation plan](docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md) — the foundation for the basketball shot chart feature.

### Changes

- **`src/types.ts`** — Added `ShotZone` type, `ShotRecord` interface, and `hasShotChart` optional flag on `SportConfig`
- **`src/components/shot-chart/courtGeometry.ts`** — Court dimension constants and classification functions:
  - `isThreePointer(x, y)` — determines if a shot is beyond the three-point line (including corner threes)
  - `classifyShotZone(x, y)` — classifies shots into restricted, paint, mid-range, or three-point zones
- **`src/components/shot-chart/BasketballCourt.tsx`** — Reusable SVG half-court component:
  - Accurate court markings (three-point arc, paint, FT line/circle, restricted area, basket/backboard, half-court line/circle)
  - Shot marker rendering (green filled circles for made, red X for missed)
  - Tap-to-coordinate conversion via `SVG.getScreenCTM().inverse()` for accurate mapping at any screen size
  - `touchAction: 'none'` on the tap target to prevent browser pan/zoom interference on mobile
  - Warm hardwood color scheme matching the basketball theme

### Court rendering with sample shots and all geometry tests passing

[Basketball court with sample shots and geometry tests](https://cursor.com/agents/bc-f4b4ea48-86e9-4b52-88de-1580be41da9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshot_chart_court_initial.webp)

### After interactive tap testing (made + missed shots added)

[Court after interactive testing](https://cursor.com/agents/bc-f4b4ea48-86e9-4b52-88de-1580be41da9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshot_chart_court_interactive.webp)

### Testing

- `pnpm build` — passes (TypeScript + Vite)
- `pnpm lint` — passes (0 errors, 3 pre-existing warnings)
- Manual testing with a temporary test page verified:
  - All court lines render correctly (three-point arc, paint, FT line, restricted area, basket, half-court)
  - Shot markers appear at correct positions
  - Tapping the court correctly converts screen coordinates to court coordinates
  - `isThreePointer()` and `classifyShotZone()` classify all test cases correctly
  - Mode toggle between Made/Missed works
  - Court scales properly on mobile viewport

### What's next

This unblocks **SC-2** (shot chart interaction page) and **SC-3** (GameState/reducer integration).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4b4ea48-86e9-4b52-88de-1580be41da9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4b4ea48-86e9-4b52-88de-1580be41da9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

