### PR TITLE
fix: SC-1 — Correct basketball court SVG to NBA regulation dimensions

### DIFF
--- a/docs/DESIGN_SHOT_CHART.md
+++ b/docs/DESIGN_SHOT_CHART.md
@@ -61,13 +61,16 @@ This design covers **v1 + the v2 data model** (store player ID from the start ev
 
 ### 3.1 Coordinate System
 
-The SVG half court uses a coordinate system based on **feet**, matching real court dimensions. The basket (center of the hoop) is the origin.
+The SVG half court uses a coordinate system based on **feet**, matching real NBA court dimensions. The basket (center of the hoop) is the origin `(0, 0)`.
+
+The basket is **5.25 ft** from the baseline (4 ft to the face of the backboard + 1.25 ft to the center of the rim). This offset means the baseline sits at `y = -5.25` and the half-court line at `y = 41.75`.
 
 | Dimension | Value | Notes |
 |-----------|-------|-------|
 | Court width | 50 ft | Full width, symmetric left/right |
 | Half court depth | 47 ft | From baseline to half-court line |
-| SVG viewBox | `"-25 0 50 47"` | Origin at basket center (0,0 = basket); x: -25 to +25; y: 0 to 47 |
+| Basket offset | 5.25 ft | From baseline to basket center (4 ft backboard + 1.25 ft rim) |
+| SVG viewBox | `"-27 -7.25 54 51"` | Basket-centered origin with padding; x: -27 to +27; y: -7.25 to 43.75 |
 
 Using real-foot coordinates means shot locations are meaningful and portable — they could be compared across games, exported, or analyzed with standard basketball analytics tools.
 
@@ -78,17 +81,18 @@ All measurements in feet from the basket center:
 | Feature | Geometry | SVG Element |
 |---------|----------|-------------|
 | **Basket** | Circle, center (0, 0), radius 0.75 ft | `<circle>` |
-| **Backboard** | Line, y = -0.5, x: -3 to +3 | `<line>` |
-| **Paint / Lane** | Rectangle, 12 ft wide × 19 ft deep, centered | `<rect>` x=-6, y=0, w=12, h=19 |
-| **Free throw line** | Line at y = 19, x: -6 to +6 | `<line>` |
-| **Free throw circle** | Circle, center (0, 19), radius 6 ft | `<circle>` (top half solid, bottom half dashed) |
+| **Backboard** | Line, y = -1.25, x: -3 to +3 (4 ft from baseline) | `<line>` |
+| **Paint / Lane** | Rectangle, 16 ft wide × 19 ft deep from baseline, centered | `<rect>` x=-8, y=-5.25, w=16, h=19 |
+| **Free throw line** | Line at y = 13.75 (19 ft from baseline - 5.25 ft offset), x: -8 to +8 | `<line>` |
+| **Free throw circle** | Circle, center (0, 13.75), radius 6 ft | `<circle>` (top half solid, bottom half dashed) |
 | **Restricted area** | Arc, center (0, 0), radius 4 ft, 0° to 180° | `<path>` semicircle |
 | **Three-point arc** | Arc, center (0, 0), radius 23.75 ft | `<path>` from corner to corner |
-| **Three-point corners** | Vertical lines, x = ±22, y = 0 to ~14 ft | `<line>` (corners are 22 ft from center, not following the arc) |
-| **Half-court line** | Line at y = 47, x: -25 to +25 | `<line>` |
-| **Half-court circle** | Circle at (0, 47), radius 6 ft, bottom half only | `<path>` |
-| **Baseline** | Line at y = 0, x: -25 to +25 | `<line>` |
-| **Sidelines** | Lines at x = -25 and x = +25, y: 0 to 47 | `<line>` |
+| **Three-point corners** | Vertical lines, x = ±22, y = -5.25 to where arc begins | `<line>` (3 ft from each sideline) |
+| **Lane hash marks** | Marks on outer edges of lane at 7, 8, 11, 14 ft from baseline | `<line>` (rebounding position marks) |
+| **Half-court line** | Line at y = 41.75, x: -25 to +25 | `<line>` |
+| **Half-court circle** | Circle at (0, 41.75), radius 6 ft, bottom half only | `<path>` |
+| **Baseline** | Line at y = -5.25, x: -25 to +25 | `<line>` |
+| **Sidelines** | Lines at x = -25 and x = +25, y: -5.25 to 41.75 | `<line>` |
 
 ### 3.3 Three-Point Line Classification
 
@@ -371,18 +375,19 @@ The court component is **reusable** — it renders both in the interactive shot 
 ### 6.2 SVG Structure
 
 ```tsx
-<svg viewBox="-25 -2 50 51" preserveAspectRatio="xMidYMid meet">
+<svg viewBox="-27 -7.25 54 51" preserveAspectRatio="xMidYMid meet">
   {/* Court background */}
-  <rect x="-25" y="-2" width="50" height="51" fill="#f5e6c8" />
+  <rect x="-25" y="-5.25" width="50" height="47" fill="#e8d5b7" />
 
-  {/* Court lines (all in white or dark lines on hardwood) */}
-  <g stroke="#c0956e" strokeWidth="0.15" fill="none">
+  {/* Court lines */}
+  <g stroke="#8B6914" strokeWidth="0.3" fill="none">
     {/* Baseline, sidelines, half-court */}
-    {/* Paint rectangle */}
+    {/* Paint rectangle (16' wide) */}
     {/* Free throw line + circle */}
+    {/* Lane hash marks (rebounding positions) */}
     {/* Three-point arc + corners */}
     {/* Restricted area arc */}
-    {/* Basket + backboard */}
+    {/* Basket + backboard (backboard 4' from baseline) */}
     {/* Half-court line + circle */}
   </g>
 

--- a/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
+++ b/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
@@ -57,22 +57,23 @@ SC-5  Game Summary      │
 **What to do:**
 
 1. **New: `src/components/shot-chart/courtGeometry.ts`**:
-   - Define constants: `COURT_WIDTH = 50`, `HALF_COURT_DEPTH = 47`, `THREE_POINT_RADIUS = 23.75`, `CORNER_THREE_X = 22`, `CORNER_THREE_Y = 14`, `RESTRICTED_RADIUS = 4`, `PAINT_WIDTH = 12`, `PAINT_DEPTH = 19`, `FT_LINE_Y = 19`, `FT_CIRCLE_RADIUS = 6`
+   - Define constants: `COURT_WIDTH = 50`, `HALF_COURT_DEPTH = 47`, `BASKET_CENTER_Y = 5.25` (4 ft backboard + 1.25 ft rim), `BASELINE_Y = -5.25`, `HALFCOURT_Y = 41.75`, `BACKBOARD_Y = -1.25`, `THREE_POINT_RADIUS = 23.75`, `CORNER_THREE_X = 22`, `RESTRICTED_RADIUS = 4`, `PAINT_WIDTH = 16` (NBA lane width), `FT_LINE_Y = 13.75` (19 ft from baseline, offset by basket), `FT_CIRCLE_RADIUS = 6`, `LANE_MARKS_FROM_BASELINE = [7, 8, 11, 14]`
    - Export `isThreePointer(x: number, y: number): boolean`
    - Export `classifyShotZone(x: number, y: number): ShotZone`
    - Export `ShotZone` type: `'restricted' | 'paint' | 'mid_range' | 'three'`
 
 2. **New: `src/components/shot-chart/BasketballCourt.tsx`**:
    - Props: `shots: ShotRecord[]`, `onCourtTap?: (x: number, y: number) => void`, `className?: string`
-   - Renders SVG with `viewBox="-25 -2 50 51"` and `preserveAspectRatio="xMidYMid meet"`
+   - Renders SVG with basket-centered viewBox and `preserveAspectRatio="xMidYMid meet"`
    - Draw all court features listed in [SHOT_CHART §3.2](DESIGN_SHOT_CHART.md):
-     - Court background (warm hardwood color: `#f5e6c8` or `#e8d5b7`)
-     - Court lines in a darker wood tone or dark brown (`#8B6914` or similar)
-     - Baseline, sidelines, half-court line
-     - Paint rectangle, free throw line, free throw circle (top half solid, bottom half dashed)
-     - Three-point arc + corner lines
+     - Court background (warm hardwood color: `#e8d5b7`)
+     - Court lines in a darker wood tone (`#8B6914`)
+     - Baseline (y=-5.25), sidelines, half-court line (y=41.75)
+     - Paint rectangle (16' wide NBA lane), free throw line, free throw circle (top half solid, bottom half dashed)
+     - Three-point arc + corner lines (corners start at baseline y=-5.25)
      - Restricted area arc
-     - Basket circle + backboard line
+     - Basket circle + backboard line (backboard at y=-1.25, 4' from baseline)
+     - Lane hash marks (rebounding positions)
      - Half-court circle (bottom half)
    - Render shot markers from `shots` array:
      - Made: green filled circle, radius 0.8, 80% opacity

--- a/src/components/shot-chart/BasketballCourt.tsx
+++ b/src/components/shot-chart/BasketballCourt.tsx
@@ -1,0 +1,217 @@
+import type { ShotRecord } from '../../types'
+import {
+  COURT_WIDTH,
+  HALF_COURT_DEPTH,
+  PAINT_WIDTH,
+  PAINT_DEPTH,
+  FT_CIRCLE_RADIUS,
+  RESTRICTED_RADIUS,
+  THREE_POINT_RADIUS,
+  CORNER_THREE_X,
+  BASKET_RADIUS,
+  BACKBOARD_WIDTH,
+} from './courtGeometry'
+
+interface BasketballCourtProps {
+  shots: ShotRecord[]
+  onCourtTap?: (x: number, y: number) => void
+  className?: string
+}
+
+const LINE_COLOR = '#8B6914'
+const LINE_WIDTH = 0.3
+const COURT_BG = '#e8d5b7'
+
+/**
+ * Three-point arc path from left corner to right corner.
+ * The arc sits at radius 23.75 ft from the basket (origin).
+ * Corner threes are straight verticals at x = ±22 from y = 0 up to where the arc begins.
+ */
+function threePointArcPath(): string {
+  const r = THREE_POINT_RADIUS
+  const cx = CORNER_THREE_X
+
+  // y where the arc starts (at x = ±22): y = sqrt(r^2 - 22^2)
+  const arcStartY = Math.sqrt(r * r - cx * cx)
+
+  // Left corner vertical: from (−22, 0) up to (−22, arcStartY)
+  // Then arc from (−22, arcStartY) around to (22, arcStartY)
+  // Then right corner vertical: from (22, arcStartY) down to (22, 0)
+  return [
+    `M ${-cx} 0`,
+    `L ${-cx} ${arcStartY}`,
+    `A ${r} ${r} 0 0 1 ${cx} ${arcStartY}`,
+    `L ${cx} 0`,
+  ].join(' ')
+}
+
+/** Restricted area: semicircle at radius 4 ft from basket (0,0), from left to right. */
+function restrictedAreaPath(): string {
+  const r = RESTRICTED_RADIUS
+  return `M ${-r} 0 A ${r} ${r} 0 0 1 ${r} 0`
+}
+
+/** Free throw circle top half (solid) — semicircle above y = 19 */
+function ftCircleTopPath(): string {
+  const r = FT_CIRCLE_RADIUS
+  const cy = PAINT_DEPTH
+  return `M ${-r} ${cy} A ${r} ${r} 0 0 1 ${r} ${cy}`
+}
+
+/** Free throw circle bottom half (dashed) — semicircle below y = 19 */
+function ftCircleBottomPath(): string {
+  const r = FT_CIRCLE_RADIUS
+  const cy = PAINT_DEPTH
+  return `M ${-r} ${cy} A ${r} ${r} 0 0 0 ${r} ${cy}`
+}
+
+/** Half-court circle bottom half — at (0, 47), radius 6 ft */
+function halfCourtCirclePath(): string {
+  const r = FT_CIRCLE_RADIUS
+  const cy = HALF_COURT_DEPTH
+  return `M ${-r} ${cy} A ${r} ${r} 0 0 0 ${r} ${cy}`
+}
+
+function handlePointerDown(
+  e: React.PointerEvent<SVGRectElement>,
+  onCourtTap: (x: number, y: number) => void
+) {
+  const svg = e.currentTarget.ownerSVGElement
+  if (!svg) return
+  const pt = svg.createSVGPoint()
+  pt.x = e.clientX
+  pt.y = e.clientY
+  const ctm = svg.getScreenCTM()
+  if (!ctm) return
+  const svgPt = pt.matrixTransform(ctm.inverse())
+  onCourtTap(
+    Math.round(svgPt.x * 10) / 10,
+    Math.round(svgPt.y * 10) / 10
+  )
+}
+
+export default function BasketballCourt({ shots, onCourtTap, className }: BasketballCourtProps) {
+  const interactive = Boolean(onCourtTap)
+  const halfW = COURT_WIDTH / 2
+  const padding = 2
+
+  return (
+    <svg
+      viewBox={`${-halfW - padding} ${-padding} ${COURT_WIDTH + padding * 2} ${HALF_COURT_DEPTH + padding * 2}`}
+      preserveAspectRatio="xMidYMid meet"
+      className={className}
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      {/* Court background */}
+      <rect
+        x={-halfW}
+        y={0}
+        width={COURT_WIDTH}
+        height={HALF_COURT_DEPTH}
+        fill={COURT_BG}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+
+      <g stroke={LINE_COLOR} strokeWidth={LINE_WIDTH} fill="none">
+        {/* Paint / lane */}
+        <rect
+          x={-PAINT_WIDTH / 2}
+          y={0}
+          width={PAINT_WIDTH}
+          height={PAINT_DEPTH}
+        />
+
+        {/* Free throw circle — top half solid */}
+        <path d={ftCircleTopPath()} />
+
+        {/* Free throw circle — bottom half dashed */}
+        <path
+          d={ftCircleBottomPath()}
+          strokeDasharray="1.0 0.8"
+        />
+
+        {/* Restricted area arc */}
+        <path d={restrictedAreaPath()} />
+
+        {/* Three-point arc + corner lines */}
+        <path d={threePointArcPath()} />
+
+        {/* Half-court line */}
+        <line
+          x1={-halfW}
+          y1={HALF_COURT_DEPTH}
+          x2={halfW}
+          y2={HALF_COURT_DEPTH}
+        />
+
+        {/* Half-court circle (bottom half only, visible inside the court) */}
+        <path d={halfCourtCirclePath()} />
+
+        {/* Backboard */}
+        <line
+          x1={-BACKBOARD_WIDTH / 2}
+          y1={-0.5}
+          x2={BACKBOARD_WIDTH / 2}
+          y2={-0.5}
+          strokeWidth={0.4}
+        />
+
+        {/* Basket (rim) */}
+        <circle cx={0} cy={0} r={BASKET_RADIUS} strokeWidth={0.25} />
+
+        {/* Connector from backboard to rim */}
+        <line x1={0} y1={-0.5} x2={0} y2={-BASKET_RADIUS} strokeWidth={0.15} />
+      </g>
+
+      {/* Shot markers */}
+      {shots.map(shot =>
+        shot.made ? (
+          <circle
+            key={shot.id}
+            cx={shot.x}
+            cy={shot.y}
+            r={0.8}
+            fill="rgba(34,197,94,0.8)"
+            stroke="rgba(22,163,74,0.9)"
+            strokeWidth={0.15}
+          />
+        ) : (
+          <g key={shot.id}>
+            <line
+              x1={shot.x - 0.6}
+              y1={shot.y - 0.6}
+              x2={shot.x + 0.6}
+              y2={shot.y + 0.6}
+              stroke="rgba(239,68,68,0.8)"
+              strokeWidth={0.3}
+              strokeLinecap="round"
+            />
+            <line
+              x1={shot.x + 0.6}
+              y1={shot.y - 0.6}
+              x2={shot.x - 0.6}
+              y2={shot.y + 0.6}
+              stroke="rgba(239,68,68,0.8)"
+              strokeWidth={0.3}
+              strokeLinecap="round"
+            />
+          </g>
+        )
+      )}
+
+      {/* Transparent tap target overlay */}
+      {interactive && onCourtTap && (
+        <rect
+          x={-halfW - padding}
+          y={-padding}
+          width={COURT_WIDTH + padding * 2}
+          height={HALF_COURT_DEPTH + padding * 2}
+          fill="transparent"
+          onPointerDown={e => handlePointerDown(e, onCourtTap)}
+          style={{ touchAction: 'none', cursor: 'crosshair' }}
+        />
+      )}
+    </svg>
+  )
+}

--- a/src/components/shot-chart/BasketballCourt.tsx
+++ b/src/components/shot-chart/BasketballCourt.tsx
@@ -1,15 +1,19 @@
 import type { ShotRecord } from '../../types'
 import {
   COURT_WIDTH,
-  HALF_COURT_DEPTH,
+  BASELINE_Y,
+  HALFCOURT_Y,
+  BACKBOARD_Y,
+  BACKBOARD_WIDTH,
+  BASKET_RADIUS,
   PAINT_WIDTH,
-  PAINT_DEPTH,
+  FT_LINE_Y,
   FT_CIRCLE_RADIUS,
   RESTRICTED_RADIUS,
   THREE_POINT_RADIUS,
   CORNER_THREE_X,
-  BASKET_RADIUS,
-  BACKBOARD_WIDTH,
+  LANE_MARKS_FROM_BASELINE,
+  BASKET_CENTER_Y,
 } from './courtGeometry'
 
 interface BasketballCourtProps {
@@ -22,54 +26,53 @@ const LINE_COLOR = '#8B6914'
 const LINE_WIDTH = 0.3
 const COURT_BG = '#e8d5b7'
 
-/**
- * Three-point arc path from left corner to right corner.
- * The arc sits at radius 23.75 ft from the basket (origin).
- * Corner threes are straight verticals at x = ±22 from y = 0 up to where the arc begins.
- */
+// Converts from court coordinates (origin at basket, +y toward half-court)
+// to SVG coordinates (origin at top-left, +y downward).
+// SVG y = HALFCOURT_Y - court y  →  basket (court y=0) maps to bottom area,
+// half-court line (court y=HALFCOURT_Y) maps to y=0 (top).
+function cy(courtY: number): number {
+  return HALFCOURT_Y - courtY
+}
+
 function threePointArcPath(): string {
   const r = THREE_POINT_RADIUS
   const cx = CORNER_THREE_X
-
-  // y where the arc starts (at x = ±22): y = sqrt(r^2 - 22^2)
   const arcStartY = Math.sqrt(r * r - cx * cx)
 
-  // Left corner vertical: from (−22, 0) up to (−22, arcStartY)
-  // Then arc from (−22, arcStartY) around to (22, arcStartY)
-  // Then right corner vertical: from (22, arcStartY) down to (22, 0)
+  // Corner verticals from baseline up to where the arc starts,
+  // then arc sweeping across. In SVG-y the arc start is higher (smaller y).
   return [
-    `M ${-cx} 0`,
-    `L ${-cx} ${arcStartY}`,
-    `A ${r} ${r} 0 0 1 ${cx} ${arcStartY}`,
-    `L ${cx} 0`,
+    `M ${-cx} ${cy(BASELINE_Y)}`,
+    `L ${-cx} ${cy(arcStartY)}`,
+    `A ${r} ${r} 0 0 0 ${cx} ${cy(arcStartY)}`,
+    `L ${cx} ${cy(BASELINE_Y)}`,
   ].join(' ')
 }
 
-/** Restricted area: semicircle at radius 4 ft from basket (0,0), from left to right. */
 function restrictedAreaPath(): string {
   const r = RESTRICTED_RADIUS
-  return `M ${-r} 0 A ${r} ${r} 0 0 1 ${r} 0`
+  // Semicircle above the basket in court-space (toward half-court).
+  // In SVG-y that means smaller y values → sweep flag 1.
+  return `M ${-r} ${cy(0)} A ${r} ${r} 0 0 1 ${r} ${cy(0)}`
 }
 
-/** Free throw circle top half (solid) — semicircle above y = 19 */
 function ftCircleTopPath(): string {
   const r = FT_CIRCLE_RADIUS
-  const cy = PAINT_DEPTH
-  return `M ${-r} ${cy} A ${r} ${r} 0 0 1 ${r} ${cy}`
+  // "Top half" of the FT circle = the part farther from the basket (toward half-court)
+  // In SVG-y that means smaller y values → use sweep flag 0
+  return `M ${-r} ${cy(FT_LINE_Y)} A ${r} ${r} 0 0 0 ${r} ${cy(FT_LINE_Y)}`
 }
 
-/** Free throw circle bottom half (dashed) — semicircle below y = 19 */
 function ftCircleBottomPath(): string {
   const r = FT_CIRCLE_RADIUS
-  const cy = PAINT_DEPTH
-  return `M ${-r} ${cy} A ${r} ${r} 0 0 0 ${r} ${cy}`
+  // "Bottom half" = the part closer to the basket → larger SVG y values → sweep flag 1
+  return `M ${-r} ${cy(FT_LINE_Y)} A ${r} ${r} 0 0 1 ${r} ${cy(FT_LINE_Y)}`
 }
 
-/** Half-court circle bottom half — at (0, 47), radius 6 ft */
 function halfCourtCirclePath(): string {
   const r = FT_CIRCLE_RADIUS
-  const cy = HALF_COURT_DEPTH
-  return `M ${-r} ${cy} A ${r} ${r} 0 0 0 ${r} ${cy}`
+  // The visible half is the part that bulges into the court (downward in SVG-y) → sweep flag 1
+  return `M ${-r} ${cy(HALFCOURT_Y)} A ${r} ${r} 0 0 1 ${r} ${cy(HALFCOURT_Y)}`
 }
 
 function handlePointerDown(
@@ -84,9 +87,10 @@ function handlePointerDown(
   const ctm = svg.getScreenCTM()
   if (!ctm) return
   const svgPt = pt.matrixTransform(ctm.inverse())
+  // Convert SVG-y back to court-y for the callback
   onCourtTap(
     Math.round(svgPt.x * 10) / 10,
-    Math.round(svgPt.y * 10) / 10
+    Math.round((HALFCOURT_Y - svgPt.y) * 10) / 10
   )
 }
 
@@ -94,10 +98,17 @@ export default function BasketballCourt({ shots, onCourtTap, className }: Basket
   const interactive = Boolean(onCourtTap)
   const halfW = COURT_WIDTH / 2
   const padding = 2
+  const halfPaintW = PAINT_WIDTH / 2
+
+  const svgCourtTop = cy(HALFCOURT_Y)    // 0
+  const svgCourtBottom = cy(BASELINE_Y)  // HALFCOURT_Y - BASELINE_Y
+  const courtH = svgCourtBottom - svgCourtTop
+  const viewW = COURT_WIDTH + padding * 2
+  const viewH = courtH + padding * 2
 
   return (
     <svg
-      viewBox={`${-halfW - padding} ${-padding} ${COURT_WIDTH + padding * 2} ${HALF_COURT_DEPTH + padding * 2}`}
+      viewBox={`${-halfW - padding} ${svgCourtTop - padding} ${viewW} ${viewH}`}
       preserveAspectRatio="xMidYMid meet"
       className={className}
       style={{ width: '100%', height: 'auto', display: 'block' }}
@@ -105,9 +116,9 @@ export default function BasketballCourt({ shots, onCourtTap, className }: Basket
       {/* Court background */}
       <rect
         x={-halfW}
-        y={0}
+        y={svgCourtTop}
         width={COURT_WIDTH}
-        height={HALF_COURT_DEPTH}
+        height={courtH}
         fill={COURT_BG}
         stroke={LINE_COLOR}
         strokeWidth={LINE_WIDTH}
@@ -116,20 +127,28 @@ export default function BasketballCourt({ shots, onCourtTap, className }: Basket
       <g stroke={LINE_COLOR} strokeWidth={LINE_WIDTH} fill="none">
         {/* Paint / lane */}
         <rect
-          x={-PAINT_WIDTH / 2}
-          y={0}
+          x={-halfPaintW}
+          y={cy(FT_LINE_Y)}
           width={PAINT_WIDTH}
-          height={PAINT_DEPTH}
+          height={cy(BASELINE_Y) - cy(FT_LINE_Y)}
         />
 
-        {/* Free throw circle — top half solid */}
+        {/* Lane hash marks */}
+        {LANE_MARKS_FROM_BASELINE.map(d => {
+          const svgY = cy(d - BASKET_CENTER_Y)
+          return (
+            <g key={d}>
+              <line x1={-halfPaintW - 0.5} y1={svgY} x2={-halfPaintW} y2={svgY} strokeWidth={0.25} />
+              <line x1={halfPaintW} y1={svgY} x2={halfPaintW + 0.5} y2={svgY} strokeWidth={0.25} />
+            </g>
+          )
+        })}
+
+        {/* Free throw circle — top half solid (farther from basket) */}
         <path d={ftCircleTopPath()} />
 
-        {/* Free throw circle — bottom half dashed */}
-        <path
-          d={ftCircleBottomPath()}
-          strokeDasharray="1.0 0.8"
-        />
+        {/* Free throw circle — bottom half dashed (closer to basket) */}
+        <path d={ftCircleBottomPath()} strokeDasharray="1.0 0.8" />
 
         {/* Restricted area arc */}
         <path d={restrictedAreaPath()} />
@@ -138,30 +157,25 @@ export default function BasketballCourt({ shots, onCourtTap, className }: Basket
         <path d={threePointArcPath()} />
 
         {/* Half-court line */}
-        <line
-          x1={-halfW}
-          y1={HALF_COURT_DEPTH}
-          x2={halfW}
-          y2={HALF_COURT_DEPTH}
-        />
+        <line x1={-halfW} y1={cy(HALFCOURT_Y)} x2={halfW} y2={cy(HALFCOURT_Y)} />
 
-        {/* Half-court circle (bottom half only, visible inside the court) */}
+        {/* Half-court circle */}
         <path d={halfCourtCirclePath()} />
 
         {/* Backboard */}
         <line
           x1={-BACKBOARD_WIDTH / 2}
-          y1={-0.5}
+          y1={cy(BACKBOARD_Y)}
           x2={BACKBOARD_WIDTH / 2}
-          y2={-0.5}
-          strokeWidth={0.4}
+          y2={cy(BACKBOARD_Y)}
+          strokeWidth={0.5}
         />
 
         {/* Basket (rim) */}
-        <circle cx={0} cy={0} r={BASKET_RADIUS} strokeWidth={0.25} />
+        <circle cx={0} cy={cy(0)} r={BASKET_RADIUS} strokeWidth={0.3} />
 
         {/* Connector from backboard to rim */}
-        <line x1={0} y1={-0.5} x2={0} y2={-BASKET_RADIUS} strokeWidth={0.15} />
+        <line x1={0} y1={cy(BACKBOARD_Y)} x2={0} y2={cy(0) + BASKET_RADIUS} strokeWidth={0.2} />
       </g>
 
       {/* Shot markers */}
@@ -170,7 +184,7 @@ export default function BasketballCourt({ shots, onCourtTap, className }: Basket
           <circle
             key={shot.id}
             cx={shot.x}
-            cy={shot.y}
+            cy={cy(shot.y)}
             r={0.8}
             fill="rgba(34,197,94,0.8)"
             stroke="rgba(22,163,74,0.9)"
@@ -180,18 +194,18 @@ export default function BasketballCourt({ shots, onCourtTap, className }: Basket
           <g key={shot.id}>
             <line
               x1={shot.x - 0.6}
-              y1={shot.y - 0.6}
+              y1={cy(shot.y) - 0.6}
               x2={shot.x + 0.6}
-              y2={shot.y + 0.6}
+              y2={cy(shot.y) + 0.6}
               stroke="rgba(239,68,68,0.8)"
               strokeWidth={0.3}
               strokeLinecap="round"
             />
             <line
               x1={shot.x + 0.6}
-              y1={shot.y - 0.6}
+              y1={cy(shot.y) - 0.6}
               x2={shot.x - 0.6}
-              y2={shot.y + 0.6}
+              y2={cy(shot.y) + 0.6}
               stroke="rgba(239,68,68,0.8)"
               strokeWidth={0.3}
               strokeLinecap="round"
@@ -204,9 +218,9 @@ export default function BasketballCourt({ shots, onCourtTap, className }: Basket
       {interactive && onCourtTap && (
         <rect
           x={-halfW - padding}
-          y={-padding}
-          width={COURT_WIDTH + padding * 2}
-          height={HALF_COURT_DEPTH + padding * 2}
+          y={svgCourtTop - padding}
+          width={viewW}
+          height={viewH}
           fill="transparent"
           onPointerDown={e => handlePointerDown(e, onCourtTap)}
           style={{ touchAction: 'none', cursor: 'crosshair' }}

--- a/src/components/shot-chart/courtGeometry.ts
+++ b/src/components/shot-chart/courtGeometry.ts
@@ -1,30 +1,51 @@
 import type { ShotZone } from '../../types'
 
+// Overall half-court dimensions (feet)
 export const COURT_WIDTH = 50
 export const HALF_COURT_DEPTH = 47
-export const THREE_POINT_RADIUS = 23.75
-export const CORNER_THREE_X = 22
-export const CORNER_THREE_Y = 14
-export const RESTRICTED_RADIUS = 4
-export const PAINT_WIDTH = 12
-export const PAINT_DEPTH = 19
-export const FT_LINE_Y = 19
+
+// Basket center is 5.25' from baseline (4' backboard offset + 1.25' to rim center).
+// All SVG coordinates are basket-centered: origin (0,0) = center of the rim.
+export const BASKET_CENTER_Y = 5.25
+export const BASELINE_Y = -BASKET_CENTER_Y                         // -5.25
+export const HALFCOURT_Y = HALF_COURT_DEPTH - BASKET_CENTER_Y      // 41.75
+
+// Backboard: face is 4' from baseline → 1.25' behind basket center
+export const BACKBOARD_Y = -(BASKET_CENTER_Y - 4)                  // -1.25
+export const BACKBOARD_WIDTH = 6                                    // 72" = 6'
+
+// Basket (rim)
+export const BASKET_RADIUS = 0.75                                   // 18" diameter
+
+// Paint / lane: 16' wide (NBA), 19' deep from baseline to free-throw line
+export const PAINT_WIDTH = 16
+export const PAINT_DEPTH_FROM_BASELINE = 19
+export const FT_LINE_Y = PAINT_DEPTH_FROM_BASELINE - BASKET_CENTER_Y  // 13.75
+
+// Free-throw circle: 6' radius, centered on the FT line
 export const FT_CIRCLE_RADIUS = 6
-export const BASKET_RADIUS = 0.75
-export const BACKBOARD_WIDTH = 6
+
+// Restricted area: 4' radius arc from basket center
+export const RESTRICTED_RADIUS = 4
+
+// Three-point line
+export const THREE_POINT_RADIUS = 23.75                             // 23'9"
+export const CORNER_THREE_X = 22                                    // 3' from sideline
+
+// Lane hash marks (rebounding/block positions) — distances from baseline
+export const LANE_MARKS_FROM_BASELINE = [7, 8, 11, 14]
 
 export function isThreePointer(x: number, y: number): boolean {
-  if (Math.abs(x) >= CORNER_THREE_X && y <= CORNER_THREE_Y) {
-    return true
-  }
-  const distFromBasket = Math.sqrt(x * x + y * y)
-  return distFromBasket > THREE_POINT_RADIUS
+  // Corner three: beyond the straight vertical at x = ±22
+  if (Math.abs(x) >= CORNER_THREE_X) return true
+  // Arc three: beyond the 23.75' arc
+  return Math.sqrt(x * x + y * y) > THREE_POINT_RADIUS
 }
 
 export function classifyShotZone(x: number, y: number): ShotZone {
   const dist = Math.sqrt(x * x + y * y)
   if (dist <= RESTRICTED_RADIUS) return 'restricted'
-  if (Math.abs(x) <= PAINT_WIDTH / 2 && y <= PAINT_DEPTH) return 'paint'
+  if (Math.abs(x) <= PAINT_WIDTH / 2 && y <= FT_LINE_Y) return 'paint'
   if (isThreePointer(x, y)) return 'three'
   return 'mid_range'
 }

--- a/src/components/shot-chart/courtGeometry.ts
+++ b/src/components/shot-chart/courtGeometry.ts
@@ -1,0 +1,30 @@
+import type { ShotZone } from '../../types'
+
+export const COURT_WIDTH = 50
+export const HALF_COURT_DEPTH = 47
+export const THREE_POINT_RADIUS = 23.75
+export const CORNER_THREE_X = 22
+export const CORNER_THREE_Y = 14
+export const RESTRICTED_RADIUS = 4
+export const PAINT_WIDTH = 12
+export const PAINT_DEPTH = 19
+export const FT_LINE_Y = 19
+export const FT_CIRCLE_RADIUS = 6
+export const BASKET_RADIUS = 0.75
+export const BACKBOARD_WIDTH = 6
+
+export function isThreePointer(x: number, y: number): boolean {
+  if (Math.abs(x) >= CORNER_THREE_X && y <= CORNER_THREE_Y) {
+    return true
+  }
+  const distFromBasket = Math.sqrt(x * x + y * y)
+  return distFromBasket > THREE_POINT_RADIUS
+}
+
+export function classifyShotZone(x: number, y: number): ShotZone {
+  const dist = Math.sqrt(x * x + y * y)
+  if (dist <= RESTRICTED_RADIUS) return 'restricted'
+  if (Math.abs(x) <= PAINT_WIDTH / 2 && y <= PAINT_DEPTH) return 'paint'
+  if (isThreePointer(x, y)) return 'three'
+  return 'mid_range'
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,16 @@
+export type ShotZone = 'restricted' | 'paint' | 'mid_range' | 'three'
+
+export interface ShotRecord {
+  id: string
+  x: number
+  y: number
+  made: boolean
+  shotType: '2pt' | '3pt'
+  zone: ShotZone
+  playerId: string
+  timestamp: number
+}
+
 export interface StatAction {
   id: string
   label: string
@@ -53,6 +66,7 @@ export interface SportConfig {
    * Basketball sets `team_foul`.
    */
   teamFoulBaseStatId?: string
+  hasShotChart?: boolean
 }
 
 export interface GameInfo {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the SC-1 basketball court SVG component to use correct NBA regulation dimensions and proper orientation, based on an official court diagram reference.

### What was wrong

The original SVG had several geometry and orientation errors:

| Feature | Old (incorrect) | New (NBA regulation) |
|---|---|---|
| **Court orientation** | Basket at top, half-court at bottom | **Basket at bottom, half-court at top** (standard shot chart layout) |
| **Paint/lane width** | 12' (old NCAA) | **16'** (NBA) |
| **Basket offset** | 0' (rim at baseline) | **5.25'** from baseline (4' backboard + 1.25' rim) |
| **Backboard position** | y = -0.5 (wrong side) | **Between basket and baseline** (4' from baseline) |
| **Free throw line** | y = 19 (from basket) | **y = 13.75** (19' from baseline, basket-centered) |
| **Half-court line** | y = 47 | **y = 41.75** |
| **Corner three lines** | Started at y = 0 | Start at **baseline** |
| **Lane hash marks** | Missing | **Added** at 7, 8, 11, 14 ft from baseline |
| **Restricted area arc** | Wrong direction | **Curves toward court center** |

### Changes

- **`src/components/shot-chart/courtGeometry.ts`** — Corrected all constants; added `BASKET_CENTER_Y`, `BASELINE_Y`, `HALFCOURT_Y`, `BACKBOARD_Y`, `LANE_MARKS_FROM_BASELINE`; `PAINT_WIDTH` 12→16; simplified `isThreePointer()` and fixed `classifyShotZone()` paint boundary
- **`src/components/shot-chart/BasketballCourt.tsx`** — Complete rewrite of SVG rendering: `cy()` mapping function converts basket-centered court coords to SVG-y (basket at bottom); correct arc sweep flags; lane hash marks; backboard/connector properly positioned
- **`docs/DESIGN_SHOT_CHART.md`** — Updated coordinate system, court features table, and SVG structure
- **`docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md`** — Updated SC-1 constants and rendering description

### Court rendering

[Corrected basketball court SVG — basket at bottom, proper orientation](https://cursor.com/agents/bc-877da1f7-c4f4-4c45-b59a-c51e88941b42/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcourt_corrected_orientation.webp)

Basket/backboard detail (zoomed):

[Zoomed view of basket, backboard, and restricted area](https://cursor.com/agents/bc-877da1f7-c4f4-4c45-b59a-c51e88941b42/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcourt_basket_detail.webp)

### Testing

- `pnpm build` — TypeScript + Vite production build passes
- `pnpm lint` — 0 errors (3 pre-existing warnings)
- Manual visual testing confirmed: correct orientation (basket bottom, half-court top), 16' wide paint, proper backboard/basket/connector positioning, restricted area curving toward court center, lane hash marks, shot markers at correct positions

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-877da1f7-c4f4-4c45-b59a-c51e88941b42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-877da1f7-c4f4-4c45-b59a-c51e88941b42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

