### PR TITLE
feat(shot-chart): SC-2 prep — route, Game Tracker link, coordinate contract

### DIFF
--- a/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
+++ b/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
@@ -112,12 +112,20 @@ SC-5  Game Summary      │
 
 **Blocks:** SC-4, SC-5
 
+**Already done (SC-2 prep, before interaction work):**
+
+- **`src/App.tsx`:** `<Route path="/shot-chart" element={<ShotChart />} />` — in production this is **`#/shot-chart`** (HashRouter).
+- **`src/pages/ShotChart.tsx`:** Shell page: guard (basketball + `gameInfo`), "← Back to Stats" → `/game`, empty court placeholder. SC-2 fills in recording UI.
+- **`src/pages/GameTracker.tsx`:** Full-width **Shot chart** button when `sport.id === 'basketball'`, below scoreboard, `navigate('/shot-chart')`.
+- **Coordinate contract:** `src/lib/shotChartCoordinates.ts` documents feet-from-rim space; `ShotRecord` in `types.ts` references it; `BasketballCourt.tsx` header points to the same. Taps must feed `isThreePointer` / `classifyShotZone` without transforming `x`/`y`.
+- **QA:** `/#/dev/shot-chart` preview and dev auth bypass unchanged; remove in a later cleanup SC.
+
 **What to do:**
 
-1. **New: `src/pages/ShotChart.tsx`** — Full-screen shot chart page:
+1. **`src/pages/ShotChart.tsx`** — Full-screen shot chart page (extend the shell):
    - Reads `sport`, `players`, `activePlayerId` from `GameContext`
-   - Guard: redirect to `/` if not basketball or no game in progress
-   - **Header**: "← Back to Stats" button (navigates to `/game`), optional "Clear All" button
+   - Guard: already redirects to `/` if not basketball or no game in progress
+   - **Header**: optional "Clear All" button (in addition to existing "← Back to Stats")
    - **Mode toggle**: "Made" / "Missed" segmented control (local state: `mode: 'made' | 'missed'`)
      - Made: green background when active
      - Missed: red background when active
@@ -136,24 +144,17 @@ SC-5  Game Summary      │
      - Paint: M/A (pct%) | Mid: M/A (pct%) | 3PT: M/A (pct%) | Total: M/A (pct%)
    - **Undo**: "↩ Undo Last Shot" button removes the last shot from local state
 
-2. **`src/App.tsx`** — Add route:
-   ```tsx
-   <Route path="/shot-chart" element={<ShotChart />} />
-   ```
+2. **`src/App.tsx`** — Route already added (`/shot-chart`).
 
-3. **`src/pages/GameTracker.tsx`** — Add "Shot Chart" button:
-   - Only visible when `sport.id === 'basketball'` (or use `sport.hasShotChart` flag once added)
-   - Placed below the scoreboard, above the stat grid
-   - Navigates to `/shot-chart`
-   - Styled prominently: full-width button with basketball icon
+3. **`src/pages/GameTracker.tsx`** — Entry button already added (basketball only).
 
-4. **`src/config/sports.ts`** — Add `hasShotChart?: boolean` to the basketball sport config (set to `true`). Add the field to `SportConfig` interface in `types.ts`.
+4. **`src/config/sports.ts`** — Optional: `hasShotChart` on `SportConfig` — **skipped for MVP**; basketball-only via `sport.id === 'basketball'`.
 
-**Files touched:** new `src/pages/ShotChart.tsx`, `src/App.tsx`, `src/pages/GameTracker.tsx`, `src/config/sports.ts`, `src/types.ts`
+**Files touched (remaining SC-2 work):** primarily `src/pages/ShotChart.tsx`; optionally `src/config/sports.ts` / `types.ts` if adding `hasShotChart` later.
 
 **Test breakpoint:**
-- Start a basketball game → see "🏀 Shot Chart" button on Game Tracker
-- Tap button → full-screen court loads with mode toggle and player selector
+- Start a basketball game → see **Shot chart** button on Game Tracker
+- Tap button → full-screen court loads; then add mode toggle and player selector
 - Toggle to "Made" → tap court → green circle appears at tapped location
 - Toggle to "Missed" → tap court → red X appears
 - Shooting summary shows correct counts and percentages

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import PlayerProfile from './pages/PlayerProfile'
 import CareerStats from './pages/CareerStats'
 import TeamStats from './pages/TeamStats'
 import TournamentStats from './pages/TournamentStats'
+import ShotChart from './pages/ShotChart'
 import ShotChartPreview from './pages/ShotChartPreview'
 
 function AppRoutes() {
@@ -54,6 +55,7 @@ function AppRoutes() {
           <Route path="/players" element={<PlayerSetup />} />
           <Route path="/checkout" element={<GameCheckout />} />
           <Route path="/game" element={<GameTracker />} />
+          <Route path="/shot-chart" element={<ShotChart />} />
           <Route path="/summary" element={<GameSummary />} />
           <Route path="/admin" element={<Admin />} />
           <Route path="/teams" element={<Teams />} />

--- a/src/components/shot-chart/BasketballCourt.tsx
+++ b/src/components/shot-chart/BasketballCourt.tsx
@@ -1,3 +1,7 @@
+/**
+ * Half-court SVG. Tap and marker `(x, y)` are feet in rim-centered space — see
+ * `src/lib/shotChartCoordinates.ts`.
+ */
 import type { ShotRecord } from '../../types'
 import {
   COURT_WIDTH,

--- a/src/lib/shotChartCoordinates.ts
+++ b/src/lib/shotChartCoordinates.ts
@@ -1,0 +1,14 @@
+/**
+ * ## Shot chart court coordinates (feet)
+ *
+ * `BasketballCourt` draws and reports taps in this single space. **`ShotRecord.x` /
+ * `ShotRecord.y` must use the same numbers** with no extra flip, scale, or offset.
+ *
+ * - **Origin `(0, 0)`:** center of the rim.
+ * - **+y:** toward the half-court line (deeper on the half-court diagram).
+ * - **Baseline** (out of bounds behind the hoop): **negative y** (`BASELINE_Y` in `courtGeometry.ts`).
+ *
+ * When creating a shot from a tap, pass `(x, y)` into `isThreePointer` and `classifyShotZone`
+ * from `src/components/shot-chart/courtGeometry.ts` unchanged.
+ */
+export {}

--- a/src/pages/GameTracker.tsx
+++ b/src/pages/GameTracker.tsx
@@ -247,6 +247,17 @@ export default function GameTracker() {
         </div>
 
         <Scoreboard />
+
+        {sport.id === 'basketball' && (
+          <button
+            type="button"
+            onClick={() => navigate('/shot-chart')}
+            className="mt-3 w-full py-3 rounded-xl font-semibold text-white shadow-md active:scale-[0.99] transition-transform
+                       bg-gradient-to-r from-orange-500 to-amber-600 border border-orange-600/30"
+          >
+            Shot chart
+          </button>
+        )}
       </div>
 
       <div className="px-3 py-2 max-w-lg mx-auto w-full">

--- a/src/pages/ShotChart.tsx
+++ b/src/pages/ShotChart.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useGame } from '../context/GameContext'
+import BasketballCourt from '../components/shot-chart/BasketballCourt'
+
+/**
+ * Full-screen shot chart (SC-2 will add mode toggle, taps → ShotRecords, summary, etc.).
+ * URL: `#/shot-chart` (HashRouter). Requires an in-progress basketball game.
+ */
+export default function ShotChart() {
+  const navigate = useNavigate()
+  const { state } = useGame()
+  const { sport, gameInfo } = state
+
+  const allowed = Boolean(sport && sport.id === 'basketball' && gameInfo)
+
+  useEffect(() => {
+    if (!allowed) {
+      navigate('/', { replace: true })
+    }
+  }, [allowed, navigate])
+
+  if (!allowed) {
+    return null
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-slate-50">
+      <div className="px-3 pt-3 pb-2 max-w-lg mx-auto w-full">
+        <button
+          type="button"
+          onClick={() => navigate('/game')}
+          className="text-sm text-slate-500 font-medium active:scale-95 transition-transform"
+        >
+          ← Back to Stats
+        </button>
+        <h1 className="mt-2 text-lg font-semibold text-slate-800">Shot chart</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          SC-2 adds recording and summaries. Tap coordinates are feet from the rim — see{' '}
+          <code className="text-xs bg-slate-100 px-1 rounded">src/lib/shotChartCoordinates.ts</code>.
+        </p>
+      </div>
+      <div className="px-3 pb-6 max-w-lg mx-auto w-full flex-1 flex flex-col">
+        <div className="rounded-xl bg-white border border-slate-200 p-3 shadow-sm mt-2">
+          <BasketballCourt shots={[]} className="w-full" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type ShotZone = 'restricted' | 'paint' | 'mid_range' | 'three'
 
+/** Location on the half-court diagram in feet; same system as `BasketballCourt` taps. @see `src/lib/shotChartCoordinates.ts` */
 export interface ShotRecord {
   id: string
   x: number


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares SC-2 without implementing recording UI yet.

- **`#/shot-chart`:** `Route path="/shot-chart"` → `ShotChart` (HashRouter). Shell: basketball + in-progress guard, back to `/game`, court placeholder.
- **Game Tracker:** Full-width **Shot chart** button when `sport.id === 'basketball'`, under the scoreboard.
- **Coordinate contract:** `src/lib/shotChartCoordinates.ts` documents rim-centered feet; `ShotRecord` JSDoc links to it; `BasketballCourt` file comment points to the same.
- **QA unchanged:** `/#/dev/shot-chart` and dev auth bypass for that hash.

## Docs

`DESIGN_SHOT_CHART_IMPLEMENTATION.md` SC-2 section updated with “already done” vs remaining work; `hasShotChart` called out as skipped for MVP.

## Verification

`pnpm build`, `pnpm lint` (existing context warnings only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

