### PR TITLE
feat(shot-chart): SC-3 — shotChart in GameState, ADD_SHOT, undo linkage

### DIFF
--- a/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
+++ b/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
@@ -175,39 +175,19 @@ SC-5  Game Summary      │
 
 **Blocks:** SC-4, SC-6
 
-**What to do:**
+**Implemented:**
 
-1. **`src/types.ts`**:
-   - Add `shotChart: ShotRecord[]` to `GameState`
-   - Add `shotId?: string` to `ActionLogEntry`
-   - Add new action types to `GameAction`:
-     ```typescript
-     | { type: 'ADD_SHOT'; shot: ShotRecord }
-     | { type: 'REMOVE_LAST_SHOT' }
-     ```
+1. **`src/types.ts`** — `GameState.shotChart`, `ActionLogEntry.shotId`, `ADD_SHOT` / `REMOVE_LAST_SHOT` on `GameAction`.
 
-2. **`src/context/GameContext.tsx`**:
-   - Initialize `shotChart: []` in `createInitialState()`
-   - Handle `ADD_SHOT` in reducer:
-     - Append shot to `shotChart`
-     - Also increment the corresponding stat (`2pt`, `2pt_miss`, `3pt`, `3pt_miss`) for `shot.playerId`
-     - Create an `ActionLogEntry` with `shotId: shot.id` for undo linkage
-   - Handle `REMOVE_LAST_SHOT`:
-     - Pop the last shot from `shotChart`
-     - This is a convenience action for the shot chart page (alternative to full UNDO)
-   - Update `UNDO` handler:
-     - When the last action has a `shotId`, also remove the matching `ShotRecord` from `shotChart`
-   - Include `shotChart` in `loadState()` deserialization (default to `[]` if missing)
-   - Include `shotChart` in localStorage persistence
-   - Include shot data in `buildSyncFingerprint()` so changes trigger cloud sync
+2. **`src/context/GameContext.tsx`** — `shotChart: []` in `createInitialState`, cloud hydrate, `loadState` default; `ADD_SHOT` appends shot, increments `2pt` / `2pt_miss` / `3pt` / `3pt_miss`, logs `increment` with `shotId`; `UNDO` on `increment` with `shotId` filters that shot from `shotChart`; `REMOVE_LAST_SHOT` pops last shot and reverts stat when the last log entry matches that shot; `buildSyncFingerprint` includes `shotChart`.
 
-3. **`src/pages/ShotChart.tsx`** — Wire to GameContext:
-   - Replace local state with `state.shotChart` from context
-   - On court tap: dispatch `ADD_SHOT` instead of updating local state
-   - On undo: dispatch `UNDO` (which handles both the shot and the stat)
-   - Filter displayed shots by the shot chart's active context (all shots for now; per-player filtering is v2)
+3. **`src/pages/ShotChart.tsx`** — Renders `state.shotChart`, `onCourtTap` → `ADD_SHOT` (uses `isThreePointer` / `classifyShotZone` on tap `x,y`), made/missed toggle + player strip; **Undo** dispatches `UNDO` (same as Game Tracker for shot-originated increments).
 
-**Files touched:** `src/types.ts`, `src/context/GameContext.tsx`, `src/pages/ShotChart.tsx`
+4. **Cloud open-game hydrates** (`Games.tsx`, `PlayerProfile.tsx`, `CareerStats.tsx`) — `shotChart: []` on fresh hydrate (chart data still SC-6).
+
+**Remaining (later work units):** SC-4 polish (dedicated “undo last shot” copy, `REMOVE_LAST_SHOT` UX); SC-5 summary; SC-6 persist `shotChart` to Supabase.
+
+**Files touched:** `src/types.ts`, `src/context/GameContext.tsx`, `src/pages/ShotChart.tsx`, `Games.tsx`, `PlayerProfile.tsx`, `CareerStats.tsx`
 
 **Test breakpoint:**
 - Start a basketball game → add players → go to shot chart

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -14,6 +14,7 @@ import type {
   ActionLogEntry,
   CloudSyncState,
   CloudSyncStatus,
+  ShotRecord,
 } from '../types'
 import { useAuth } from './AuthContext'
 import {
@@ -86,6 +87,7 @@ function createInitialState(status: CloudSyncStatus = 'idle'): GameState {
     cloudSync: createInitialCloudSyncState(status),
     currentPeriod: 1,
     teamStatsConfig: null,
+    shotChart: [],
   }
 }
 
@@ -101,6 +103,14 @@ function generateId(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 7)
 }
 
+/** Stat key to increment when adding a shot from the chart. */
+function statIdForShotRecord(shot: ShotRecord): string {
+  if (shot.shotType === '3pt') {
+    return shot.made ? '3pt' : '3pt_miss'
+  }
+  return shot.made ? '2pt' : '2pt_miss'
+}
+
 function buildSyncFingerprint(state: GameState): string {
   return JSON.stringify({
     sportId: state.sport?.id ?? null,
@@ -110,6 +120,7 @@ function buildSyncFingerprint(state: GameState): string {
     homeScoreAdjustment: state.homeScoreAdjustment,
     notes: state.notes,
     teamStatsConfig: state.teamStatsConfig,
+    shotChart: state.shotChart,
     players: state.players.map(player => ({
       id: player.id,
       name: player.name,
@@ -202,6 +213,7 @@ function buildHydratedStateFromCloudGame(
     currentPeriod: 1,
     teamStatsConfig: cloudGame.teamStatsConfig,
     actionLog: [],
+    shotChart: [],
     cloudSync: {
       ...createInitialCloudSyncState('synced'),
       seasonId: cloudGame.seasonId ?? null,
@@ -270,6 +282,58 @@ function gameReducer(state: GameState, action: GameAction): GameState {
 
     case 'SET_ACTIVE_PLAYER':
       return { ...state, activePlayerId: action.playerId }
+
+    case 'ADD_SHOT': {
+      const shot = action.shot
+      const player = state.players.find(p => p.id === shot.playerId)
+      if (!player) return state
+      const statId = statIdForShotRecord(shot)
+      const prevValue = player.stats[statId] || 0
+      const logEntry: ActionLogEntry = {
+        id: generateId(),
+        timestamp: Date.now(),
+        type: 'increment',
+        playerId: shot.playerId,
+        statId,
+        previousValue: prevValue,
+        shotId: shot.id,
+      }
+      return {
+        ...state,
+        shotChart: [...state.shotChart, shot],
+        players: state.players.map(p =>
+          p.id === shot.playerId
+            ? { ...p, stats: { ...p.stats, [statId]: prevValue + 1 } }
+            : p
+        ),
+        actionLog: [...state.actionLog, logEntry],
+      }
+    }
+
+    case 'REMOVE_LAST_SHOT': {
+      if (state.shotChart.length === 0) return state
+      const popped = state.shotChart[state.shotChart.length - 1]
+      const nextShots = state.shotChart.slice(0, -1)
+      const last = state.actionLog[state.actionLog.length - 1]
+      if (
+        last?.type === 'increment' &&
+        last.shotId === popped.id &&
+        last.playerId === popped.playerId &&
+        last.statId === statIdForShotRecord(popped)
+      ) {
+        return {
+          ...state,
+          shotChart: nextShots,
+          actionLog: state.actionLog.slice(0, -1),
+          players: state.players.map(p =>
+            p.id === last.playerId
+              ? { ...p, stats: { ...p.stats, [last.statId!]: last.previousValue } }
+              : p
+          ),
+        }
+      }
+      return { ...state, shotChart: nextShots }
+    }
 
     case 'INCREMENT_STAT': {
       const player = state.players.find(p => p.id === action.playerId)
@@ -438,6 +502,12 @@ function gameReducer(state: GameState, action: GameAction): GameState {
                 : p
             ),
           }
+          if (lastAction.type === 'increment' && lastAction.shotId) {
+            newState = {
+              ...newState,
+              shotChart: newState.shotChart.filter(s => s.id !== lastAction.shotId),
+            }
+          }
           break
         case 'opponent_score_up':
         case 'opponent_score_down':
@@ -512,6 +582,7 @@ function loadState(): GameState {
         ? Math.floor(parsed.currentPeriod)
         : 1,
     teamStatsConfig: parsed.teamStatsConfig ?? null,
+    shotChart: Array.isArray(parsed.shotChart) ? parsed.shotChart : [],
     players: Array.isArray(parsed.players) ? parsed.players : [],
     actionLog: Array.isArray(parsed.actionLog) ? parsed.actionLog : [],
     cloudSync: {

--- a/src/pages/CareerStats.tsx
+++ b/src/pages/CareerStats.tsx
@@ -286,6 +286,7 @@ export default function CareerStats() {
         currentPeriod: 1,
         teamStatsConfig: null,
         actionLog: [],
+        shotChart: [],
         cloudSync: {
           seasonId: cloudGame.seasonId ?? null,
           teamId: cloudGame.teamId,

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -233,6 +233,7 @@ export default function Games() {
       currentPeriod: 1,
       teamStatsConfig: null,
       actionLog: [],
+      shotChart: [],
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,
         teamId: cloudGame.teamId,

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -284,6 +284,7 @@ export default function PlayerProfile() {
       currentPeriod: 1,
       teamStatsConfig: null,
       actionLog: [],
+      shotChart: [],
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,
         teamId: cloudGame.teamId,

--- a/src/pages/ShotChart.tsx
+++ b/src/pages/ShotChart.tsx
@@ -1,16 +1,37 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGame } from '../context/GameContext'
 import BasketballCourt from '../components/shot-chart/BasketballCourt'
+import { classifyShotZone, isThreePointer } from '../components/shot-chart/courtGeometry'
+import {
+  isTeamPseudoPlayer,
+  TEAM_PLAYER_HOME_ID,
+  TEAM_PLAYER_OPP_ID,
+} from '../lib/teamPlayers'
+import type { Player, ShotRecord } from '../types'
+
+function sortTeamPlayersFirst(players: Player[]): Player[] {
+  const teams = players.filter(isTeamPseudoPlayer)
+  const home = teams.find(p => p.id === TEAM_PLAYER_HOME_ID || p.teamSide === 'home')
+  const opp = teams.find(p => p.id === TEAM_PLAYER_OPP_ID || p.teamSide === 'opponent')
+  const restTeam = teams.filter(p => p !== home && p !== opp)
+  const individuals = players.filter(p => !isTeamPseudoPlayer(p))
+  const orderedTeams = [home, opp, ...restTeam].filter(Boolean) as Player[]
+  return [...orderedTeams, ...individuals]
+}
+
+function newShotId(): string {
+  return `shot_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`
+}
 
 /**
- * Full-screen shot chart (SC-2 will add mode toggle, taps → ShotRecords, summary, etc.).
- * URL: `#/shot-chart` (HashRouter). Requires an in-progress basketball game.
+ * Shot chart: `#/shot-chart`. Taps dispatch `ADD_SHOT` (SC-3); markers use `state.shotChart`.
  */
 export default function ShotChart() {
   const navigate = useNavigate()
-  const { state } = useGame()
-  const { sport, gameInfo } = state
+  const { state, dispatch } = useGame()
+  const { sport, gameInfo, players, activePlayerId, shotChart, actionLog } = state
+  const [mode, setMode] = useState<'made' | 'missed'>('made')
 
   const allowed = Boolean(sport && sport.id === 'basketball' && gameInfo)
 
@@ -19,6 +40,33 @@ export default function ShotChart() {
       navigate('/', { replace: true })
     }
   }, [allowed, navigate])
+
+  const selectorPlayers = useMemo(() => sortTeamPlayersFirst(players), [players])
+  const effectivePlayerId =
+    activePlayerId && players.some(p => p.id === activePlayerId)
+      ? activePlayerId
+      : selectorPlayers[0]?.id ?? null
+
+  const onCourtTap = useCallback(
+    (x: number, y: number) => {
+      if (!effectivePlayerId) return
+      const three = isThreePointer(x, y)
+      const shot: ShotRecord = {
+        id: newShotId(),
+        x,
+        y,
+        made: mode === 'made',
+        shotType: three ? '3pt' : '2pt',
+        zone: classifyShotZone(x, y),
+        playerId: effectivePlayerId,
+        timestamp: Date.now(),
+      }
+      dispatch({ type: 'ADD_SHOT', shot })
+    },
+    [dispatch, effectivePlayerId, mode]
+  )
+
+  const canUndo = actionLog.length > 0
 
   if (!allowed) {
     return null
@@ -35,14 +83,96 @@ export default function ShotChart() {
           ← Back to Stats
         </button>
         <h1 className="mt-2 text-lg font-semibold text-slate-800">Shot chart</h1>
-        <p className="text-sm text-slate-500 mt-1">
-          SC-2 adds recording and summaries. Tap coordinates are feet from the rim — see{' '}
-          <code className="text-xs bg-slate-100 px-1 rounded">src/lib/shotChartCoordinates.ts</code>.
+        <p className="text-xs text-slate-500 mt-1">
+          Tap coordinates are feet from the rim (
+          <code className="bg-slate-100 px-1 rounded">shotChartCoordinates.ts</code>
+          ).
         </p>
+
+        <div className="mt-3 flex rounded-xl border border-slate-200 overflow-hidden shadow-sm">
+          <button
+            type="button"
+            onClick={() => setMode('made')}
+            className={`flex-1 py-2.5 text-sm font-semibold transition-colors ${
+              mode === 'made'
+                ? 'bg-emerald-600 text-white'
+                : 'bg-white text-slate-600 hover:bg-slate-50'
+            }`}
+          >
+            Made
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('missed')}
+            className={`flex-1 py-2.5 text-sm font-semibold transition-colors ${
+              mode === 'missed'
+                ? 'bg-rose-600 text-white'
+                : 'bg-white text-slate-600 hover:bg-slate-50'
+            }`}
+          >
+            Missed
+          </button>
+        </div>
       </div>
+
+      <div className="px-3 py-2 max-w-lg mx-auto w-full">
+        <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide items-stretch">
+          {selectorPlayers.map((player, index) => {
+            const isTeam = isTeamPseudoPlayer(player)
+            const teamCount = selectorPlayers.filter(isTeamPseudoPlayer).length
+            const showDivider = isTeam && index === teamCount - 1 && teamCount > 0
+            const isActive = player.id === effectivePlayerId
+
+            return (
+              <div key={player.id} className="flex flex-shrink-0 items-stretch gap-2">
+                <button
+                  type="button"
+                  onClick={() => dispatch({ type: 'SET_ACTIVE_PLAYER', playerId: player.id })}
+                  title={player.name}
+                  className={`
+                    flex-shrink-0 px-3 py-2 rounded-xl text-sm font-semibold max-w-[10.5rem]
+                    transition-all duration-150 active:scale-95 text-left
+                    ${isTeam
+                      ? isActive
+                        ? `bg-gradient-to-br from-slate-600 to-slate-800 text-white shadow-md ring-2 ring-white/30`
+                        : `bg-gradient-to-br from-slate-100 to-slate-200/90 text-slate-800 border border-slate-300/80 shadow-sm`
+                      : isActive
+                        ? `${sport!.theme.bg} text-white shadow-md`
+                        : 'bg-white text-slate-600 border border-slate-200'
+                    }
+                  `}
+                >
+                  <span className={isTeam ? 'opacity-90' : 'opacity-70'}>
+                    {isTeam ? '★' : `#${player.number || '?'}`}
+                  </span>{' '}
+                  <span className="line-clamp-2 break-words">
+                    {isTeam ? player.name : player.name.split(' ')[0]}
+                  </span>
+                </button>
+                {showDivider && (
+                  <div className="w-px self-stretch min-h-[2.5rem] bg-slate-300 shrink-0" aria-hidden />
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="px-3 pb-2 max-w-lg mx-auto w-full">
+        <button
+          type="button"
+          disabled={!canUndo}
+          onClick={() => dispatch({ type: 'UNDO' })}
+          className="w-full py-2.5 rounded-xl text-sm font-semibold border border-slate-200 bg-white text-slate-700
+                     disabled:opacity-40 disabled:pointer-events-none active:scale-[0.99] transition-transform"
+        >
+          ↩ Undo last action
+        </button>
+      </div>
+
       <div className="px-3 pb-6 max-w-lg mx-auto w-full flex-1 flex flex-col">
-        <div className="rounded-xl bg-white border border-slate-200 p-3 shadow-sm mt-2">
-          <BasketballCourt shots={[]} className="w-full" />
+        <div className="rounded-xl bg-white border border-slate-200 p-3 shadow-sm mt-1">
+          <BasketballCourt shots={shotChart} onCourtTap={onCourtTap} className="w-full" />
         </div>
       </div>
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,8 @@ export interface ActionLogEntry {
   playerId?: string
   statId?: string
   previousValue: number
+  /** When set, `UNDO` also removes the matching row from `GameState.shotChart`. */
+  shotId?: string
   /** For home_team_score_* undo: snapshot before the change. */
   previousHomeTeamScore?: number | null
   previousHomeScoreAdjustment?: number
@@ -152,6 +154,8 @@ export interface GameState {
    * Null when no season or empty config.
    */
   teamStatsConfig: Record<string, unknown> | null
+  /** Location-tagged shots from the shot chart (feet from rim; see `shotChartCoordinates.ts`). */
+  shotChart: ShotRecord[]
 }
 
 export type CloudSyncStatus =
@@ -187,6 +191,8 @@ export type GameAction =
   | { type: 'INCREMENT_HOME_SCORE' }
   | { type: 'DECREMENT_HOME_SCORE' }
   | { type: 'SET_NOTES'; notes: string }
+  | { type: 'ADD_SHOT'; shot: ShotRecord }
+  | { type: 'REMOVE_LAST_SHOT' }
   | { type: 'UNDO' }
   | { type: 'RESET_GAME' }
   | { type: 'SET_CLOUD_SYNC_STATE'; cloudSync: Partial<CloudSyncState> }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **SC-3** from `DESIGN_SHOT_CHART_IMPLEMENTATION.md`: shot chart data lives on `GameState`, taps increment scoring stats, and `UNDO` removes both the stat change and the shot marker when the action was shot-originated.

## Types

- `GameState.shotChart: ShotRecord[]`
- `ActionLogEntry.shotId?: string`
- `GameAction`: `ADD_SHOT`, `REMOVE_LAST_SHOT`

## Reducer (`GameContext`)

- `ADD_SHOT`: append shot, increment `2pt` / `2pt_miss` / `3pt` / `3pt_miss` from `shot.shotType` + `shot.made`, append `increment` log with `shotId`.
- `UNDO`: when reversing `increment` with `shotId`, remove matching shot from `shotChart`.
- `REMOVE_LAST_SHOT`: pop last shot; if last log entry matches that shot, also pop log and revert stat (otherwise chart-only pop — edge case).
- `buildSyncFingerprint` includes `shotChart`; `loadState` restores `shotChart` (default `[]`).
- Cloud hydrate templates: `shotChart: []` (Supabase shot rows still SC-6).

## Shot chart page

- Renders `state.shotChart`; taps dispatch `ADD_SHOT` with `isThreePointer` / `classifyShotZone` on raw tap coordinates.
- Made / Missed toggle, player selector (same ordering as Game Tracker).
- **Undo last action** → `UNDO` (same pipeline as tracker).

## Docs

SC-3 section updated: implemented vs deferred (SC-4 copy, SC-6 cloud).

## Verification

`pnpm build`, `pnpm lint` (existing context warnings only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

