### PR TITLE
feat(shot-chart): SC-4 — undo polish, clear chart, stat tooltips

### DIFF
--- a/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
+++ b/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
@@ -210,29 +210,25 @@ SC-5  Game Summary      │
 
 **Blocks:** SC-5
 
-**What to do:**
+**Implemented:**
 
-1. **Undo on shot chart page**:
-   - The shot chart page has its own "↩ Undo Last Shot" button
-   - This dispatches `UNDO` — the reducer checks if the last action was shot-originated (has `shotId`) and removes both the stat and the shot record
-   - Show the undo label: "Last: #23 2PT Made" or "Last: #11 3PT Missed" (derive from the last shot record)
+1. **`UNDO_LAST_SHOT`** — Only undoes when the last `actionLog` entry has `shotId` (chart-originated increment). **`UNDO`** still reverses any last action (Game Tracker bar).
 
-2. **Stat-button-to-chart awareness**:
-   - When on the Game Tracker and a coach taps the 2PT stat button directly, no shot marker appears (no location data). This is correct — the stat counter increments but the shot chart only shows location-tagged shots.
-   - Document this behavior in a small info tooltip: "Shots recorded via the Shot Chart include location data. Shots recorded via stat buttons do not appear on the chart."
+2. **`applyUndoLastEntry`** — Shared helper used by `UNDO`, `UNDO_LAST_SHOT`, `REMOVE_LAST_SHOT`, and **`CLEAR_SHOT_CHART`**.
 
-3. **Edge case**: Coach records a shot via the chart, then goes to Game Tracker and undoes it there. The `UNDO` in GameContext handles this correctly because the `ActionLogEntry` has a `shotId`. Verify this flow.
+3. **`CLEAR_SHOT_CHART`** — Confirmed on the shot chart page; repeatedly undoes tail log entries while they still match the tail of `shotChart` (reverts chart-shot stats; leaves stat-button-only history intact).
 
-4. **Edge case**: Coach undoes on the shot chart, then goes to Game Tracker. The stat counter should reflect the undo. Verify.
+4. **`REMOVE_LAST_SHOT`** — If the last log line does not match the last shot, only pops `shotChart` (no stat change).
 
-**Files touched:** `src/pages/ShotChart.tsx`, `src/context/GameContext.tsx` (minor tweaks)
+5. **Shot chart UI** — "Undo last shot" + subtitle from last shot log (`Last: #12 2PT Made`, etc.); hint when last action was not chart-originated; **Clear all chart shots** with confirm.
+
+6. **Game Tracker** — `title` tooltip on basketball **2PT / 2PT Miss / 3PT / 3PT Miss / FT / FT Miss** stat tiles: chart records location; grid taps are stats-only.
+
+**Files touched:** `src/types.ts`, `src/context/GameContext.tsx`, `src/pages/ShotChart.tsx`, `src/pages/GameTracker.tsx`
 
 **Test breakpoint:**
-- Record 3 shots via chart → go to Game Tracker → stat counters show 3 shots
-- Undo 1 on Game Tracker → go to chart → only 2 markers visible
-- Record 2 shots via chart → undo on chart → 1 marker remains, stat counter shows 4 total
-- Record shots on chart AND via stat buttons → counts are additive (expected v1 behavior)
-- Clear all shots → stat counters for 2pt/3pt/misses return to values from stat-button-only entries (they won't go to 0 if some were added via buttons)
+- Chart shots + stat-button shots → additive counts; undo last shot only when chart was last; clear chart restores stat-button-only totals for chart-backed stats
+- Undo chart shot from Game Tracker → marker removed (unchanged from SC-3)
 
 **Commit message:** `feat: polish shot chart undo coordination and stat sync edge cases`
 

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -111,6 +111,56 @@ function statIdForShotRecord(shot: ShotRecord): string {
   return shot.made ? '2pt' : '2pt_miss'
 }
 
+/** Revert the last `actionLog` entry (and linked shot when `shotId` is set). Returns null if log empty. */
+function applyUndoLastEntry(state: GameState): GameState | null {
+  if (state.actionLog.length === 0) return null
+  const lastAction = state.actionLog[state.actionLog.length - 1]
+  let newState: GameState = { ...state, actionLog: state.actionLog.slice(0, -1) }
+
+  switch (lastAction.type) {
+    case 'increment':
+    case 'decrement':
+      newState = {
+        ...newState,
+        players: newState.players.map(p =>
+          p.id === lastAction.playerId
+            ? { ...p, stats: { ...p.stats, [lastAction.statId!]: lastAction.previousValue } }
+            : p
+        ),
+      }
+      if (lastAction.type === 'increment' && lastAction.shotId) {
+        newState = {
+          ...newState,
+          shotChart: newState.shotChart.filter(s => s.id !== lastAction.shotId),
+        }
+      }
+      break
+    case 'opponent_score_up':
+    case 'opponent_score_down':
+      newState = { ...newState, opponentScore: lastAction.previousValue }
+      break
+    case 'home_score_up':
+    case 'home_score_down':
+      newState = { ...newState, homeScoreAdjustment: lastAction.previousValue }
+      break
+    case 'home_team_score_up':
+    case 'home_team_score_down':
+      if (lastAction.previousHomeTeamScore == null) {
+        newState = {
+          ...newState,
+          homeTeamScore: null,
+          homeScoreAdjustment: lastAction.previousHomeScoreAdjustment ?? 0,
+        }
+      } else {
+        newState = { ...newState, homeTeamScore: lastAction.previousHomeTeamScore }
+      }
+      break
+    default:
+      return newState
+  }
+  return newState
+}
+
 function buildSyncFingerprint(state: GameState): string {
   return JSON.stringify({
     sportId: state.sport?.id ?? null,
@@ -313,26 +363,41 @@ function gameReducer(state: GameState, action: GameAction): GameState {
     case 'REMOVE_LAST_SHOT': {
       if (state.shotChart.length === 0) return state
       const popped = state.shotChart[state.shotChart.length - 1]
-      const nextShots = state.shotChart.slice(0, -1)
       const last = state.actionLog[state.actionLog.length - 1]
-      if (
+      const logMatchesShot =
         last?.type === 'increment' &&
         last.shotId === popped.id &&
         last.playerId === popped.playerId &&
         last.statId === statIdForShotRecord(popped)
-      ) {
-        return {
-          ...state,
-          shotChart: nextShots,
-          actionLog: state.actionLog.slice(0, -1),
-          players: state.players.map(p =>
-            p.id === last.playerId
-              ? { ...p, stats: { ...p.stats, [last.statId!]: last.previousValue } }
-              : p
-          ),
-        }
+      if (logMatchesShot) {
+        return applyUndoLastEntry(state) ?? state
       }
-      return { ...state, shotChart: nextShots }
+      return { ...state, shotChart: state.shotChart.slice(0, -1) }
+    }
+
+    case 'UNDO_LAST_SHOT': {
+      const last = state.actionLog[state.actionLog.length - 1]
+      if (!last?.shotId) return state
+      return applyUndoLastEntry(state) ?? state
+    }
+
+    case 'CLEAR_SHOT_CHART': {
+      if (state.shotChart.length === 0) return state
+      let s = state
+      while (s.shotChart.length > 0) {
+        const popped = s.shotChart[s.shotChart.length - 1]
+        const last = s.actionLog[s.actionLog.length - 1]
+        const matches =
+          last?.type === 'increment' &&
+          last.shotId === popped.id &&
+          last.playerId === popped.playerId &&
+          last.statId === statIdForShotRecord(popped)
+        if (!matches) break
+        const next = applyUndoLastEntry(s)
+        if (!next) break
+        s = next
+      }
+      return s
     }
 
     case 'INCREMENT_STAT': {
@@ -486,52 +551,8 @@ function gameReducer(state: GameState, action: GameAction): GameState {
       }
     }
 
-    case 'UNDO': {
-      if (state.actionLog.length === 0) return state
-      const lastAction = state.actionLog[state.actionLog.length - 1]
-      let newState = { ...state, actionLog: state.actionLog.slice(0, -1) }
-
-      switch (lastAction.type) {
-        case 'increment':
-        case 'decrement':
-          newState = {
-            ...newState,
-            players: newState.players.map(p =>
-              p.id === lastAction.playerId
-                ? { ...p, stats: { ...p.stats, [lastAction.statId!]: lastAction.previousValue } }
-                : p
-            ),
-          }
-          if (lastAction.type === 'increment' && lastAction.shotId) {
-            newState = {
-              ...newState,
-              shotChart: newState.shotChart.filter(s => s.id !== lastAction.shotId),
-            }
-          }
-          break
-        case 'opponent_score_up':
-        case 'opponent_score_down':
-          newState = { ...newState, opponentScore: lastAction.previousValue }
-          break
-        case 'home_score_up':
-        case 'home_score_down':
-          newState = { ...newState, homeScoreAdjustment: lastAction.previousValue }
-          break
-        case 'home_team_score_up':
-        case 'home_team_score_down':
-          if (lastAction.previousHomeTeamScore == null) {
-            newState = {
-              ...newState,
-              homeTeamScore: null,
-              homeScoreAdjustment: lastAction.previousHomeScoreAdjustment ?? 0,
-            }
-          } else {
-            newState = { ...newState, homeTeamScore: lastAction.previousHomeTeamScore }
-          }
-          break
-      }
-      return newState
-    }
+    case 'UNDO':
+      return applyUndoLastEntry(state) ?? state
 
     case 'RESET_GAME':
       return createInitialState(resetStatus)

--- a/src/pages/GameTracker.tsx
+++ b/src/pages/GameTracker.tsx
@@ -443,9 +443,20 @@ export default function GameTracker() {
                     }
                     const subtitle = subtitleParts.length > 0 ? subtitleParts.join(' · ') : undefined
 
-                    return (
+                    const chartAwareTitle =
+                      sport.id === 'basketball' &&
+                      (action.id === '2pt' ||
+                        action.id === '2pt_miss' ||
+                        action.id === '3pt' ||
+                        action.id === '3pt_miss' ||
+                        action.id === 'ft' ||
+                        action.id === 'ft_miss')
+                        ? 'Shots from the Shot Chart include court location. Taps here count in stats only and do not add markers on the chart.'
+                        : undefined
+
+                    const buttonKey = action.periodScoped ? `${action.id}_p${currentPeriod}` : action.id
+                    const statButton = (
                       <StatButton
-                        key={action.periodScoped ? `${action.id}_p${currentPeriod}` : action.id}
                         label={action.label}
                         shortLabel={action.shortLabel}
                         value={currentVal}
@@ -476,6 +487,14 @@ export default function GameTracker() {
                         }
                         attemptCount={missAction ? (activePlayer.stats[missAction.id] || 0) : undefined}
                       />
+                    )
+
+                    return chartAwareTitle ? (
+                      <span key={buttonKey} title={chartAwareTitle} className="block cursor-help">
+                        {statButton}
+                      </span>
+                    ) : (
+                      <span key={buttonKey}>{statButton}</span>
                     )
                   })}
                 </div>

--- a/src/pages/ShotChart.tsx
+++ b/src/pages/ShotChart.tsx
@@ -8,7 +8,7 @@ import {
   TEAM_PLAYER_HOME_ID,
   TEAM_PLAYER_OPP_ID,
 } from '../lib/teamPlayers'
-import type { Player, ShotRecord } from '../types'
+import type { ActionLogEntry, Player, ShotRecord } from '../types'
 
 function sortTeamPlayersFirst(players: Player[]): Player[] {
   const teams = players.filter(isTeamPseudoPlayer)
@@ -24,8 +24,27 @@ function newShotId(): string {
   return `shot_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`
 }
 
+function shotLabelFromLogEntry(
+  entry: ActionLogEntry | undefined,
+  players: Player[]
+): string | null {
+  if (!entry?.shotId || entry.type !== 'increment' || !entry.playerId || !entry.statId) {
+    return null
+  }
+  const player = players.find(p => p.id === entry.playerId)
+  const num = player?.number?.trim()
+  const who = num ? `#${num}` : player?.name?.split(' ')[0] ?? 'Player'
+  const sid = entry.statId
+  let kind = sid.toUpperCase()
+  if (sid === '2pt') kind = '2PT Made'
+  else if (sid === '2pt_miss') kind = '2PT Miss'
+  else if (sid === '3pt') kind = '3PT Made'
+  else if (sid === '3pt_miss') kind = '3PT Miss'
+  return `Last: ${who} ${kind}`
+}
+
 /**
- * Shot chart: `#/shot-chart`. Taps dispatch `ADD_SHOT` (SC-3); markers use `state.shotChart`.
+ * Shot chart: `#/shot-chart`. Taps dispatch `ADD_SHOT`; markers use `state.shotChart`.
  */
 export default function ShotChart() {
   const navigate = useNavigate()
@@ -66,7 +85,24 @@ export default function ShotChart() {
     [dispatch, effectivePlayerId, mode]
   )
 
-  const canUndo = actionLog.length > 0
+  const lastEntry = actionLog.length > 0 ? actionLog[actionLog.length - 1] : undefined
+  const canUndoShot = Boolean(lastEntry?.shotId)
+  const undoShotSubtitle = useMemo(
+    () => shotLabelFromLogEntry(lastEntry, players),
+    [lastEntry, players]
+  )
+  const canClearShots = shotChart.length > 0
+
+  const handleClearChart = () => {
+    if (
+      !window.confirm(
+        'Remove every shot from the chart and undo their scoring stats? Stat taps (no location) are not changed.'
+      )
+    ) {
+      return
+    }
+    dispatch({ type: 'CLEAR_SHOT_CHART' })
+  }
 
   if (!allowed) {
     return null
@@ -158,15 +194,33 @@ export default function ShotChart() {
         </div>
       </div>
 
-      <div className="px-3 pb-2 max-w-lg mx-auto w-full">
+      <div className="px-3 pb-2 max-w-lg mx-auto w-full space-y-2">
         <button
           type="button"
-          disabled={!canUndo}
-          onClick={() => dispatch({ type: 'UNDO' })}
-          className="w-full py-2.5 rounded-xl text-sm font-semibold border border-slate-200 bg-white text-slate-700
+          disabled={!canUndoShot}
+          onClick={() => dispatch({ type: 'UNDO_LAST_SHOT' })}
+          className="w-full py-2.5 rounded-xl text-sm font-semibold border border-slate-200 bg-white text-slate-800
                      disabled:opacity-40 disabled:pointer-events-none active:scale-[0.99] transition-transform"
         >
-          ↩ Undo last action
+          ↩ Undo last shot
+        </button>
+        {undoShotSubtitle && (
+          <p className="text-center text-xs text-slate-500 -mt-1">{undoShotSubtitle}</p>
+        )}
+        {!canUndoShot && actionLog.length > 0 && (
+          <p className="text-center text-xs text-slate-400">
+            Last action was not from the chart — use <span className="font-medium">Undo</span> on Game Tracker
+            for stat taps and other changes.
+          </p>
+        )}
+        <button
+          type="button"
+          disabled={!canClearShots}
+          onClick={handleClearChart}
+          className="w-full py-2 rounded-xl text-sm font-medium border border-rose-200 bg-rose-50 text-rose-800
+                     disabled:opacity-40 disabled:pointer-events-none active:scale-[0.99] transition-transform"
+        >
+          Clear all chart shots
         </button>
       </div>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,10 @@ export type GameAction =
   | { type: 'SET_NOTES'; notes: string }
   | { type: 'ADD_SHOT'; shot: ShotRecord }
   | { type: 'REMOVE_LAST_SHOT' }
+  /** Undo once only if the last log entry is shot-chart–originated (`shotId` set). */
+  | { type: 'UNDO_LAST_SHOT' }
+  /** Pop every shot from the tail of `shotChart` that still matches the last log entry (see reducer). */
+  | { type: 'CLEAR_SHOT_CHART' }
   | { type: 'UNDO' }
   | { type: 'RESET_GAME' }
   | { type: 'SET_CLOUD_SYNC_STATE'; cloudSync: Partial<CloudSyncState> }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SC-4 from `DESIGN_SHOT_CHART_IMPLEMENTATION.md`: shot-chart undo is explicit, chart can be cleared while preserving stat-only history, and Game Tracker documents chart vs grid taps.

## Reducer

- **`applyUndoLastEntry`:** single implementation for reversing the last log entry (including `shotId` → remove one marker).
- **`UNDO`:** delegates to `applyUndoLastEntry` (unchanged behavior for Game Tracker).
- **`UNDO_LAST_SHOT`:** no-op unless the last log entry has **`shotId`** (so chart page does not undo a stat-button increment by mistake).
- **`CLEAR_SHOT_CHART`:** while the last shot matches the last log entry, undo in a loop — removes all chart-backed shots and their stat bumps; stat-button-only log entries remain.
- **`REMOVE_LAST_SHOT`:** if last log matches last shot → full undo; else pop **`shotChart` only** (avoids desync).

## UI

- **Shot chart:** primary control **Undo last shot** + subtitle (`Last: #12 2PT Made`, …); note when last action was not chart-originated; **Clear all chart shots** with `confirm`.
- **Game Tracker:** `title` on basketball **2pt / 2pt_miss / 3pt / 3pt_miss / ft / ft_miss** tiles explaining chart vs stat grid.

## Docs

SC-4 section updated to “implemented” with the above behavior.

## Verification

`pnpm build`, `pnpm lint` (existing context warnings only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

