### PR TITLE
feat(shot-chart): SC-5 — Game Summary shot tab + ShootingSummary

### DIFF
--- a/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
+++ b/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
@@ -242,44 +242,19 @@ SC-5  Game Summary      │
 
 **Blocks:** Nothing
 
-**What to do:**
+**Implemented:**
 
-1. **New: `src/components/shot-chart/ShootingSummary.tsx`**:
-   - Props: `shots: ShotRecord[]`
-   - Computes zone-based stats: restricted, paint, mid-range, three-point, total
-   - For each zone: made count, attempt count, percentage
-   - Renders a compact grid:
-     ```
-     ┌──────────┬──────────┬──────────┐
-     │ Restrict │  Paint   │ Mid-Rng  │
-     │  4/6     │  4/8     │  2/5     │
-     │  67%     │  50%     │  40%     │
-     └──────────┴──────────┴──────────┘
-     ┌──────────┬──────────────────────┐
-     │  3-Point │      TOTAL          │
-     │  3/9     │     13/28           │
-     │  33%     │      46%            │
-     └──────────┴──────────────────────┘
-     ```
+1. **`src/components/shot-chart/ShootingSummary.tsx`** — `shots: ShotRecord[]`; aggregates by `shot.zone` (restricted, paint, mid_range, three) plus total; compact 3+2 grid (row 2: 3PT + Total).
 
-2. **`src/pages/GameSummary.tsx`**:
-   - Check if `state.shotChart.length > 0`
-   - If yes, add a "Shot Chart" tab to the summary tabs (alongside existing "Players" / "Team")
-   - The tab renders:
-     - `<BasketballCourt shots={state.shotChart} />` (read-only, no `onCourtTap`)
-     - `<ShootingSummary shots={state.shotChart} />`
+2. **`src/pages/GameSummary.tsx`** — **Shot chart** tab when `sport.id === 'basketball'` and `shotChart.length > 0`; read-only `<BasketballCourt shots={shotChart} />` and `<ShootingSummary />`. Tab hidden if no chart shots (including non-basketball).
 
-3. **Also add the `ShootingSummary` to the shot chart page** (`ShotChart.tsx`) below the court, replacing the inline summary added in SC-2.
+3. **`src/pages/ShotChart.tsx`** — `ShootingSummary` below the court.
 
-**Files touched:** new `src/components/shot-chart/ShootingSummary.tsx`, `src/pages/GameSummary.tsx`, `src/pages/ShotChart.tsx`
+**Files touched:** `ShootingSummary.tsx`, `GameSummary.tsx`, `ShotChart.tsx`
 
 **Test breakpoint:**
-- Play a game, record 10+ shots via the chart across all zones
-- Navigate to Summary → see "Shot Chart" tab
-- Tab shows read-only court with all markers
-- Zone breakdown shows correct made/attempt/percentage for each zone
-- No "Shot Chart" tab if no shots were recorded
-- Zone percentages match manual count of markers on the court
+- Record chart shots → Summary → Shot chart tab → court + zone grid
+- No tab when `shotChart` is empty
 
 **Commit message:** `feat: add shot chart visualization and zone breakdown to Game Summary`
 

--- a/src/components/shot-chart/ShootingSummary.tsx
+++ b/src/components/shot-chart/ShootingSummary.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from 'react'
+import type { ShotRecord, ShotZone } from '../../types'
+
+interface ShootingSummaryProps {
+  shots: ShotRecord[]
+  className?: string
+}
+
+const ROW1_ZONES: { zone: ShotZone; shortLabel: string }[] = [
+  { zone: 'restricted', shortLabel: 'Restrict' },
+  { zone: 'paint', shortLabel: 'Paint' },
+  { zone: 'mid_range', shortLabel: 'Mid' },
+]
+
+function pct(made: number, att: number): string {
+  if (att === 0) return '—'
+  return `${Math.round((made / att) * 100)}%`
+}
+
+function ZoneCell({
+  label,
+  made,
+  attempts,
+}: {
+  label: string
+  made: number
+  attempts: number
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50/80 px-2 py-2 text-center">
+      <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500 truncate">{label}</p>
+      <p className="text-sm font-bold text-slate-800 mt-0.5">
+        {made}/{attempts}
+      </p>
+      <p className="text-xs text-slate-600">{pct(made, attempts)}</p>
+    </div>
+  )
+}
+
+export default function ShootingSummary({ shots, className }: ShootingSummaryProps) {
+  const byZone = useMemo(() => {
+    const counts: Record<ShotZone, { made: number; att: number }> = {
+      restricted: { made: 0, att: 0 },
+      paint: { made: 0, att: 0 },
+      mid_range: { made: 0, att: 0 },
+      three: { made: 0, att: 0 },
+    }
+    let totalMade = 0
+    let totalAtt = 0
+    for (const s of shots) {
+      const z = s.zone
+      if (counts[z]) {
+        counts[z].att += 1
+        if (s.made) counts[z].made += 1
+      }
+      totalAtt += 1
+      if (s.made) totalMade += 1
+    }
+    return { counts, totalMade, totalAtt }
+  }, [shots])
+
+  if (shots.length === 0) {
+    return (
+      <p className={`text-sm text-slate-500 ${className ?? ''}`.trim()}>No chart shots recorded.</p>
+    )
+  }
+
+  const { counts, totalMade, totalAtt } = byZone
+
+  return (
+    <div className={className}>
+      <h3 className="text-sm font-semibold text-slate-600 mb-2">Shooting by zone</h3>
+      <div className="grid grid-cols-3 gap-2 mb-2">
+        {ROW1_ZONES.map(({ zone, shortLabel }) => (
+          <ZoneCell
+            key={zone}
+            label={shortLabel}
+            made={counts[zone].made}
+            attempts={counts[zone].att}
+          />
+        ))}
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <ZoneCell label="3-Point" made={counts.three.made} attempts={counts.three.att} />
+        <ZoneCell label="Total" made={totalMade} attempts={totalAtt} />
+      </div>
+    </div>
+  )
+}

--- a/src/pages/GameSummary.tsx
+++ b/src/pages/GameSummary.tsx
@@ -7,6 +7,8 @@ import { isTeamPseudoPlayer, TEAM_PLAYER_HOME_ID, TEAM_PLAYER_OPP_ID } from '../
 import { resolveTeamStatsConfig } from '../config/teamStatsDefaults'
 import { hasTrackedTeamSide } from '../lib/teamStatsSummary'
 import TeamStatSummary from '../components/team-stats/TeamStatSummary'
+import BasketballCourt from '../components/shot-chart/BasketballCourt'
+import ShootingSummary from '../components/shot-chart/ShootingSummary'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
 
@@ -32,7 +34,7 @@ export default function GameSummary() {
   const navigate = useNavigate()
   const { state, dispatch } = useGame()
   const { user, isConfigured } = useAuth()
-  const { sport, gameInfo, players, opponentScore, homeTeamScore, homeScoreAdjustment } = state
+  const { sport, gameInfo, players, opponentScore, homeTeamScore, homeScoreAdjustment, shotChart } = state
   const [finalizing, setFinalizing] = useState(false)
   const [finalizeError, setFinalizeError] = useState<string | null>(null)
   const [resolvedStats, setResolvedStats] = useState<ResolvedStatsMap | null>(null)
@@ -51,8 +53,8 @@ export default function GameSummary() {
   const [savingCorrection, setSavingCorrection] = useState(false)
   const [resolvedKey, setResolvedKey] = useState(0)
   const [viewMode, setViewMode] = useState<'primary' | 'all'>('primary')
-  /** Players vs scores vs team-level stat summary (fouls, timeouts). */
-  const [summaryTab, setSummaryTab] = useState<'players' | 'team' | 'team_stats'>('players')
+  /** Players vs scores vs team-level stat summary (fouls, timeouts) vs shot chart (basketball). */
+  const [summaryTab, setSummaryTab] = useState<'players' | 'team' | 'team_stats' | 'shot_chart'>('players')
   /** Final games: overlay from get_game_team_stats (resolved placeholder stats). */
   const [teamTrackedStatsByRemoteId, setTeamTrackedStatsByRemoteId] = useState<
     Record<string, Record<string, number>> | null
@@ -132,11 +134,19 @@ export default function GameSummary() {
       (hasTrackedTeamSide(teamStatHomeStats, sport) || hasTrackedTeamSide(teamStatOppStats, sport))
   )
 
+  const showShotChartTab = Boolean(sport?.id === 'basketball' && shotChart.length > 0)
+
   useEffect(() => {
     if (!showTeamStatsTab && summaryTab === 'team_stats') {
       setSummaryTab('players')
     }
   }, [showTeamStatsTab, summaryTab])
+
+  useEffect(() => {
+    if (!showShotChartTab && summaryTab === 'shot_chart') {
+      setSummaryTab('players')
+    }
+  }, [showShotChartTab, summaryTab])
 
   const teamStatsSummaryEl = useMemo(() => {
     if (!sport || !gameInfo || !showTeamStatsTab || summaryTab !== 'team_stats') return null
@@ -793,6 +803,17 @@ export default function GameSummary() {
                 Team stats
               </button>
             )}
+            {showShotChartTab && (
+              <button
+                type="button"
+                onClick={() => setSummaryTab('shot_chart')}
+                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                  summaryTab === 'shot_chart' ? 'bg-slate-700 text-white' : 'text-slate-600 hover:bg-slate-100'
+                }`}
+              >
+                Shot chart
+              </button>
+            )}
           </div>
         {isFinalCloudGame && summaryTab === 'players' && (
           <>
@@ -835,6 +856,17 @@ export default function GameSummary() {
         </div>
 
         {teamStatsSummaryEl}
+
+        {summaryTab === 'shot_chart' && (
+          <div className="space-y-4 mb-6">
+            <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+              <BasketballCourt shots={shotChart} className="w-full" />
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+              <ShootingSummary shots={shotChart} />
+            </div>
+          </div>
+        )}
 
         {summaryTab === 'team' && (
           <div className="card mb-6 border-slate-200">

--- a/src/pages/ShotChart.tsx
+++ b/src/pages/ShotChart.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGame } from '../context/GameContext'
 import BasketballCourt from '../components/shot-chart/BasketballCourt'
+import ShootingSummary from '../components/shot-chart/ShootingSummary'
 import { classifyShotZone, isThreePointer } from '../components/shot-chart/courtGeometry'
 import {
   isTeamPseudoPlayer,
@@ -224,9 +225,12 @@ export default function ShotChart() {
         </button>
       </div>
 
-      <div className="px-3 pb-6 max-w-lg mx-auto w-full flex-1 flex flex-col">
+      <div className="px-3 pb-6 max-w-lg mx-auto w-full flex-1 flex flex-col space-y-3">
         <div className="rounded-xl bg-white border border-slate-200 p-3 shadow-sm mt-1">
           <BasketballCourt shots={shotChart} onCourtTap={onCourtTap} className="w-full" />
+        </div>
+        <div className="rounded-xl bg-white border border-slate-200 p-3 shadow-sm">
+          <ShootingSummary shots={shotChart} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SC-5: zone-based shooting summary and read-only court on Game Summary when chart shots exist.

## `ShootingSummary`

- Props: `shots: ShotRecord[]`
- Aggregates by `shot.zone` (restricted, paint, mid_range, three) and overall total
- Layout: 3-column row (Restrict / Paint / Mid), then 2-column row (3PT / Total)

## `GameSummary`

- **Shot chart** tab when `sport.id === 'basketball'` and `state.shotChart.length > 0`
- Tab body: read-only `BasketballCourt` (no `onCourtTap`) + `ShootingSummary`
- If tab becomes invalid (e.g. cleared), effect resets `summaryTab` to Players

## `ShotChart`

- `ShootingSummary` below the interactive court

## Docs

`DESIGN_SHOT_CHART_IMPLEMENTATION.md` SC-5 marked implemented.

## Verification

`pnpm build`, `pnpm lint` (existing context warnings only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

