### PR TITLE
feat(shot-chart): SC-6 — shot_chart table + cloud sync/hydrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The dev server starts at `http://localhost:5173`.
    - `supabase/migrations/029_merge_block_team_placeholders.sql` — merge RPCs reject placeholder players
    - `supabase/migrations/030_team_stats_schema.sql` — `games.home_team_player_id`, `opp_team_player_id`, `seasons.team_stats_config`, display views, `get_game_team_stats` (see file for notes on `get_game_stats_resolved`)
    - `supabase/migrations/031_get_game_team_stats.sql` — repair: `get_game_team_stats` only if needed
+   - `supabase/migrations/032_shot_chart.sql` — `shot_chart` per-game shot locations (cloud sync from the shot chart; see `docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md` SC-6)
    > If you already applied earlier migrations, run only the new ones (e.g. only `018` for the seasons data model redesign).
    > Before **`019`**, run `supabase/scripts/audit_data_integrity_pre_019.sql` in the SQL Editor if you have existing data; migration `019` aborts if duplicate teams, invalid `seasons.sport`, duplicate active jersey numbers, or bad `games.tournament_id` links exist.
    > **Migration 018 is destructive**: it drops `teams.sport`, `teams.season`, `players.team_id`, `players.jersey_number`, `players.position`, and `players.is_active` columns after migrating data to the new `seasons`, `team_players`, and `player_guardians` tables. Back up your database before running.

--- a/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
+++ b/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
@@ -268,67 +268,20 @@ SC-5  Game Summary      │
 
 **Blocks:** SC-7
 
-**What to do:**
+**Implemented:**
 
-1. **New: `supabase/migrations/028_shot_chart.sql`** (or next available number):
-   ```sql
-   CREATE TABLE shot_chart (
-     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-     game_id uuid NOT NULL REFERENCES games(id) ON DELETE CASCADE,
-     player_id uuid NOT NULL REFERENCES players(id) ON DELETE CASCADE,
-     x numeric NOT NULL,
-     y numeric NOT NULL,
-     made boolean NOT NULL,
-     shot_type text NOT NULL CHECK (shot_type IN ('2pt', '3pt')),
-     zone text NOT NULL CHECK (zone IN ('restricted', 'paint', 'mid_range', 'three')),
-     recorded_by uuid NOT NULL REFERENCES profiles(id),
-     created_at timestamptz NOT NULL DEFAULT now()
-   );
+1. **`supabase/migrations/032_shot_chart.sql`** — Table `shot_chart` with `game_id`, `player_id`, `recorded_by`, **`client_shot_id`** (stable `ShotRecord.id` for idempotent replace), `x`, `y`, `made`, `shot_type`, `zone`, `created_at`. Unique `(game_id, recorded_by, client_shot_id)`. RLS: team members **select** on games in their teams; **insert/update/delete own** rows (`recorded_by = auth.uid()`), aligned with `game_stats`.
 
-   CREATE INDEX idx_shot_chart_game ON shot_chart(game_id);
-   CREATE INDEX idx_shot_chart_game_player ON shot_chart(game_id, player_id);
+2. **`syncGameSnapshotToCloud`** — After `upsertGameStats`, **`syncShotChartToCloud`**: for basketball only, **delete** `shot_chart` where `(game_id, recorded_by) = (…, userId)`, then **insert** all `state.shotChart` rows with mapped `player_id`. If the table is missing (old DB), delete/insert errors are ignored so sync still succeeds.
 
-   ALTER TABLE shot_chart ENABLE ROW LEVEL SECURITY;
+3. **`hydrateCloudGameFromRow`** — For `sportId === 'basketball'`, **select** `shot_chart` for `(game_id, recorded_by)`; map remote `player_id` → local via `playerIdMap`; build `HydratedCloudGame.shotChart`. **`buildHydratedStateFromCloudGame`** / **Games** / **PlayerProfile** / **CareerStats** use `cloudGame.shotChart`.
 
-   -- Team members can view shot charts for their team's games
-   CREATE POLICY "shot_chart_select" ON shot_chart
-     FOR SELECT USING (
-       game_id IN (SELECT id FROM games WHERE team_id IN (
-         SELECT team_id FROM team_members WHERE user_id = (SELECT auth.uid())
-       ))
-     );
-
-   -- Users can insert their own shot chart data
-   CREATE POLICY "shot_chart_insert" ON shot_chart
-     FOR INSERT WITH CHECK (recorded_by = (SELECT auth.uid()));
-
-   -- Users can update/delete their own shot chart data
-   CREATE POLICY "shot_chart_update" ON shot_chart
-     FOR UPDATE USING (recorded_by = (SELECT auth.uid()));
-
-   CREATE POLICY "shot_chart_delete" ON shot_chart
-     FOR DELETE USING (recorded_by = (SELECT auth.uid()));
-   ```
-
-2. **`src/lib/cloudSync.ts`** — Add shot chart sync:
-   - In `syncGameSnapshotToCloud`: after upserting `game_stats`, also upsert `shot_chart` rows
-   - Strategy: delete existing `shot_chart` rows for this `(game_id, recorded_by)` and re-insert all from `state.shotChart`. This is simpler than per-shot diffing and the row count is small (typically <50 per game).
-   - Map local player IDs to cloud player IDs using `playerIdMap` for the `player_id` column.
-
-3. **`src/lib/cloudSync.ts`** — Load shot chart on cloud resume:
-   - In `loadLatestCloudGame` / `loadCloudGameById`: after loading game stats, also query `shot_chart` for this game
-   - Map cloud player IDs back to local IDs
-   - Include in hydrated state as `shotChart: [...]`
-
-**Files touched:** new `supabase/migrations/028_shot_chart.sql`, `src/lib/cloudSync.ts`
+**Files touched:** `032_shot_chart.sql`, `cloudSync.ts`, `GameContext.tsx`, `Games.tsx`, `PlayerProfile.tsx`, `CareerStats.tsx`
 
 **Test breakpoint:**
-- Apply migration to Supabase
-- Start a cloud game → record shots via chart → verify in Supabase DB:
-  - `shot_chart` table has rows with correct `game_id`, `player_id`, `x`, `y`, `made`, `shot_type`, `zone`
-- Close and reopen the game → shot chart data restored from cloud
-- Different user on same game sees shot chart data (via RLS select policy)
-- Delete a game → shot chart rows cascade-deleted
+- Apply migration → record chart shots → sync → rows in `shot_chart`
+- Resume game → markers restored
+- Game delete cascades rows
 
 **Commit message:** `feat: add shot_chart table migration and cloud sync support`
 

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -263,7 +263,7 @@ function buildHydratedStateFromCloudGame(
     currentPeriod: 1,
     teamStatsConfig: cloudGame.teamStatsConfig,
     actionLog: [],
-    shotChart: [],
+    shotChart: cloudGame.shotChart ?? [],
     cloudSync: {
       ...createInitialCloudSyncState('synced'),
       seasonId: cloudGame.seasonId ?? null,

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -1,4 +1,4 @@
-import type { GameInfo, GameState, Player } from '../types'
+import type { GameInfo, GameState, Player, ShotRecord } from '../types'
 import { supabase } from './supabase'
 import { isTeamPseudoPlayer, TEAM_PLAYER_HOME_ID, TEAM_PLAYER_OPP_ID } from './teamPlayers'
 
@@ -34,6 +34,8 @@ export interface HydratedCloudGame {
   teamId: string
   gameId: string
   playerIdMap: Record<string, string>
+  /** Chart shots for this game + recorder (basketball); empty if table missing or none. */
+  shotChart: ShotRecord[]
   hydratedAt: string
 }
 
@@ -106,6 +108,15 @@ function isMissingGameTeamPlaceholderColumnError(error: { message?: string } | n
 function isMissingIsTeamPlaceholderColumnError(error: { message?: string } | null): boolean {
   if (!error?.message) return false
   return error.message.includes('is_team_placeholder') && error.message.includes('column')
+}
+
+function isMissingShotChartTableError(error: { message?: string } | null): boolean {
+  if (!error?.message) return false
+  const m = error.message.toLowerCase()
+  return (
+    (m.includes('shot_chart') && m.includes('relation') && m.includes('does not exist')) ||
+    (m.includes('shot_chart') && m.includes('could not find the table'))
+  )
 }
 
 function parseSeasonTeamStatsConfig(raw: unknown): Record<string, unknown> | null {
@@ -652,6 +663,77 @@ async function upsertGameStats(
   }
 }
 
+async function syncShotChartToCloud(
+  state: GameState,
+  userId: string,
+  gameId: string,
+  playerIdMap: Record<string, string>
+): Promise<void> {
+  if (!supabase) {
+    throw new Error('Supabase client not configured')
+  }
+  if (state.sport?.id !== 'basketball') {
+    return
+  }
+
+  const { error: delError } = await supabase
+    .from('shot_chart')
+    .delete()
+    .eq('game_id', gameId)
+    .eq('recorded_by', userId)
+
+  if (delError) {
+    if (isMissingShotChartTableError(delError)) {
+      return
+    }
+    throw new Error(`Shot chart sync (delete) failed: ${delError.message}`)
+  }
+
+  if (state.shotChart.length === 0) {
+    return
+  }
+
+  const rows: Array<{
+    game_id: string
+    player_id: string
+    recorded_by: string
+    client_shot_id: string
+    x: number
+    y: number
+    made: boolean
+    shot_type: '2pt' | '3pt'
+    zone: ShotRecord['zone']
+  }> = []
+
+  for (const shot of state.shotChart) {
+    const remotePlayerId = playerIdMap[shot.playerId]
+    if (!remotePlayerId) continue
+    rows.push({
+      game_id: gameId,
+      player_id: remotePlayerId,
+      recorded_by: userId,
+      client_shot_id: shot.id,
+      x: shot.x,
+      y: shot.y,
+      made: shot.made,
+      shot_type: shot.shotType,
+      zone: shot.zone,
+    })
+  }
+
+  if (rows.length === 0) {
+    return
+  }
+
+  const { error: insError } = await supabase.from('shot_chart').insert(rows)
+  if (insError) {
+    if (isMissingShotChartTableError(insError)) {
+      return
+    }
+    throw new Error(`Shot chart sync (insert) failed: ${insError.message}`)
+  }
+}
+
 export async function syncGameSnapshotToCloud({
   state,
   userId,
@@ -703,6 +785,8 @@ export async function syncGameSnapshotToCloud({
   }
 
   await upsertGameStats(state, userId, gameId, nextPlayerIdMap)
+
+  await syncShotChartToCloud(state, userId, gameId, nextPlayerIdMap)
 
   await linkGameTeamPlaceholderIds(
     gameId,
@@ -898,6 +982,55 @@ async function hydrateCloudGameFromRow(userId: string, gameRow: CloudGameRow): P
     playerIdMap[TEAM_PLAYER_OPP_ID] = oppCloudId
   }
 
+  const remoteToLocalPlayerId: Record<string, string> = {}
+  for (const [localId, remoteId] of Object.entries(playerIdMap)) {
+    remoteToLocalPlayerId[remoteId] = localId
+  }
+
+  const shotChart: ShotRecord[] = []
+  if (sportId === 'basketball') {
+    const { data: shotRows, error: shotErr } = await supabase
+      .from('shot_chart')
+      .select('player_id, client_shot_id, x, y, made, shot_type, zone, created_at')
+      .eq('game_id', gameRow.id)
+      .eq('recorded_by', userId)
+      .order('created_at', { ascending: true })
+
+    if (shotErr) {
+      if (!isMissingShotChartTableError(shotErr)) {
+        throw new Error(`Shot chart load failed: ${shotErr.message}`)
+      }
+    } else {
+      const zones: ShotRecord['zone'][] = ['restricted', 'paint', 'mid_range', 'three']
+      for (const row of (shotRows ?? []) as Array<{
+        player_id: string
+        client_shot_id: string
+        x: number | string
+        y: number | string
+        made: boolean
+        shot_type: string
+        zone: string
+        created_at: string
+      }>) {
+        const localPlayerId = remoteToLocalPlayerId[row.player_id]
+        if (!localPlayerId) continue
+        const z = row.zone as ShotRecord['zone']
+        if (!zones.includes(z)) continue
+        const st = row.shot_type === '3pt' ? '3pt' : '2pt'
+        shotChart.push({
+          id: row.client_shot_id,
+          x: Number(row.x),
+          y: Number(row.y),
+          made: row.made,
+          shotType: st,
+          zone: z,
+          playerId: localPlayerId,
+          timestamp: new Date(row.created_at).getTime(),
+        })
+      }
+    }
+  }
+
   const activePlayerId = rosterPlayers[0]?.id ?? teamPlayers[0]?.id ?? null
 
   return {
@@ -922,6 +1055,7 @@ async function hydrateCloudGameFromRow(userId: string, gameRow: CloudGameRow): P
     teamId: teamRow.id as string,
     gameId: gameRow.id,
     playerIdMap,
+    shotChart,
     hydratedAt: new Date().toISOString(),
   }
 }

--- a/src/pages/CareerStats.tsx
+++ b/src/pages/CareerStats.tsx
@@ -286,7 +286,7 @@ export default function CareerStats() {
         currentPeriod: 1,
         teamStatsConfig: null,
         actionLog: [],
-        shotChart: [],
+        shotChart: cloudGame.shotChart ?? [],
         cloudSync: {
           seasonId: cloudGame.seasonId ?? null,
           teamId: cloudGame.teamId,

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -233,7 +233,7 @@ export default function Games() {
       currentPeriod: 1,
       teamStatsConfig: null,
       actionLog: [],
-      shotChart: [],
+      shotChart: cloudGame.shotChart ?? [],
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,
         teamId: cloudGame.teamId,

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -284,7 +284,7 @@ export default function PlayerProfile() {
       currentPeriod: 1,
       teamStatsConfig: null,
       actionLog: [],
-      shotChart: [],
+      shotChart: cloudGame.shotChart ?? [],
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,
         teamId: cloudGame.teamId,

--- a/supabase/migrations/032_shot_chart.sql
+++ b/supabase/migrations/032_shot_chart.sql
@@ -1,0 +1,41 @@
+-- Shot chart: location-tagged attempts per game (per recorder). Replaced wholesale on sync.
+
+create table if not exists public.shot_chart (
+  id uuid primary key default gen_random_uuid(),
+  game_id uuid not null references public.games (id) on delete cascade,
+  player_id uuid not null references public.players (id) on delete cascade,
+  recorded_by uuid not null references public.profiles (id),
+  client_shot_id text not null,
+  x numeric not null,
+  y numeric not null,
+  made boolean not null,
+  shot_type text not null check (shot_type in ('2pt', '3pt')),
+  zone text not null check (zone in ('restricted', 'paint', 'mid_range', 'three')),
+  created_at timestamptz not null default now(),
+  unique (game_id, recorded_by, client_shot_id)
+);
+
+create index if not exists idx_shot_chart_game on public.shot_chart (game_id);
+create index if not exists idx_shot_chart_game_player on public.shot_chart (game_id, player_id);
+create index if not exists idx_shot_chart_recorded_by on public.shot_chart (recorded_by);
+
+alter table public.shot_chart enable row level security;
+
+create policy "shot_chart_select_member" on public.shot_chart
+  for select using (
+    game_id in (
+      select id from public.games
+      where team_id in (
+        select team_id from public.team_members where user_id = auth.uid()
+      )
+    )
+  );
+
+create policy "shot_chart_insert_own" on public.shot_chart
+  for insert with check (recorded_by = auth.uid());
+
+create policy "shot_chart_update_own" on public.shot_chart
+  for update using (recorded_by = auth.uid());
+
+create policy "shot_chart_delete_own" on public.shot_chart
+  for delete using (recorded_by = auth.uid());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SC-6: persist `GameState.shotChart` to Supabase and restore on cloud hydrate.

## Migration `032_shot_chart.sql`

- Table `public.shot_chart`: `game_id`, `player_id`, `recorded_by`, **`client_shot_id`** (stores `ShotRecord.id`), `x`, `y`, `made`, `shot_type`, `zone`, `created_at`
- Unique `(game_id, recorded_by, client_shot_id)` for replace-on-sync
- RLS aligned with `game_stats`: team members can **select** rows for team games; **insert/update/delete** where `recorded_by = auth.uid()`
- `ON DELETE CASCADE` from `games`

## `cloudSync.ts`

- **`syncShotChartToCloud`**: basketball only — `DELETE` where `(game_id, recorded_by)`, then `INSERT` all shots with `playerIdMap`; ignores errors if `shot_chart` relation missing (older DBs)
- **`hydrateCloudGameFromRow`**: for basketball, `SELECT` shots for `(game_id, recorded_by)`; map cloud `player_id` → local; **`HydratedCloudGame.shotChart`**
- **`buildHydratedStateFromCloudGame`** + **Games / PlayerProfile / CareerStats** hydrate `shotChart` from `cloudGame.shotChart`

## Docs

- `DESIGN_SHOT_CHART_IMPLEMENTATION.md` SC-6 updated
- `README.md` migration list includes `032`

## Verification

`pnpm build`, `pnpm lint` (existing context warnings only).

## Deploy note

Apply **`032_shot_chart.sql`** in Supabase before expecting cross-device shot persistence.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

