### PR TITLE
docs: shot chart status + dev QA path (REGRESSION_TESTING, AGENTS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ See `package.json` scripts. Standard commands:
 
 - `pnpm.onlyBuiltDependencies` in `package.json` allowlists `esbuild`; no interactive `pnpm approve-builds` needed.
 - The app uses `HashRouter` (`/#/path`), not `BrowserRouter`. URLs in the browser will look like `http://localhost:5173/#/game`.
+- **Shot chart (basketball):** Real flow `#/shot-chart` from Game Tracker. **Dev-only SVG preview:** `#/dev/shot-chart` loads sample shots without auth (`ShotChartPreview`); see `docs/REGRESSION_TESTING.md` §4d.
 - Game state persists in `localStorage` under key `statkeeper_game`. To reset state, either use the "New Game" flow in the UI or clear localStorage.
 - Sport configurations live in `src/config/sports.ts`. Adding a new sport means adding a `SportConfig` entry to the array — the UI auto-discovers it.
 - **Team-level stats (basketball):** Optional `teamCategories` on `SportConfig`; local pseudo-player ids `__team_home__` / `__team_opp__` (`src/lib/teamPlayers.ts`). Season rules: `seasons.team_stats_config`, edited in **Settings → Seasons** (`SeasonTeamStatsEditor`). Cloud: placeholder rows on `players`, `games.home_team_player_id` / `opp_team_player_id`, RPC `get_game_team_stats`. Game Summary tab **Team stats** when any team stat exists. Design: `docs/DESIGN_TEAM_STATS_*.md`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A mobile-first Progressive Web App for tracking sports game statistics in real t
 - **Game Notes** — free-text notes field in Game Tracker and Game Summary; synced to cloud
 - **Live Scoreboard** — home total can be a standalone scoreboard value or computed from player scoring stats + optional adjustment; manual opponent score
 - **Basketball team stats** — home/opponent “team” rows in Game Tracker for fouls (per period), timeouts, techs, turnovers; period toggle, bonus indicators, and season rules from `seasons.team_stats_config` (edit under **Settings → Seasons**). Cloud games sync placeholder `players` + `game_stats`; **Game Summary** includes a **Team stats** tab (fouls by period, bonus events, other team stats). See [docs/DESIGN_TEAM_STATS_TRACKING.md](docs/DESIGN_TEAM_STATS_TRACKING.md)
+- **Basketball shot chart** — half-court SVG from Game Tracker (**Shot chart**); tap to record made/miss with zone classification; syncs with 2PT/3PT stats; **Game Summary** tab when chart shots exist; cloud persistence via migration **`032_shot_chart.sql`** ([implementation plan](docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md))
 - **Undo Support** — undo any stat action instantly
 - **Game Summary** — per-player and team totals in organized tables; M/A (%) columns for shooting stats
 - **Delete Entities** — delete seasons, teams, players, games, and tournaments with confirmation prompts; centralized Data Management in Settings

--- a/docs/DESIGN_SHOT_CHART.md
+++ b/docs/DESIGN_SHOT_CHART.md
@@ -2,7 +2,7 @@
 
 An interactive half-court basketball diagram where a coach taps the court to record shot locations. Shots are marked as **made** (filled circle) or **missed** (X), auto-classified by zone (paint, mid-range, three-point), and integrated with the existing stat tracking pipeline so the same data drives both the shot chart visualization and the stat counters (`2pt`, `2pt_miss`, `3pt`, `3pt_miss`, `ft`).
 
-**Status:** Design phase. Not yet implemented.
+**Status:** **MVP shipped** in app (court, shot chart page, GameState + cloud sync after migration `032_shot_chart.sql`, Game Summary tab, polish). This document still describes the full vision; some diagram details differ from the shipped court — see [DESIGN_SHOT_CHART_IMPLEMENTATION.md](DESIGN_SHOT_CHART_IMPLEMENTATION.md) **Status** for work-unit notes and intentional MVP deltas.
 
 **Related docs:**
 - [DESIGN_TEAM_STATS_TRACKING.md](DESIGN_TEAM_STATS_TRACKING.md) — team pseudo-player architecture (shot chart will support team-level tracking first)

--- a/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
+++ b/docs/DESIGN_SHOT_CHART_IMPLEMENTATION.md
@@ -8,6 +8,44 @@ Step-by-step implementation plan for the basketball shot chart feature, broken i
 
 ---
 
+## Status (as of 2026-04)
+
+| Work unit | Status | Notes |
+|-----------|--------|--------|
+| **SC-1** | **Shipped** | Court SVG, `courtGeometry`, types, dev preview `/#/dev/shot-chart` |
+| **SC-2** | **Shipped** | `#/shot-chart` page: made/miss, player strip, tap → `ADD_SHOT`, `ShootingSummary` on page |
+| **SC-3** | **Shipped** | `GameState.shotChart`, reducer, persistence fingerprint, hydrate from cloud |
+| **SC-4** | **Shipped** | `UNDO_LAST_SHOT`, `CLEAR_SHOT_CHART`, `ConfirmDialog` clear-all (SC-7), stat-grid tooltips |
+| **SC-5** | **Shipped** | `ShootingSummary`, Game Summary **Shot chart** tab |
+| **SC-6** | **Shipped** (apply DB) | Migration `032_shot_chart.sql`; sync + load in `cloudSync.ts`. **Run migration on Supabase** for production cloud round-trip. |
+| **SC-7** | **Shipped** | Haptics, marker pulse, tap debounce, tracker badge, empty-court hint |
+
+### Shipped product behavior (summary)
+
+- **Game Tracker (basketball):** Shot chart button with **count badge**; stat tiles for FG/FT have **tooltips** explaining chart vs grid taps.
+- **Shot chart route** `/#/shot-chart`: mode toggle, player selector, court tap records shots into **`shotChart`** and **scoring stats**; zone summary; **undo last shot** (chart-only); **clear all** with confirmation; haptic + pulse + debounce + empty hint.
+- **Game Summary:** **Shot chart** tab when there are chart shots: read-only court + zone summary.
+- **Persistence:** `shotChart` in **localStorage** with game state; **cloud** replace-sync per `(game_id, recorded_by)` after migration **032** is applied.
+- **Dev QA:** `/#/dev/shot-chart` + optional auth bypass (remove when no longer needed).
+
+### Follow-ups / backlog (not in MVP scope)
+
+- Remove or gate **`/dev/shot-chart`** and preview-only auth bypass when QA is done.
+- Optional **`hasShotChart`** on `SportConfig` instead of hard-coded basketball id.
+- **Unit tests** for `isThreePointer` / `classifyShotZone` (and optionally sync mapping).
+- **Multi-recorder:** chart rows are per `recorded_by`; merging or “primary recorder” view for shots is a future product decision.
+- **Design doc** [DESIGN_SHOT_CHART.md](DESIGN_SHOT_CHART.md): vision still describes restricted arc / some colors differently from the shipped diagram — see SC-1 notes for intentional MVP deltas.
+
+### Process / quality suggestions (for future features)
+
+1. **Keep a short “Status” block** at the top of implementation plans once work lands — avoids scanning every SC section for done vs todo.
+2. **PR template checklist:** migration applied? smoke path (record → sync → reload)? Especially when schema and client ship together.
+3. **Single contract doc** — shot chart already points at `shotChartCoordinates.ts`; for new surfaces, link that file from any new entry points.
+4. **Optional CI:** `pnpm test` with Vitest for pure functions (`courtGeometry`) is cheap insurance when geometry or sync mapping changes.
+5. **Feature flag or version gate** if the client must tolerate missing DB tables briefly (SC-6 already no-ops when `shot_chart` is missing; document that for support).
+
+---
+
 ## 1. Dependency Graph
 
 ```
@@ -120,48 +158,14 @@ SC-5  Game Summary      │
 - **Coordinate contract:** `src/lib/shotChartCoordinates.ts` documents feet-from-rim space; `ShotRecord` in `types.ts` references it; `BasketballCourt.tsx` header points to the same. Taps must feed `isThreePointer` / `classifyShotZone` without transforming `x`/`y`.
 - **QA:** `/#/dev/shot-chart` preview and dev auth bypass unchanged; remove in a later cleanup SC.
 
-**What to do:**
+**Implemented (combined SC-2 + SC-3 wiring):** Full `ShotChart` page uses **`GameState.shotChart`** and **`ADD_SHOT`** (not local-only state). Mode toggle, player strip, `ShootingSummary` below court, undo/clear flows per SC-4/SC-7. Route and tracker entry were added in prep; see **Status** section above.
 
-1. **`src/pages/ShotChart.tsx`** — Full-screen shot chart page (extend the shell):
-   - Reads `sport`, `players`, `activePlayerId` from `GameContext`
-   - Guard: already redirects to `/` if not basketball or no game in progress
-   - **Header**: optional "Clear All" button (in addition to existing "← Back to Stats")
-   - **Mode toggle**: "Made" / "Missed" segmented control (local state: `mode: 'made' | 'missed'`)
-     - Made: green background when active
-     - Missed: red background when active
-   - **Player selector**: horizontal strip (same as Game Tracker) so the coach can switch who the shot is attributed to. Active player is highlighted.
-   - **Court**: Full-width `<BasketballCourt>` with `onCourtTap` handler
-   - **On tap**: Create a `ShotRecord` from coordinates + mode + active player:
-     - `id`: generated unique ID
-     - `x`, `y`: from court tap
-     - `made`: from mode toggle
-     - `shotType`: from `isThreePointer(x, y)`
-     - `zone`: from `classifyShotZone(x, y)`
-     - `playerId`: `activePlayerId`
-     - `timestamp`: `Date.now()`
-   - For now, store shots in **local component state** (will wire to GameContext in SC-3). This lets us test the UI independently.
-   - **Shooting summary**: Below the court, show zone-based stats computed from local shot array (see [SHOT_CHART §5.7](DESIGN_SHOT_CHART.md)):
-     - Paint: M/A (pct%) | Mid: M/A (pct%) | 3PT: M/A (pct%) | Total: M/A (pct%)
-   - **Undo**: "↩ Undo Last Shot" button removes the last shot from local state
+**Optional later:** `hasShotChart` on `SportConfig` — skipped for MVP.
 
-2. **`src/App.tsx`** — Route already added (`/shot-chart`).
-
-3. **`src/pages/GameTracker.tsx`** — Entry button already added (basketball only).
-
-4. **`src/config/sports.ts`** — Optional: `hasShotChart` on `SportConfig` — **skipped for MVP**; basketball-only via `sport.id === 'basketball'`.
-
-**Files touched (remaining SC-2 work):** primarily `src/pages/ShotChart.tsx`; optionally `src/config/sports.ts` / `types.ts` if adding `hasShotChart` later.
+**Files touched:** `ShotChart.tsx`, `App.tsx`, `GameTracker.tsx` (and SC-3/4/5/7 files as listed in those sections).
 
 **Test breakpoint:**
-- Start a basketball game → see **Shot chart** button on Game Tracker
-- Tap button → full-screen court loads; then add mode toggle and player selector
-- Toggle to "Made" → tap court → green circle appears at tapped location
-- Toggle to "Missed" → tap court → red X appears
-- Shooting summary shows correct counts and percentages
-- Undo removes the last shot
-- "Back to Stats" returns to Game Tracker
-- No shot chart button for baseball or other sports
-- Court fills the screen width on mobile
+- Basketball game → **Shot chart** → record made/miss → stats and summary tab update → back to tracker shows badge
 
 **Commit message:** `feat: add interactive shot chart page with made/missed toggle and court tapping`
 
@@ -183,9 +187,7 @@ SC-5  Game Summary      │
 
 3. **`src/pages/ShotChart.tsx`** — Renders `state.shotChart`, `onCourtTap` → `ADD_SHOT` (uses `isThreePointer` / `classifyShotZone` on tap `x,y`), made/missed toggle + player strip; **Undo** dispatches `UNDO` (same as Game Tracker for shot-originated increments).
 
-4. **Cloud open-game hydrates** (`Games.tsx`, `PlayerProfile.tsx`, `CareerStats.tsx`) — `shotChart: []` on fresh hydrate (chart data still SC-6).
-
-**Remaining (later work units):** SC-4 polish (dedicated “undo last shot” copy, `REMOVE_LAST_SHOT` UX); SC-5 summary; SC-6 persist `shotChart` to Supabase.
+4. **Cloud open-game hydrates** (`Games.tsx`, `PlayerProfile.tsx`, `CareerStats.tsx`) — `shotChart` from `HydratedCloudGame` when migration **032** is applied.
 
 **Files touched:** `src/types.ts`, `src/context/GameContext.tsx`, `src/pages/ShotChart.tsx`, `Games.tsx`, `PlayerProfile.tsx`, `CareerStats.tsx`
 

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -125,6 +125,20 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 
 ---
 
+## 4d. Shot chart — dev preview (SVG / layout QA)
+
+**Purpose:** Quickly verify **half-court SVG** geometry and markers **without** signing in or starting a game. **Dev only** (`pnpm dev`).
+
+| Step | Action | Expected |
+|------|--------|------------|
+| 4d.1 | `pnpm dev` → open `http://localhost:5173/#/dev/shot-chart` (HashRouter) | **Shot chart preview (dev)** page with sample made/miss markers on the court |
+| 4d.2 | (Optional) With Supabase configured | App **skips the auth screen** when the URL hash contains `/dev/shot-chart` so the preview loads immediately |
+| 4d.3 | Production build (`pnpm build` + `pnpm preview`) | The `/dev/shot-chart` route is **not** registered in production bundles; use a **real** basketball game and `#/shot-chart` for end-user testing |
+
+**Related:** Full shot chart flow (stats, cloud) — start a basketball game → **Shot chart** on Game Tracker → `#/shot-chart`. See [DESIGN_SHOT_CHART_IMPLEMENTATION.md](DESIGN_SHOT_CHART_IMPLEMENTATION.md).
+
+---
+
 ## 5. Game flow (local state)
 
 **Precondition:** Any mode (offline or signed in).
@@ -281,6 +295,7 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 ## Notes
 
 - **HashRouter:** In-app links use hash routes (e.g. `/#/game`, `/#/teams`).  
+- **Shot chart SVG (dev QA):** `/#/dev/shot-chart` — see **§4d** above (`ShotChartPreview.tsx` + optional auth bypass in `App.tsx` only in dev).
 - **localStorage:** Game and settings key `statkeeper_game`; clear to reset local state.  
 - **Migrations:** If a script fails on cloud features, confirm migrations through **019** are applied in Supabase SQL Editor when using seasons, `team_players`, and data-integrity constraints (`019_data_integrity_constraints.sql`). Run `supabase/scripts/audit_data_integrity_pre_019.sql` before `019` if upgrading an existing project. For **player merge** (Teams → Merge players), apply **`024_player_merge_rpcs.sql`** ([DESIGN_PLAYER_MERGE.md](DESIGN_PLAYER_MERGE.md)).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Earlier commit **53a3f4f**: implementation plan **Status** table, README shot chart feature, `DESIGN_SHOT_CHART.md` shipped note, SC-2/SC-3 doc fixes.
- Commit **90f4696**: **§4d** in `docs/REGRESSION_TESTING.md` for dev SVG QA (`/#/dev/shot-chart`); Notes bullet; **AGENTS.md** gotcha for dev vs real `#/shot-chart`.

## PR note

Doc updates (**53a3f4f**) were pushed when the SC-7 PR may already have been merged/closed — if those files are not on `stattracker`, merge this branch or cherry-pick **53a3f4f** + **90f4696**.

## Supabase

Migration **032** applied per user — shot chart cloud sync should be live.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c547603a-ccd8-4d79-aede-fcbad6160d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

