### PR TITLE
Log cloud sync failures to client_sync_errors

### DIFF
--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -24,6 +24,7 @@ import {
   getLastOpenedPreferenceSupport,
 } from '../lib/cloudSync'
 import { supabase } from '../lib/supabase'
+import { logClientSyncError } from '../lib/logClientSyncError'
 import { sports } from '../config/sports'
 import { getDisplayedHomeScore } from '../lib/gameScore'
 
@@ -853,13 +854,17 @@ export function GameProvider({ children }: { children: ReactNode }) {
         })
         return
       }
+      const errMsg = error instanceof Error ? error.message : 'Cloud sync failed'
       dispatch({
         type: 'SET_CLOUD_SYNC_STATE',
         cloudSync: {
           status: 'error',
-          lastError: error instanceof Error ? error.message : 'Cloud sync failed',
+          lastError: errMsg,
         },
       })
+      if (userId) {
+        void logClientSyncError(userId, errMsg, stateRef.current)
+      }
     } finally {
       syncInFlightRef.current = false
     }

--- a/src/lib/logClientSyncError.ts
+++ b/src/lib/logClientSyncError.ts
@@ -1,0 +1,65 @@
+import type { GameState } from '../types'
+import { supabase } from './supabase'
+
+function isMissingClientSyncErrorsTableError(error: { message?: string } | null): boolean {
+  if (!error?.message) return false
+  const m = error.message.toLowerCase()
+  return (
+    (m.includes('client_sync_errors') && m.includes('relation') && m.includes('does not exist')) ||
+    (m.includes('client_sync_errors') && m.includes('could not find the table'))
+  )
+}
+
+let lastLogKey = ''
+let lastLogAt = 0
+const THROTTLE_MS = 45_000
+
+function buildSyncErrorContext(state: GameState): Record<string, unknown> {
+  return {
+    sportId: state.sport?.id ?? null,
+    teamName: state.gameInfo?.teamName ?? null,
+    opponentName: state.gameInfo?.opponentName ?? null,
+    tournamentId: state.gameInfo?.tournamentId ?? null,
+    tournamentName: state.gameInfo?.tournamentName ?? null,
+    gameDate: state.gameInfo?.date ?? null,
+    cloudGameId: state.cloudSync.gameId ?? null,
+    cloudTeamId: state.cloudSync.teamId ?? null,
+    cloudSeasonId: state.cloudSync.seasonId ?? null,
+    playerCount: state.players.length,
+    shotChartCount: state.shotChart.length,
+    pathname: typeof window !== 'undefined' ? window.location.pathname : null,
+    hash: typeof window !== 'undefined' ? window.location.hash : null,
+  }
+}
+
+/**
+ * Inserts one row for debugging sync failures that happen before DB writes succeed.
+ * Throttled to avoid flooding if sync retries rapidly. Swallows errors (including missing table).
+ */
+export async function logClientSyncError(
+  userId: string,
+  message: string,
+  state: GameState
+): Promise<void> {
+  if (!supabase || !userId) return
+
+  const trimmed = message.trim().slice(0, 4000)
+  const throttleKey = `${userId}:${trimmed}`
+  const now = Date.now()
+  if (throttleKey === lastLogKey && now - lastLogAt < THROTTLE_MS) {
+    return
+  }
+  lastLogKey = throttleKey
+  lastLogAt = now
+
+  const { error } = await supabase.from('client_sync_errors').insert({
+    user_id: userId,
+    message: trimmed,
+    context: buildSyncErrorContext(state),
+  })
+
+  if (error && isMissingClientSyncErrorsTableError(error)) {
+    return
+  }
+  // Intentionally quiet on other failures (RLS, network) to avoid recursive noise
+}

--- a/supabase/migrations/033_client_sync_errors.sql
+++ b/supabase/migrations/033_client_sync_errors.sql
@@ -1,0 +1,23 @@
+-- Client-reported cloud sync failures (e.g. errors before any game row exists).
+
+create table if not exists public.client_sync_errors (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles (id) on delete cascade,
+  created_at timestamptz not null default now(),
+  message text not null,
+  context jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_client_sync_errors_user_created
+  on public.client_sync_errors (user_id, created_at desc);
+
+comment on table public.client_sync_errors is
+  'Best-effort inserts from the app when syncGameSnapshotToCloud fails (non-network).';
+
+alter table public.client_sync_errors enable row level security;
+
+create policy "client_sync_errors_select_own" on public.client_sync_errors
+  for select using (user_id = auth.uid());
+
+create policy "client_sync_errors_insert_own" on public.client_sync_errors
+  for insert with check (user_id = auth.uid());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small `public.client_sync_errors` table and a best-effort client insert when `syncGameSnapshotToCloud` throws a **non-network** error. That covers failures that happen before any `games` / `game_stats` row is written, which were otherwise invisible in the database.

## Details

- **Migration `033_client_sync_errors.sql`:** table with `user_id`, `message`, `context` (jsonb), indexed by user + time. RLS: authenticated users may **insert** and **select** only their own rows (`user_id = auth.uid()`).
- **`logClientSyncError`:** throttles identical `(userId, message)` to once per 45s; truncates message to 4000 chars; `context` includes sport, team/opponent names, tournament ids/names, game date, current cloud ids, player/shot counts, and URL hash (useful for checkout vs tracker). Silently no-ops if the table does not exist yet (same pattern as shot chart).
- **`GameContext`:** after dispatching `cloudSync.status: 'error'`, calls `logClientSyncError` when `userId` is set.

The hosted Supabase project was updated via MCP with the same migration so production can receive rows as soon as this ships.

## How to use

In Supabase Table Editor or SQL:

```sql
select created_at, message, context
from public.client_sync_errors
order by created_at desc
limit 50;
```

Filter by user if needed (`user_id = '...'`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-840bf349-fd29-423c-bed7-58e802ec8b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-840bf349-fd29-423c-bed7-58e802ec8b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

