### PR TITLE
Backfill persisted sync errors to client_sync_errors

### DIFF
--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -24,7 +24,7 @@ import {
   getLastOpenedPreferenceSupport,
 } from '../lib/cloudSync'
 import { supabase } from '../lib/supabase'
-import { logClientSyncError } from '../lib/logClientSyncError'
+import { isPersistedSyncLastErrorNetworkish, logClientSyncError } from '../lib/logClientSyncError'
 import { sports } from '../config/sports'
 import { getDisplayedHomeScore } from '../lib/gameScore'
 
@@ -32,6 +32,8 @@ import { getDisplayedHomeScore } from '../lib/gameScore'
 export const GAME_STORAGE_KEY = 'statkeeper_game'
 const CLOUD_RESUME_TARGETS_KEY = 'statkeeper_cloud_resume_targets'
 const PENDING_SYNC_KEY = 'statkeeper_pending_sync'
+/** One row per user+message: persisted `cloudSync.lastError` uploaded to `client_sync_errors`. */
+const SYNC_LAST_ERROR_BACKFILL_PREFIX = 'statkeeper_sync_err_backfill:'
 
 function getPendingSyncFlag(): boolean {
   try {
@@ -648,6 +650,45 @@ export function GameProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     stateRef.current = state
   }, [state])
+
+  /** Upload a previously persisted sync error once (before `client_sync_errors` existed or insert failed). */
+  useEffect(() => {
+    if (!isConfigured || !userId || !supabase || !isOnline) return
+    const msg = state.cloudSync.lastError?.trim()
+    if (!msg || state.cloudSync.status !== 'error') return
+    if (isPersistedSyncLastErrorNetworkish(msg)) return
+
+    const key = `${SYNC_LAST_ERROR_BACKFILL_PREFIX}${userId}:${msg}`
+    try {
+      if (localStorage.getItem(key) === '1') return
+    } catch {
+      return
+    }
+
+    let cancelled = false
+    void (async () => {
+      const ok = await logClientSyncError(userId, msg, stateRef.current, {
+        bypassThrottle: true,
+        extraContext: { source: 'localStorage_backfill' },
+      })
+      if (cancelled || !ok) return
+      try {
+        localStorage.setItem(key, '1')
+      } catch {
+        // ignore
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    isConfigured,
+    userId,
+    isOnline,
+    state.cloudSync.lastError,
+    state.cloudSync.status,
+  ])
 
   useEffect(() => {
     localStorage.setItem(GAME_STORAGE_KEY, JSON.stringify(state))

--- a/src/lib/logClientSyncError.ts
+++ b/src/lib/logClientSyncError.ts
@@ -1,6 +1,10 @@
 import type { GameState } from '../types'
 import { supabase } from './supabase'
 
+export function isPersistedSyncLastErrorNetworkish(message: string): boolean {
+  return /(network|offline|failed to fetch|fetch failed|timeout)/i.test(message)
+}
+
 function isMissingClientSyncErrorsTableError(error: { message?: string } | null): boolean {
   if (!error?.message) return false
   const m = error.message.toLowerCase()
@@ -13,6 +17,12 @@ function isMissingClientSyncErrorsTableError(error: { message?: string } | null)
 let lastLogKey = ''
 let lastLogAt = 0
 const THROTTLE_MS = 45_000
+
+export type LogClientSyncErrorOptions = {
+  /** When true, skip the in-memory throttle (e.g. one-shot backfill of a stored error). */
+  bypassThrottle?: boolean
+  extraContext?: Record<string, unknown>
+}
 
 function buildSyncErrorContext(state: GameState): Record<string, unknown> {
   return {
@@ -35,31 +45,44 @@ function buildSyncErrorContext(state: GameState): Record<string, unknown> {
 /**
  * Inserts one row for debugging sync failures that happen before DB writes succeed.
  * Throttled to avoid flooding if sync retries rapidly. Swallows errors (including missing table).
+ * @returns true when a row was inserted successfully.
  */
 export async function logClientSyncError(
   userId: string,
   message: string,
-  state: GameState
-): Promise<void> {
-  if (!supabase || !userId) return
+  state: GameState,
+  options?: LogClientSyncErrorOptions
+): Promise<boolean> {
+  if (!supabase || !userId) return false
 
   const trimmed = message.trim().slice(0, 4000)
-  const throttleKey = `${userId}:${trimmed}`
-  const now = Date.now()
-  if (throttleKey === lastLogKey && now - lastLogAt < THROTTLE_MS) {
-    return
+  if (!options?.bypassThrottle) {
+    const throttleKey = `${userId}:${trimmed}`
+    const now = Date.now()
+    if (throttleKey === lastLogKey && now - lastLogAt < THROTTLE_MS) {
+      return false
+    }
+    lastLogKey = throttleKey
+    lastLogAt = now
   }
-  lastLogKey = throttleKey
-  lastLogAt = now
+
+  const baseContext = buildSyncErrorContext(state)
+  const context =
+    options?.extraContext && Object.keys(options.extraContext).length > 0
+      ? { ...baseContext, ...options.extraContext }
+      : baseContext
 
   const { error } = await supabase.from('client_sync_errors').insert({
     user_id: userId,
     message: trimmed,
-    context: buildSyncErrorContext(state),
+    context,
   })
 
   if (error && isMissingClientSyncErrorsTableError(error)) {
-    return
+    return false
   }
-  // Intentionally quiet on other failures (RLS, network) to avoid recursive noise
+  if (error) {
+    return false
+  }
+  return true
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Uploads a previously persisted `cloudSync.lastError` from localStorage once when the app loads (signed in, online, status error).

## Details

- Dedupe: `localStorage` key `statkeeper_sync_err_backfill:${userId}:${message}` after successful insert.
- Context includes `source: 'localStorage_backfill'`.
- Skips network-ish messages.
- `logClientSyncError` returns boolean; supports `bypassThrottle` and `extraContext`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-840bf349-fd29-423c-bed7-58e802ec8b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-840bf349-fd29-423c-bed7-58e802ec8b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

