### PR TITLE
Fix cloud sync invalid UUID for team placeholder (__team_home__)

### DIFF
--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -25,6 +25,7 @@ import {
 } from '../lib/cloudSync'
 import { supabase } from '../lib/supabase'
 import { isPersistedSyncLastErrorNetworkish, logClientSyncError } from '../lib/logClientSyncError'
+import { sanitizePlayerIdMapForCloud } from '../lib/uuidValidation'
 import { sports } from '../config/sports'
 import { getDisplayedHomeScore } from '../lib/gameScore'
 
@@ -612,7 +613,7 @@ function loadState(): GameState {
     cloudSync: {
           ...createInitialCloudSyncState(restoredStatus),
           ...(parsed.cloudSync ?? {}),
-          playerIdMap: parsed.cloudSync?.playerIdMap ?? {},
+          playerIdMap: sanitizePlayerIdMapForCloud(parsed.cloudSync?.playerIdMap ?? {}),
           gameStatus: parsed.cloudSync?.gameStatus ?? null,
           status: restoredStatus,
         },

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -1,6 +1,7 @@
 import type { GameInfo, GameState, Player, ShotRecord } from '../types'
 import { supabase } from './supabase'
 import { isTeamPseudoPlayer, TEAM_PLAYER_HOME_ID, TEAM_PLAYER_OPP_ID } from './teamPlayers'
+import { isValidRemotePlayerUuid } from './uuidValidation'
 
 interface SyncGameSnapshotInput {
   state: GameState
@@ -447,15 +448,18 @@ async function ensureTeamPlaceholderPlayer(
 
   const { firstName, lastName } = parsePlayerName(player.name)
 
-  if (existingRemoteId) {
+  const remoteId =
+    existingRemoteId && isValidRemotePlayerUuid(existingRemoteId) ? existingRemoteId : undefined
+
+  if (remoteId) {
     const { error: updateError } = await supabase
       .from('players')
       .update({ first_name: firstName, last_name: lastName || null, nickname: null })
-      .eq('id', existingRemoteId)
+      .eq('id', remoteId)
     if (updateError) {
       throw new Error(`Team placeholder update failed: ${updateError.message}`)
     }
-    return existingRemoteId
+    return remoteId
   }
 
   const fullInsert = {
@@ -527,16 +531,19 @@ async function ensurePlayerId(
 
   const { firstName, lastName } = parsePlayerName(player.name)
 
+  const remoteId =
+    existingRemoteId && isValidRemotePlayerUuid(existingRemoteId) ? existingRemoteId : undefined
+
   if (isTeamPseudoPlayer(player)) {
-    return ensureTeamPlaceholderPlayer(player, userId, existingRemoteId)
+    return ensureTeamPlaceholderPlayer(player, userId, remoteId)
   }
   const jerseyNumber = player.number.trim()
 
-  if (existingRemoteId) {
+  if (remoteId) {
     const { error: updateError } = await supabase
       .from('players')
       .update({ first_name: firstName, last_name: lastName, nickname: null })
-      .eq('id', existingRemoteId)
+      .eq('id', remoteId)
 
     if (updateError) {
       throw new Error(`Player update failed: ${updateError.message}`)
@@ -545,11 +552,11 @@ async function ensurePlayerId(
     await supabase
       .from('team_players')
       .upsert(
-        { team_id: teamId, player_id: existingRemoteId, jersey_number: jerseyNumber, is_active: true },
+        { team_id: teamId, player_id: remoteId, jersey_number: jerseyNumber, is_active: true },
         { onConflict: 'team_id,player_id' }
       )
 
-    return existingRemoteId
+    return remoteId
   }
 
   const { data: existingOnTeam, error: junctionLookupError } = await supabase

--- a/src/lib/uuidValidation.ts
+++ b/src/lib/uuidValidation.ts
@@ -1,0 +1,17 @@
+/** True if `id` looks like a Postgres `uuid` (avoids passing local pseudo-ids to `.eq('id', …)`). */
+export function isValidRemotePlayerUuid(id: string | undefined | null): id is string {
+  if (!id || typeof id !== 'string') return false
+  const s = id.trim()
+  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(s)
+}
+
+/** Drops map entries whose values are not cloud UUIDs (fixes persisted `__team_home__` → `__team_home__`). */
+export function sanitizePlayerIdMapForCloud(map: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [localId, remoteId] of Object.entries(map)) {
+    if (isValidRemotePlayerUuid(remoteId)) {
+      out[localId] = remoteId
+    }
+  }
+  return out
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause (from `client_sync_errors`)

`Team placeholder update failed: invalid input syntax for type uuid: "__team_home__"` — `cloudSync.playerIdMap` had mapped the local pseudo id `__team_home__` to the string `__team_home__` instead of a real `players.id` UUID. Sync then ran `UPDATE players ... WHERE id = '__team_home__'`, which Postgres rejects.

## Fix

- `src/lib/uuidValidation.ts`: `isValidRemotePlayerUuid` + `sanitizePlayerIdMapForCloud`.
- `cloudSync.ts`: `ensureTeamPlaceholderPlayer` / `ensurePlayerId` only treat values as remote ids when they pass UUID format; otherwise create/lookup as before.
- `GameContext` `loadState`: sanitize persisted `playerIdMap` so bad entries are dropped on reload.

## Context

`cloudGameId` was null in logged errors — sync died on the first team pseudo player before the game row was created. After this fix, first sync should create placeholder `players` rows and proceed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-840bf349-fd29-423c-bed7-58e802ec8b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-840bf349-fd29-423c-bed7-58e802ec8b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

