### PR TITLE
Add CI workflow for PR status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - stattracker
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a lightweight GitHub Actions workflow that runs on pull requests targeting `stattracker`. This provides a status check GitHub can require in branch protection rules.

With **Require branches to be up to date before merging** enabled, you need at least one required status check before GitHub shows the **Update branch** button when the base branch moves ahead.

## What it runs

On each PR (and when the PR branch is updated):

- `pnpm lint`
- `pnpm test`
- `pnpm build`

## After merge — branch protection setup

1. Open **Settings → Branches → Branch protection rules** for `stattracker`.
2. Under **Require status checks to pass before merging**, click **+ Add checks**.
3. Select **`ci`** (may appear as **CI / ci**).
4. Save the rule.

Once that check is required, PRs that fall behind `stattracker` will show **Update branch** in the GitHub UI.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f61a516b-f339-4b75-9aad-8b18b8afdf2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f61a516b-f339-4b75-9aad-8b18b8afdf2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

