### PR TITLE
Fix: court popup ghost-tap guard + more forgiving tap detection

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -152,13 +152,14 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4e.5 | Tap the court beyond the arc → **Missed** | "Detected: 3-pointer"; red ✕ marker; `3 Miss` +1; score unchanged |
 | 4e.6 | Tap court → **Off Reb** (repeat for Def Reb / Steal / Block / Assist) | Popup closes; the matching stat (`OFF`/`DEF`/`STL`/`BLK`/`AST`) +1; **no marker** on the court |
 | 4e.7 | Tap court → **Cancel** (or tap outside the popup) | Popup dismisses; no stat, no marker |
-| 4e.8 | Start a scroll gesture with the finger **on the court** | Page scrolls; no popup opens (tap-vs-scroll discrimination, ~10px tolerance) |
+| 4e.8 | Start a scroll gesture with the finger **on the court** | Page scrolls; no popup opens (tap-vs-scroll discrimination, ~18px tolerance — slightly wobbly taps still count as taps) |
 | 4e.9 | Select the opponent team chip (★) → tap court → Made | Shot attributed to the opponent pseudo-player |
 | 4e.10 | Tap **↩ Undo** (bottom bar) or **↩ Undo last shot** after a popup shot | Marker removed and stat reverted |
 | 4e.11 | Log a made 2 via popup, then tap the `2PT` grid button | Both increment the same stat (additive — dual input by design); correct with the button's − or Undo |
 | 4e.12 | Open `#/shot-chart` directly | Redirects to `#/game` (or home when no basketball game) |
 | 4e.13 | Non-basketball sport (e.g. soccer) → Game Tracker | Page unchanged: no court, full grid only |
 | 4e.14 | Reload mid-game | Shots/stats restored from `localStorage`; markers still on the court |
+| 4e.15 | Tap the court at a spot where a popup button will appear (e.g. where Def Reb renders) | Popup opens and **waits** — the opening tap never activates the button under the finger (ghost-tap guard: presses count only when begun on the popup, ≥300ms after it opened). A deliberate second tap then works normally |
 
 ---
 

--- a/src/components/shot-chart/BasketballCourt.tsx
+++ b/src/components/shot-chart/BasketballCourt.tsx
@@ -22,8 +22,12 @@ import {
 } from './courtGeometry'
 
 const TAP_DEBOUNCE_MS = 120
-/** Screen-px movement beyond which a pointer gesture counts as a scroll, not a tap (D9). */
-const TAP_MOVE_TOLERANCE_PX = 10
+/**
+ * Screen-px movement beyond which a pointer gesture counts as a scroll, not a tap (D9).
+ * 10px rejected too many real taps in device testing (fingers drift a few px); 18px keeps
+ * taps forgiving while a deliberate scroll flick still travels well past it.
+ */
+const TAP_MOVE_TOLERANCE_PX = 18
 
 interface BasketballCourtProps {
   shots: ShotRecord[]

--- a/src/components/shot-chart/CourtEventPopup.tsx
+++ b/src/components/shot-chart/CourtEventPopup.tsx
@@ -1,4 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+
+/**
+ * Presses within this window after opening are ignored. Combined with the
+ * pointer-down arming check below, this stops the court tap that opened the
+ * popup from also activating whichever button renders under the finger.
+ */
+const ARMING_DELAY_MS = 300
 
 /** Stat-only events the popup can record (no court location stored). */
 export const COURT_STAT_EVENTS = [
@@ -37,6 +44,34 @@ export default function CourtEventPopup({
   onPick,
   onCancel,
 }: CourtEventPopupProps) {
+  /**
+   * Ghost-tap guard: the court tap that opens the popup fires a trailing `click` at the
+   * same screen point, which would instantly press whatever button rendered under the
+   * finger. A press only counts when its `pointerdown` landed on the popup itself, at
+   * least ARMING_DELAY_MS after opening — the opening tap's pointer-down happened before
+   * the popup existed, so it can never arm it.
+   */
+  const openedAtRef = useRef(Date.now())
+  const armedRef = useRef(false)
+
+  const handlePointerDownCapture = () => {
+    if (Date.now() - openedAtRef.current >= ARMING_DELAY_MS) {
+      armedRef.current = true
+    }
+  }
+
+  const pick = (event: CourtEvent) => {
+    if (!armedRef.current) return
+    armedRef.current = false
+    onPick(event)
+  }
+
+  const cancel = () => {
+    if (!armedRef.current) return
+    armedRef.current = false
+    onCancel()
+  }
+
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onCancel()
@@ -48,7 +83,8 @@ export default function CourtEventPopup({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
-      onClick={onCancel}
+      onPointerDownCapture={handlePointerDownCapture}
+      onClick={cancel}
     >
       <div
         className="bg-white rounded-2xl shadow-xl max-w-sm w-full p-4 space-y-3"
@@ -64,7 +100,7 @@ export default function CourtEventPopup({
         <div className="grid grid-cols-2 gap-2">
           <button
             type="button"
-            onClick={() => onPick({ kind: 'shot', made: true })}
+            onClick={() => pick({ kind: 'shot', made: true })}
             className="py-4 rounded-xl text-base font-bold text-white bg-emerald-600
                        active:bg-emerald-700 active:scale-95 transition-transform"
           >
@@ -72,7 +108,7 @@ export default function CourtEventPopup({
           </button>
           <button
             type="button"
-            onClick={() => onPick({ kind: 'shot', made: false })}
+            onClick={() => pick({ kind: 'shot', made: false })}
             className="py-4 rounded-xl text-base font-bold text-white bg-rose-600
                        active:bg-rose-700 active:scale-95 transition-transform"
           >
@@ -85,7 +121,7 @@ export default function CourtEventPopup({
             <button
               key={statId}
               type="button"
-              onClick={() => onPick({ kind: 'stat', statId })}
+              onClick={() => pick({ kind: 'stat', statId })}
               className="py-3 px-1 rounded-xl text-sm font-semibold text-slate-700 bg-slate-100
                          border border-slate-200 active:bg-slate-200 active:scale-95 transition-transform"
             >
@@ -100,7 +136,7 @@ export default function CourtEventPopup({
 
         <button
           type="button"
-          onClick={onCancel}
+          onClick={cancel}
           className="w-full py-2.5 rounded-xl text-sm font-semibold text-slate-600 border border-slate-300
                      active:scale-95 transition-transform"
         >


### PR DESCRIPTION
## Summary

Two device-testing fixes for the court event capture popup (F1), found during manual QA:

- **Ghost-tap guard (`CourtEventPopup.tsx`):** the court tap that opens the popup fires a trailing `click` at the same screen point, instantly pressing whichever popup button rendered under the finger (typically Def Reb) — the user never even saw the popup. The popup now only accepts a press whose `pointerdown` landed **on the popup itself, ≥300ms after opening**. The opening tap's pointer-down happened before the popup existed, so it can never activate a button (or the tap-outside cancel). Deliberate taps after the popup appears behave exactly as before; Escape still works immediately.
- **Tap-vs-scroll tolerance (`BasketballCourt.tsx`):** raised `TAP_MOVE_TOLERANCE_PX` from 10 → 18. At 10px, natural finger drift during a tap was frequently classified as a scroll and the tap did nothing; 18px keeps taps forgiving while a real scroll flick still travels well past it.
- **Docs:** regression script §4e.8 updated (new tolerance) and new step §4e.15 (ghost-tap guard).

## Test plan

- [x] `pnpm build`, `pnpm lint`, `pnpm test` — clean/green
- [ ] Device QA: tap a court spot that lines up with a popup button — popup opens and waits; nothing is recorded until a second, deliberate tap
- [ ] Device QA: normal (slightly wobbly) taps open the popup reliably; scrolling with a finger on the court still never opens it (§4e.8)
- [ ] Tap-outside cancel and Escape still dismiss with no stat recorded
