### PR TITLE
docs: clean up roadmap drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,10 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 
 ### What's Next
 
+- [ ] **Court capture polish** — F5/F6/F12/F7 are planned next slices for shot-value override, in-popup player switching, recent-events undo, and assist-linking; F8-F11 remain roadmap sketches ([roadmap](docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md))
+- [ ] **Team Info hub + drill-downs** — canonical `/team?teamId=` route with roster, schedule, player/game/season drill-downs ([plan](docs/PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md))
 - [ ] **Multi-game parking + sync queue** — multiple in-progress/paused games per device, offline-safe snapshots, ordered cloud sync ([plan](docs/PLAN_MULTI_GAME_PARKING.md))
-- [ ] Stat view redesign: career stats page, tournament stats page, team season summary, inline game stat lines on player profile (design: [DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md))
+- [ ] **Stat view follow-ups** — the major career/season/team/tournament stat views are shipped; use [DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md) and [completed/STAT_TRACKING_UI_PROGRESS.md](docs/completed/STAT_TRACKING_UI_PROGRESS.md) as references for smaller refinements
 - [ ] Team collaboration invites: multi-parent workflows, invite links (design: [DESIGN_MULTI_PARENT_INVITE_LINKS.md](docs/archived/DESIGN_MULTI_PARENT_INVITE_LINKS.md))
 - [ ] Per-sport stat refinements and additional stats (minutes for hockey/soccer/football, missed shots for hockey)
 - [ ] Player transfer UI: search/autocomplete for adding existing players to new teams
@@ -338,7 +340,7 @@ A backlog of ideas to iterate over:
 2. **Editable team names, player names, and tournaments** — Allow editing from the proper locations; editing and sync work for both local and cloud. *Implemented: team name + nickname editable from Teams page; player first/last name, jersey number, nickname editable from Teams roster; opponent name editable from Games history (inline edit). Tournaments as first-class entity — `tournaments` table (migration 016) with team-scoped picker in Game Setup; games reference `tournament_id`. Design: [DESIGN_TOURNAMENTS.md](docs/completed/DESIGN_TOURNAMENTS.md).*
 4. **Minutes played, game notes, missed shots** — Extend stat tracking. *Implemented: minutes played as per-player counter in basketball (stat `min`, Playmaking category); game notes with free-text field in Game Tracker and Game Summary, synced to cloud (migration 017); missed shots for basketball with [−][A][+] attempt buttons and M/A (%) columns in Game Summary.*
 5. **Delete editable entities** — Ability to delete all editable things (teams, players, tournaments, games, etc.). Every delete action shows a confirmation prompt with Yes/No buttons before proceeding. *Implemented: delete teams, players (hard delete), games, and tournaments from the Teams page, Games page, Game Setup tournament picker, and a centralized Data Management section in Settings (Admin). All deletes show a confirmation dialog. Cascading deletes handled by Supabase FK constraints (`ON DELETE CASCADE`).*
-6. **Score totals in game list** — Game summaries / game history menu should show the score totals for each team (home vs opponent) in the list.
+6. **Score totals in game list** — *Implemented for final and in-progress Cloud Games cards via F4; scheduled 0-0 games hide the score.*
 7. **Optional stat descriptions** — Toggle to display full stat names (e.g., "Free Throw") instead of abbreviated labels (e.g., "FT"); or optionally show stat descriptions.
 8. **Games tied to season** — Determine how games are tied to an individual season (e.g., team has season field; games inherit or reference it; season filter in leaderboard). *Implemented: `seasons` table as top-level entity (migration 018); teams belong to a season via `season_id` FK; games inherit season through their team; season filter in Game Setup; season CRUD in Settings. Design: [DESIGN_SEASONS_DATA_MODEL.md](docs/completed/DESIGN_SEASONS_DATA_MODEL.md).*
 9. **Clean up existing games** — A way to clean up existing games (delete, archive, or bulk actions). *Partially addressed by enhancement #5 (delete games individually from Games page and Data Management in Settings). Bulk actions and archive not yet implemented.*
@@ -347,7 +349,7 @@ A backlog of ideas to iterate over:
 
 ### Known Issues
 
-1. **Completed game appears as both final and in progress** — When a game is completed from the summary, in cloud saves it appears as both a completed game and as an in-progress game. When a game is closed and saved, the in-progress game should end.
+1. **Verify historical duplicate final/in-progress listing** — Older docs noted that a completed cloud game could appear as both final and in progress after finalization. Re-test this against the current Cloud Games flow before treating it as an active bug; if it still reproduces, fix the finalization/list filtering path.
 
 ### Performance updates
 

--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -200,22 +200,28 @@ flowchart LR
 | [`REGRESSION_TESTING.md`](REGRESSION_TESTING.md) | Manual test scripts — extend when behavior changes |
 | [`INTEGRATION_PLAN.md`](INTEGRATION_PLAN.md) | Cloud architecture bible (long; use as reference) |
 
-### Active work (check before starting)
+### Active / next work (check before starting)
 
 | Doc | Topic |
 |-----|-------|
-| [`PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md`](PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md) | Scrollable tracker + court tap popup |
-| [`PLAN_F2`–`F7`, `F12`](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | Court capture enhancements (see roadmap for order) |
+| [`PLAN_F5_AUTO_2_3_OVERRIDE.md`](PLAN_F5_AUTO_2_3_OVERRIDE.md) | Next small court-capture correctness win: pre-log 2PT/3PT override |
+| [`PLAN_F6_IN_POPUP_PLAYER_SWITCH.md`](PLAN_F6_IN_POPUP_PLAYER_SWITCH.md) | Next attribution win: confirm/switch player inside `CourtEventPopup` |
+| [`PLAN_F12_RECENT_EVENTS_UNDO.md`](PLAN_F12_RECENT_EVENTS_UNDO.md) | Recent-events undo popup; build before F7 |
+| [`PLAN_F7_ASSIST_LINKING.md`](PLAN_F7_ASSIST_LINKING.md) | Assist-linking after made shots; depends on F12 for transparent undo |
+| [`PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md`](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | Remaining F8-F11 sketches and overall court-capture order |
 | [`PLAN_MULTI_GAME_PARKING.md`](PLAN_MULTI_GAME_PARKING.md) | Multiple parked games + sync queue |
 | [`PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md`](PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md) | Team hub drill-down routes |
 
-**Build order (court program):** F1 → F2 → F3; F12 before F7; F4 anytime; F5–F11 per roadmap.
+**Court program status:** F1-F4 are implemented; manual Supabase-heavy QA remains in
+[`REGRESSION_TESTING.md`](REGRESSION_TESTING.md). For remaining court work, F5/F6 are ready
+small slices, F12 must precede F7, F8-F10 are polish sketches, and F11 should stay gated on
+live-use feedback.
 
 ### Verification norms
 
 CI ([`.github/workflows/ci.yml`](../.github/workflows/ci.yml)): `pnpm lint` → `pnpm test` → `pnpm build`.
 
-Vitest covers **`src/lib/` pure helpers only** (6 test files). UI validated manually via [`REGRESSION_TESTING.md`](REGRESSION_TESTING.md).
+Vitest covers **`src/lib/` pure helpers only**. UI validated manually via [`REGRESSION_TESTING.md`](REGRESSION_TESTING.md).
 
 When shipping a feature, plans typically call for updating this overview (if architecture changes), `AGENTS.md`, `REGRESSION_TESTING.md`, and `README.md`.
 

--- a/docs/DESIGN_SHOT_TRACKER_UI_REVAMP.md
+++ b/docs/DESIGN_SHOT_TRACKER_UI_REVAMP.md
@@ -4,7 +4,10 @@ Umbrella doc for the StatKeeper basketball shot-tracking revamp. It captures the
 context, the data model the work builds on, the recommended build order, and the
 cross-cutting decisions so the individual plans stay consistent.
 
-> **Status:** Planning only. No code shipped. Each linked plan/sketch is a draft for review.
+> **Status:** F1-F4 are implemented in the app and documented in the linked plans. F5, F6,
+> F7, and F12 have expanded implementation plans; F8-F11 remain roadmap sketches until
+> promoted to full plans. Manual Supabase-heavy QA is still tracked in
+> [REGRESSION_TESTING.md](REGRESSION_TESTING.md).
 >
 > **Major pivot (recorded):** F1 was originally "make the shot chart a tab." After
 > live-use feedback it is now a **single scrollable Game Tracker** where the **court is a
@@ -19,22 +22,21 @@ cross-cutting decisions so the individual plans stay consistent.
 
 | # | Feature | Plan | One-line goal |
 |---|---------|------|----------------|
-| **F1** | Single-page Game Tracker + **Court Event Capture** | [PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md](PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md) | One scroll page; tap court → event popup (Made/Miss w/ auto 2-3 · Off/Def Reb · Steal · Block · Assist) as an *additive* fast input; the **full stat grid stays editable**. |
-| **F2** | Per-player + team shot views | [PLAN_F2_PER_PLAYER_AND_TEAM_SHOT_VIEWS.md](PLAN_F2_PER_PLAYER_AND_TEAM_SHOT_VIEWS.md) | Filter the inline court to the selected player; team selections show every player's shots on that side. |
-| **F3** | Shot trackers on cloud-saved games | [PLAN_F3_CLOUD_GAME_SHOT_CHARTS.md](PLAN_F3_CLOUD_GAME_SHOT_CHARTS.md) | Show full (all-recorder) shot charts when reviewing in-progress/final cloud games. |
-| **F4** | In-progress scores on the resume UI | [PLAN_F4_IN_PROGRESS_SCORES_ON_RESUME_UI.md](PLAN_F4_IN_PROGRESS_SCORES_ON_RESUME_UI.md) | Live score on the home active-game card and the Cloud Games list. |
-| **F5–F12** | Court Event Capture enhancements | [PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | 2/3 override (F5) · in-popup player switch (F6) · assist-linking (F7) · per-player line (F8) · rebound-after-miss (F9) · sequence numbers (F10) · Option B quick buttons (F11) · recent-events undo popup (F12). |
+| **F1** | Single-page Game Tracker + **Court Event Capture** | [PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md](PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md) | **Implemented.** One scroll page; tap court -> event popup (Made/Miss w/ auto 2-3, Off/Def Reb, Steal, Block, Assist) as an additive fast input; the **full stat grid stays editable**. |
+| **F2** | Per-player + team shot views | [PLAN_F2_PER_PLAYER_AND_TEAM_SHOT_VIEWS.md](PLAN_F2_PER_PLAYER_AND_TEAM_SHOT_VIEWS.md) | **Implemented.** Filter the inline court to the selected player; team selections show every player's shots on that side; All shows everything. |
+| **F3** | Shot trackers on cloud-saved games | [PLAN_F3_CLOUD_GAME_SHOT_CHARTS.md](PLAN_F3_CLOUD_GAME_SHOT_CHARTS.md) | **Implemented; needs two-user QA.** Show full all-recorder shot charts when reviewing in-progress/final cloud games. |
+| **F4** | In-progress scores on the resume UI | [PLAN_F4_IN_PROGRESS_SCORES_ON_RESUME_UI.md](PLAN_F4_IN_PROGRESS_SCORES_ON_RESUME_UI.md) | **Implemented; needs cloud-list QA.** Live score on the home active-game card and the Cloud Games list. |
+| **F5-F12** | Court Event Capture enhancements | [PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | **Next court-capture work.** 2/3 override (F5), in-popup player switch (F6), assist-linking (F7), per-player line (F8), rebound-after-miss (F9), sequence numbers (F10), Option B quick buttons (F11), recent-events undo popup (F12). |
 
-F1 is the foundation for F2, F3, and F5–F12. F4 is independent and can land anytime.
+F1 is the foundation for F2, F3, and F5-F12. F4 is independent and has landed.
 
 ## Why these belong together
 
-The shipped shot chart ([completed/DESIGN_SHOT_CHART.md](completed/DESIGN_SHOT_CHART.md),
+The original shot chart ([completed/DESIGN_SHOT_CHART.md](completed/DESIGN_SHOT_CHART.md),
 [completed/DESIGN_SHOT_CHART_IMPLEMENTATION.md](completed/DESIGN_SHOT_CHART_IMPLEMENTATION.md))
-deferred per-player filtering (§2.2, §8.2) and richer review surfaces. F2/F3 are that
-deferred work. F1 reimagines *how stats are entered during live play* (court-as-input),
-which the original docs hinted at but never built; F5–F12 refine that loop. F4 is an
-orthogonal review/resume quality-of-life win.
+deferred per-player filtering (§2.2, §8.2) and richer review surfaces. F2/F3 shipped that
+deferred work. F1 reimagined *how stats are entered during live play* (court-as-input);
+F5-F12 refine that loop. F4 shipped as an orthogonal review/resume quality-of-life win.
 
 ## Current architecture (what the plans build on)
 
@@ -51,9 +53,9 @@ interface ShotRecord {
 }
 ```
 
-Shots live in `GameState.shotChart: ShotRecord[]` (one flat array per game). Key gap for
-F2/F3: **recording is per-player, but display is not** — `BasketballCourt` renders the
-whole array.
+Shots live in `GameState.shotChart: ShotRecord[]` (one flat array per game). F2/F3 now
+consume that player attribution through `shotsForSelection` and the cloud review load path;
+future court-capture enhancements should keep this flat `ShotRecord[]` shape.
 
 **For F1:** the court popup needs **no new data** — Made/Miss → `ADD_SHOT` (which already
 increments `2pt`/`3pt`(`_miss`) + links a `shotId` for undo); rebound/steal/block/assist →
@@ -63,14 +65,14 @@ increments `2pt`/`3pt`(`_miss`) + links a `shotId` for undo); rebound/steal/bloc
 
 | Surface | File | Role |
 |---------|------|------|
-| Game Tracker | `src/pages/GameTracker.tsx` | The main page: scoreboard, player selector strip, stat grid, period toggle, undo bar; today has a **Shot chart** button → `/shot-chart`. **F1 turns this into the single-page court-capture screen.** |
-| Shot Chart page | `src/pages/ShotChart.tsx` | `/shot-chart` route. **F1 redirects this to `/game`** (body becomes the inline `ShotChartPanel`). |
+| Game Tracker | `src/pages/GameTracker.tsx` | The main page: scoreboard, sticky player selector strip, inline court capture, stat grid, period toggle, undo bar. |
+| Shot Chart page | `src/pages/ShotChart.tsx` | Legacy `/shot-chart` route; redirects to `/game`. |
 | Game Summary | `src/pages/GameSummary.tsx` | Read-only tabs (Players / Scores / Team stats / Shot chart) for live + cloud games. |
 | Cloud Games list | `src/pages/Games.tsx` | Lists cloud games; Resume / View Summary; final games show a resolved score line. |
 | Home | `src/pages/SportSelect.tsx` | Active-game card (local state) with Resume/New. |
-| Court | `src/components/shot-chart/BasketballCourt.tsx` | Reusable SVG half-court; `shots` + optional `onCourtTap`. F1 adds tap-vs-scroll discrimination. |
+| Court | `src/components/shot-chart/BasketballCourt.tsx` | Reusable SVG half-court; `shots` + optional `onCourtTap`, with tap-vs-scroll discrimination. |
 | Shooting summary | `src/components/shot-chart/ShootingSummary.tsx` | Zone breakdown for a `shots` array. |
-| Player ordering | `sortTeamPlayersFirst()` (duplicated in `GameTracker`/`ShotChart`) | Team pseudo-players first; F1 extracts this into `PlayerSelectorStrip`. |
+| Player selector | `src/components/PlayerSelectorStrip.tsx` | Shared team-first strip with optional All chip for shot-chart views. |
 
 ### Player model
 
@@ -85,8 +87,9 @@ increments `2pt`/`3pt`(`_miss`) + links a `shotId` for undo); rebound/steal/bloc
 - `shot_chart` table (`supabase/migrations/032_shot_chart.sql`): one row per
   `(game_id, recorded_by, client_shot_id)`. RLS: team members can SELECT all rows for
   their teams' games; writes limited to `recorded_by = auth.uid()`.
-- Hydration (`hydrateCloudGameFromRow`, `src/lib/cloudSync.ts`) loads **only
-  `recorded_by = userId`** shots today (F3 changes this for review).
+- Hydration (`hydrateCloudGameFromRow`, `src/lib/cloudSync.ts`) still loads the viewer's
+  own shots into live `GameState`; F3's `loadGameShotChartForReview` separately loads
+  display-only all-recorder shots for Game Summary review.
 - Scores: `getDisplayedHomeScore()` / `resolveFinalHomeScoreFromGameRow()`
   (`src/lib/gameScore.ts`); `games` rows carry `opponent_score`, `home_team_score`
   (nullable), `home_score_adjustment`.
@@ -120,9 +123,9 @@ increments `2pt`/`3pt`(`_miss`) + links a `shotId` for undo); rebound/steal/bloc
 ## Recommended build order
 
 ```
-F1  Single-page tracker + Court Event Capture     (foundation)
- ├─ F2  Per-player / team shot filtering           (needs F1)
- ├─ F3  Cloud-saved game shot review               (needs F1 + F2)
+F1  Single-page tracker + Court Event Capture     (implemented)
+ ├─ F2  Per-player / team shot filtering           (implemented)
+ ├─ F3  Cloud-saved game shot review               (implemented; two-user QA pending)
  ├─ F5  Auto 2/3 override chip                      (tiny; correctness)
  ├─ F6  In-popup player confirm/switch             (attribution; top pain)
  ├─ F12 Recent-events undo popup                   (correction UX; PRECEDES F7)
@@ -131,9 +134,10 @@ F1  Single-page tracker + Court Event Capture     (foundation)
  ├─ F9  Rebound-after-miss prompt                  (opt-in)
  ├─ F10 Shot sequence numbers / recency            (cosmetic)
  └─ F11 Hybrid quick buttons (Option B)            (only if testing shows it's needed)
-F4  In-progress scores on resume UI                (independent; quick win, anytime)
+F4  In-progress scores on resume UI                (implemented; cloud-list QA pending)
 
-Hard constraints: F1 first · F2 before F3 · F12 before F7 · F4 anytime. Other slots flexible.
+Hard constraints for remaining work: F12 before F7. F5/F6/F8/F9/F10 can be sequenced by
+product priority; F11 should stay gated on live-use feedback.
 ```
 
 Rationale and per-feature phases: see

--- a/docs/INTEGRATION_PLAN.md
+++ b/docs/INTEGRATION_PLAN.md
@@ -697,7 +697,7 @@ The `VITE_` prefix is required by Vite to expose variables to the browser. The p
 
 ## 11. Known Issues
 
-1. **Completed game appears as both final and in progress** — When a game is completed from the summary, in cloud saves it appears as both a completed game and as an in-progress game. When a game is closed and saved, the in-progress game should end.
+1. **Verify historical duplicate final/in-progress listing** — Older notes reported that a completed cloud game could appear as both final and in progress after finalization. Re-test this against the current Cloud Games flow before treating it as an active bug; if it still reproduces, fix the finalization/list filtering path.
 
 ---
 

--- a/docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md
+++ b/docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md
@@ -1,11 +1,10 @@
 # Court Event Capture — Enhancements Roadmap (F5–F12)
 
-> **For agentic workers:** This is a roadmap of **named, ordered, phased sketches** for
-> the follow-on enhancements to the Court Event Capture model introduced in
-> [PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md](PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md). Each
-> item is a sketch (goal, dependency, phases, files, effort, open question), not yet a
-> full task-by-task plan. When one is picked up, expand it to a full plan with a
-> "Pre-handoff design decisions" section like F1–F4.
+> **For agentic workers:** This is the roadmap for follow-on enhancements to the Court
+> Event Capture model introduced in [PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md](PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md).
+> F5, F6, F7, and F12 have expanded implementation plans. F8-F11 are still sketches
+> (goal, dependency, phases, files, effort, open question); when one is picked up, expand
+> it to a full plan with a "Pre-handoff design decisions" section.
 
 All of these **depend on F1** (the single-page tracker + `CourtEventPopup`). None changes
 the data model — they map to existing dispatches (`ADD_SHOT`, `INCREMENT_STAT`) and reuse
@@ -29,13 +28,13 @@ These are the user's six requested enhancements plus the deferred "Option B" hyb
 ## Recommended implementation order (whole program)
 
 Foundation first, then attribution-correctness wins, then progressive polish, with the
-speculative hybrid gated on real use. F4 (resume scores) is independent and can slot in
-anytime as a quick win.
+speculative hybrid gated on real use. F1-F4 have landed; F3/F4 still have Supabase-heavy
+manual QA items tracked in [REGRESSION_TESTING.md](REGRESSION_TESTING.md).
 
 ```
-F1  Single-page tracker + Court Event Capture (foundation)
- ├─ F2  Per-player / team shot filtering        (needs F1)
- ├─ F3  Cloud-saved game shot review             (needs F1 + F2)
+F1  Single-page tracker + Court Event Capture (implemented)
+ ├─ F2  Per-player / team shot filtering        (implemented)
+ ├─ F3  Cloud-saved game shot review             (implemented; two-user QA pending)
  ├─ F5  Auto 2/3 override chip                   (tiny; correctness)
  ├─ F6  In-popup player confirm/switch           (attribution safety; user's top pain)
  ├─ F12 Recent-events undo popup                 (correction UX; PRECEDES F7)
@@ -44,17 +43,16 @@ F1  Single-page tracker + Court Event Capture (foundation)
  ├─ F9  Rebound-after-miss prompt                (needs live tuning; opt-in)
  ├─ F10 Shot sequence numbers / recency          (cosmetic)
  └─ F11 Hybrid quick buttons (Option B)          (only if testing shows blk/stl/ast need 1-tap)
-F4  In-progress scores on resume UI              (independent; quick win, anytime)
+F4  In-progress scores on resume UI              (implemented; cloud-list QA pending)
 ```
 
-**Hard constraints (everything else is flexible):** F1 first · **F2 before F3** (F3 reuses
-F2's `shotsForSelection`) · **F12 before F7** (F7's two-step assist undo relies on F12's
-visible event list) · F4 anytime.
+**Hard constraints for remaining work:** **F12 before F7** (F7's two-step assist undo
+relies on F12's visible event list). F5/F6/F8/F9/F10 can be sequenced by product priority.
+F11 should stay gated on live-use feedback.
 
-**Why this order:** F1 is the foundation. F2 then F3 deliver the per-player + cloud chart
-features early. F5 and F6 are cheap capture-loop wins (correct shot value; confirmed
+**Why this order:** F5 and F6 are cheap capture-loop wins (correct shot value; confirmed
 player). F12 precedes F7 so the recent-events popup makes F7's two-step assist undo
-transparent (no reducer change). F8–F10 are progressive polish. F11 is intentionally last:
+transparent (no reducer change). F8-F10 are progressive polish. F11 is intentionally last:
 build it only if live testing shows the extra tap for block/steal/assist is real friction.
 
 ---


### PR DESCRIPTION
## Summary
- update shot-tracker roadmap docs now that F1-F4 have landed
- refresh agent overview next-work guidance for F5/F6/F12/F7 and F8-F11
- align README and integration known-issue wording with current verification needs

## Testing
- docs-only change
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only updates to roadmap and agent guidance; no application or database changes.
> 
> **Overview**
> **Documentation-only** refresh so agent and product docs match the court-capture program after **F1–F4** landing.
> 
> **README** — *What's Next* now leads with **court capture polish** (F5/F6/F12/F7) and **Team Info drill-downs**; stat-view work is reframed as smaller follow-ups against completed UI docs. **Future enhancement #6** is marked done via **F4** (scores on Cloud Games cards). The duplicate final/in-progress cloud listing is downgraded to a **re-verify** item, not a confirmed active bug.
> 
> **`AGENT_CODEBASE_OVERVIEW.md`** — the active-work table points agents at **F5, F6, F12, F7**, and the **F8–F11** roadmap instead of F1–F4 plans, with an explicit **F1–F4 implemented** status and **F12 before F7** ordering.
> 
> **`DESIGN_SHOT_TRACKER_UI_REVAMP.md`** and **`PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md`** — feature tables and build-order trees mark **F1–F4 implemented** (F3/F4 note pending manual QA); umbrella status and architecture notes describe the **current** Game Tracker / cloud review behavior rather than pre-ship planning copy.
> 
> **`INTEGRATION_PLAN.md`** — known-issue #1 wording matches README (verify before fixing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c730ff962d909d6453cc5151810874cdf7f014cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->