### PR TITLE
docs: plan F13 shot detail workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 
 ### What's Next
 
-- [ ] **Court capture polish** — F5 shot-value override, F6 in-popup player switching, F12 recent-events undo, F7 assist-linking, F8 popup stat line, and F9 rebound-after-miss prompt are implemented; F10-F11 remain roadmap sketches ([roadmap](docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md))
+- [ ] **Court capture polish** — F5 shot-value override, F6 in-popup player switching, F12 recent-events undo, F7 assist-linking, F8 popup stat line, and F9 rebound-after-miss prompt are implemented; F10 visible numbering is superseded by F13 shot detail/edit planning, while F11 remains gated on live-use feedback ([roadmap](docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md), [F13 plan](docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md))
 - [ ] **Team Info hub + drill-downs** — canonical `/team?teamId=` route with roster, schedule, player/game/season drill-downs ([plan](docs/PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md))
 - [ ] **Multi-game parking + sync queue** — multiple in-progress/paused games per device, offline-safe snapshots, ordered cloud sync ([plan](docs/PLAN_MULTI_GAME_PARKING.md))
 - [ ] **Stat view follow-ups** — the major career/season/team/tournament stat views are shipped; use [DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md) and [completed/STAT_TRACKING_UI_PROGRESS.md](docs/completed/STAT_TRACKING_UI_PROGRESS.md) as references for smaller refinements

--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -204,13 +204,15 @@ flowchart LR
 
 | Doc | Topic |
 |-----|-------|
-| [`PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md`](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | Remaining F10-F11 sketches and overall court-capture order |
+| [`PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md`](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | Court-capture roadmap; F10 superseded by F13 |
+| [`PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md`](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md) | Draft plan for shot detail, linked metadata, and editing |
 | [`PLAN_MULTI_GAME_PARKING.md`](PLAN_MULTI_GAME_PARKING.md) | Multiple parked games + sync queue |
 | [`PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md`](PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md) | Team hub drill-down routes |
 
 **Court program status:** F1-F9 and F12 are implemented; manual Supabase-heavy QA remains in
-[`REGRESSION_TESTING.md`](REGRESSION_TESTING.md). F10 is a polish sketch, and F11 should
-stay gated on live-use feedback.
+[`REGRESSION_TESTING.md`](REGRESSION_TESTING.md). F10 standalone marker numbering is no
+longer needed and is superseded by F13 shot detail/edit planning. F11 should stay gated on
+live-use feedback.
 
 ### Verification norms
 

--- a/docs/DESIGN_SHOT_TRACKER_UI_REVAMP.md
+++ b/docs/DESIGN_SHOT_TRACKER_UI_REVAMP.md
@@ -5,8 +5,8 @@ context, the data model the work builds on, the recommended build order, and the
 cross-cutting decisions so the individual plans stay consistent.
 
 > **Status:** F1-F9 and F12 are implemented in the app and documented in the linked plans.
-> F10-F11 remain roadmap sketches until
-> promoted to full plans. Manual Supabase-heavy QA is still tracked in
+> F10 is no longer needed as a standalone feature and is superseded by F13. F13 is a
+> planning draft; F11 remains gated on live-use feedback. Manual Supabase-heavy QA is still tracked in
 > [REGRESSION_TESTING.md](REGRESSION_TESTING.md).
 >
 > **Major pivot (recorded):** F1 was originally "make the shot chart a tab." After
@@ -31,7 +31,7 @@ cross-cutting decisions so the individual plans stay consistent.
 | **F12** | Recent-events undo popup | [PLAN_F12_RECENT_EVENTS_UNDO.md](PLAN_F12_RECENT_EVENTS_UNDO.md) | **Implemented.** The bottom Undo opens a recent-events popup; the newest event can be undone via existing LIFO `UNDO`. |
 | **F7** | Assist-linking on a made shot | [PLAN_F7_ASSIST_LINKING.md](PLAN_F7_ASSIST_LINKING.md) | **Implemented.** After a made court shot, optionally credit a same-side teammate assist as a separate `ast` increment. |
 | **F8** | Live per-player line in popup | [PLAN_F8_LIVE_PER_PLAYER_LINE.md](PLAN_F8_LIVE_PER_PLAYER_LINE.md) | **Implemented.** Shows the selected player's compact live stat line under the popup's Log for label. |
-| **F9-F11** | Court Event Capture enhancements | [PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | F9 rebound-after-miss is implemented; next court-capture work is sequence numbers (F10) or Option B quick buttons (F11). |
+| **F9-F13** | Court Event Capture enhancements | [PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | F9 rebound-after-miss is implemented; F10 visible numbering is superseded by F13 shot detail/edit planning; F11 remains gated. |
 
 F1 is the foundation for F2, F3, and F5-F12. F4 is independent and has landed.
 
@@ -141,12 +141,16 @@ F1  Single-page tracker + Court Event Capture     (implemented)
  └─ F11 Hybrid quick buttons (Option B)            (only if testing shows it's needed)
 F4  In-progress scores on resume UI                (implemented; cloud-list QA pending)
 
-F9 is complete. F10 can be sequenced by product priority; F11 should stay gated on
-live-use feedback.
+F9 is complete. F10 is superseded by F13 shot detail/edit planning. F13 should be reviewed
+before build; F11 should stay gated on live-use feedback.
 ```
 
 Rationale and per-feature phases: see
 [PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md).
+
+Note: the legacy visible-marker-numbering idea listed as F10 above is no longer planned as
+a standalone build. It is superseded by F13, which moves shot numbering into a shot detail
+and edit workflow.
 
 ## Open questions (consolidated)
 
@@ -162,6 +166,8 @@ Resolved items are struck/marked; defaults are what the plans assume.
 | Q4 | F3: all-recorder vs primary-recorder shots on cloud review? | All-recorder via a review path, **de-duped to the primary recorder per player** (F3 §7 D1–D2). |
 | Q5 | F4: trust the synced `games` row score vs aggregate stats? | Row snapshot first; stats fallback only when `home_team_score` is null (creator-scoped). |
 | Q6 | F11 (Option B) quick buttons — build now or gate on testing? | Gate on live testing of Option A; default A. |
+
+| Q7 | F10 visible numbering? | **Resolved:** no standalone marker numbering; superseded by F13 shot detail metadata. |
 
 ## Testing posture
 

--- a/docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md
+++ b/docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md
@@ -1,18 +1,20 @@
-# Court Event Capture — Enhancements Roadmap (F5–F12)
+# Court Event Capture - Enhancements Roadmap (F5-F13)
 
 > **For agentic workers:** This is the roadmap for follow-on enhancements to the Court
 > Event Capture model introduced in [PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md](PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md).
-> F5, F6, F7, F8, F9, and F12 are implemented. F10-F11 are still sketches
-> (goal, dependency, phases, files, effort, open question); when one is picked up, expand
-> it to a full plan with a "Pre-handoff design decisions" section.
+> F5, F6, F7, F8, F9, and F12 are implemented. F10 is no longer needed as a
+> standalone visible-numbering feature and is superseded by F13. F11 remains gated on
+> live-use feedback. F13 is drafted for review in
+> [PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md).
 
-All of these **depend on F1** (the single-page tracker + `CourtEventPopup`). None changes
-the data model — they map to existing dispatches (`ADD_SHOT`, `INCREMENT_STAT`) and reuse
-`BasketballCourt` / `ShootingSummary` / `PlayerSelectorStrip`.
+F5-F12 depend on F1 (the single-page tracker + `CourtEventPopup`) and avoid data-model
+changes by mapping to existing dispatches (`ADD_SHOT`, `INCREMENT_STAT`). F13 is the first
+planned court-capture feature that intentionally considers durable shot metadata and edit
+semantics.
 
 ## Origin
 
-These are the user's six requested enhancements plus the deferred "Option B" hybrid:
+These are the user's six requested enhancements plus deferred/new follow-ups:
 
 | Roadmap id | Origin | Theme |
 |---|---|---|
@@ -21,238 +23,212 @@ These are the user's six requested enhancements plus the deferred "Option B" hyb
 | F7 | suggestion #2 | Assist-linking on a made shot |
 | F8 | suggestion #5 | Live per-player line in the popup |
 | F9 | suggestion #4 | Rebound-after-miss chained prompt |
-| F10 | suggestion #6 | Shot sequence numbers / recency |
+| F10 | suggestion #6 | Shot sequence numbers / recency (superseded by F13) |
 | F11 | Option B | Hybrid 1-tap quick buttons for blk/stl/ast |
 | F12 | user idea | Recent-events undo popup (last ~5 events, undo from top) |
+| F13 | user idea | Shot detail + linked metadata + edit modal |
 
-## Recommended implementation order (whole program)
+## Recommended Implementation Order
 
 Foundation first, then attribution-correctness wins, then progressive polish, with the
-speculative hybrid gated on real use. F1-F6 have landed; F3/F4 still have Supabase-heavy
-manual QA items tracked in [REGRESSION_TESTING.md](REGRESSION_TESTING.md).
+speculative hybrid gated on real use.
 
+```text
+F1  Single-page tracker + Court Event Capture       (implemented)
+ |-- F2  Per-player / team shot filtering           (implemented)
+ |-- F3  Cloud-saved game shot review               (implemented; two-user QA pending)
+ |-- F5  Auto 2/3 override chip                     (implemented)
+ |-- F6  In-popup player confirm/switch             (implemented)
+ |-- F12 Recent-events undo popup                   (implemented; unblocks F7)
+ |-- F7  Assist-linking on a made shot              (implemented)
+ |-- F8  Live per-player line in popup              (implemented)
+ |-- F9  Rebound-after-miss prompt                  (implemented; opt-in)
+ |-- F10 Shot sequence numbers / recency            (superseded; no standalone work)
+ |-- F13 Shot detail + linked metadata/edit modal   (planned; review draft)
+ `-- F11 Hybrid quick buttons (Option B)            (only if live testing shows friction)
+F4  In-progress scores on resume UI                 (implemented; cloud-list QA pending)
 ```
-F1  Single-page tracker + Court Event Capture (implemented)
- ├─ F2  Per-player / team shot filtering        (implemented)
- ├─ F3  Cloud-saved game shot review             (implemented; two-user QA pending)
- ├─ F5  Auto 2/3 override chip                   (implemented)
- ├─ F6  In-popup player confirm/switch           (implemented)
- ├─ F12 Recent-events undo popup                 (implemented; unblocks F7)
- ├─ F7  Assist-linking on a made shot            (implemented)
- ├─ F8  Live per-player line in popup            (implemented)
- ├─ F9  Rebound-after-miss prompt                (implemented; opt-in)
- ├─ F10 Shot sequence numbers / recency          (cosmetic)
- └─ F11 Hybrid quick buttons (Option B)          (only if testing shows blk/stl/ast need 1-tap)
-F4  In-progress scores on resume UI              (implemented; cloud-list QA pending)
-```
 
-**Remaining work:** F10 can be sequenced by product priority. F11 should stay gated on
-live-use feedback.
+**Remaining work:** F13 should be reviewed and phased before build. F11 should stay gated
+on live-use feedback.
 
-**Why this order:** F12 gives F7's two-step assist undo a visible event list
-(no reducer change). F10 is progressive polish. F11 is intentionally last:
-build it only if live testing shows the extra tap for block/steal/assist is real friction.
+**Why this order:** F12 gives F7's two-step assist undo a visible event list without a
+reducer change. F13 is the natural successor to F7/F9 because it turns their
+adjacent-but-unlinked stat increments into durable shot metadata and an eventual edit
+surface. F11 is intentionally last: build it only if live testing shows the extra tap for
+block/steal/assist is real friction.
 
 ---
 
-## F5 — Auto 2/3 with manual override chip
+## F5 - Auto 2/3 with manual override chip
 
-> **Expanded to a full plan:** [PLAN_F5_AUTO_2_3_OVERRIDE.md](PLAN_F5_AUTO_2_3_OVERRIDE.md)
-> (tasks + pre-handoff decisions).
+> **Expanded to a full plan:** [PLAN_F5_AUTO_2_3_OVERRIDE.md](PLAN_F5_AUTO_2_3_OVERRIDE.md).
+> **Status:** Implemented.
 
 **Goal:** In `CourtEventPopup`, the location-detected shot value (`isThreePointer(x,y)`)
-is shown and can be **overridden** with one tap (foot-on-the-line, deep heave, or scorer
-disagreement) before logging Made/Missed.
-
-**Depends on:** F1 (popup exists). **Effort:** XS.
-
-**Phases:**
-- **P1:** Add a `2PT / 3PT` segmented chip to the popup, defaulted from
-  `isThreePointer(x,y)`. The chosen value (not the raw location) drives `shotType` and the
-  resulting `2pt`/`3pt`(`_miss`) stat. Location `(x,y)` is still stored as tapped.
+is shown and can be overridden with one tap before logging Made/Missed.
 
 **Key files:** `CourtEventPopup.tsx`. No data change.
 
-**Open question:** If the user overrides 2↔3, do we keep the literal tap location (marker
-sits where tapped, value forced) — recommended yes — or nudge the marker? Default: keep
-location, force value.
+**Resolved:** Keep the literal tap location and force the selected shot value when the user
+overrides 2PT/3PT.
 
 ---
 
-## F6 — In-popup player confirm / switch
+## F6 - In-popup player confirm / switch
 
-> **Expanded to a full plan:** [PLAN_F6_IN_POPUP_PLAYER_SWITCH.md](PLAN_F6_IN_POPUP_PLAYER_SWITCH.md)
-> (tasks + pre-handoff decisions).
+> **Expanded to a full plan:** [PLAN_F6_IN_POPUP_PLAYER_SWITCH.md](PLAN_F6_IN_POPUP_PLAYER_SWITCH.md).
+> **Status:** Implemented.
 
-**Goal:** The popup header shows the selected player and lets you **switch attribution**
-before logging — the strongest fix for "I logged it to the wrong/at-the-time-unclear
-player." Confirms who gets the stat at the moment of the event.
+**Goal:** The popup header shows the selected player and lets the scorer switch attribution
+before logging.
 
-**Depends on:** F1. **Effort:** S.
+**Key files:** `CourtEventPopup.tsx`, `PlayerSelectorStrip`, `sortTeamPlayersFirst`.
 
-**Phases:**
-- **P1:** Header shows `#num Name` of the active player (read-only label).
-- **P2:** Make the label a control: a compact dropdown / mini player list (reuse
-  `PlayerSelectorStrip` data) to pick a different player. Decide whether picking changes
-  the **global** active player (sticky, subsequent taps follow) or only **this** event.
-
-**Key files:** `CourtEventPopup.tsx`, reuse `PlayerSelectorStrip` / `sortTeamPlayersFirst`.
-
-**Open question:** Switching scope — global (recommended: updates `activePlayerId` so the
-sticky strip and next taps follow) vs. one-off (this event only). Default: global.
+**Resolved:** Switching in the popup updates the global active player.
 
 ---
 
-## F7 — Assist-linking on a made shot
+## F7 - Assist-linking on a made shot
 
-> **Expanded to a full plan:** [PLAN_F7_ASSIST_LINKING.md](PLAN_F7_ASSIST_LINKING.md)
-> (tasks + pre-handoff decisions). Uses **two-step undo made transparent by F12** — **no
-> reducer change** (F5–F12 stay data-model-free). **Status:** Implemented.
+> **Expanded to a full plan:** [PLAN_F7_ASSIST_LINKING.md](PLAN_F7_ASSIST_LINKING.md).
+> **Status:** Implemented.
 
-**Goal:** After a **Made** shot, optionally credit the assisting teammate in the same
-gesture (assists are almost always tied to a made FG).
-
-**Depends on:** F1; pairs naturally with F6 (player picker reuse). **Effort:** M
-(undo coordination is the real work).
-
-**Phases:**
-- **P1:** Implemented: after Made, show an optional "Assisted by …" picker (skippable /
-  "no assist"). Picking a teammate dispatches `INCREMENT_STAT(assister, 'ast')` after the shot.
-- **P2:** Implemented by F12 visibility: undoing the shot and linked assist stays two
-  independent LIFO steps with clear ordering. Recent-passers ordering remains future polish.
+**Goal:** After a made shot, optionally credit a same-side teammate assist in the same
+gesture.
 
 **Key files:** `CourtEventPopup.tsx`, `ShotChartPanel.tsx`, `src/lib/assistCandidates.ts`.
 
-**Resolved:** two separate undo steps (assist, then shot) with F12 visibility; no reducer
-linkage.
+**Resolved:** The shot and assist are two separate undo entries, made understandable by
+F12's recent-events popup. No reducer/data-model change in F7.
 
 ---
 
-## F8 — Live per-player line in the popup
+## F8 - Live per-player line in the popup
 
 > **Expanded to a full plan:** [PLAN_F8_LIVE_PER_PLAYER_LINE.md](PLAN_F8_LIVE_PER_PLAYER_LINE.md).
 > **Status:** Implemented.
 
-**Goal:** Show the selected player's quick stat line (e.g. `12 pts · 5 reb · 3 ast`) in
-the popup header for instant context while logging.
+**Goal:** Show the selected player's quick stat line in `CourtEventPopup`.
 
-**Depends on:** F1; nice with F6. **Effort:** XS.
+**Key files:** `CourtEventPopup.tsx`, `src/lib/statDisplay.ts`.
 
-**Phases:**
-- **P1:** Implemented: compute the compact line from `player.stats` using existing helper
-  `formatCompactGameStatLine` and render it under the player name in `CourtEventPopup`.
-
-**Key files:** `CourtEventPopup.tsx`, `src/lib/statDisplay.ts` (reuse).
-
-**Resolved:** use existing `formatCompactGameStatLine` output: score, basketball rebounds,
+**Resolved:** Use existing `formatCompactGameStatLine` output: score, basketball rebounds,
 and sport `keyStatIds`.
 
 ---
 
-## F9 — Rebound-after-miss chained prompt
+## F9 - Rebound-after-miss chained prompt
 
 > **Expanded to a full plan:** [PLAN_F9_REBOUND_AFTER_MISS_PROMPT.md](PLAN_F9_REBOUND_AFTER_MISS_PROMPT.md).
 > **Status:** Implemented.
 
-**Goal:** A missed shot is usually followed by a rebound; optionally chain a quick
-"Rebound? Off / Def / none" prompt right after **Missed** to capture the sequence without
-a second court tap.
+**Goal:** After a missed shot, optionally prompt for Off Reb, Def Reb, or No rebound.
 
-**Depends on:** F1. **Effort:** S–M.
+**Key files:** `CourtEventPopup.tsx`, `ShotChartPanel.tsx`, `src/lib/reboundPrompt.ts`,
+`src/context/SettingsContext.tsx`.
 
-**Phases:**
-- **P1:** Implemented: after Missed, the opt-in prompt can record Off Reb, Def Reb, or
-  No rebound. The shot stays locked to the missed-shot player/team.
-- **P2:** Implemented: Settings toggle defaults off. Off rebound defaults to the missed
-  shot side's team pseudo-player; Def rebound defaults to the opposite side's team
-  pseudo-player. Candidate chips allow switching to an individual on that side.
-
-**Key files:** `CourtEventPopup.tsx`, `ShotChartPanel.tsx`,
-`src/lib/reboundPrompt.ts`, `src/context/SettingsContext.tsx` (toggle).
-
-**Resolved:** Default **off** (opt-in). Rebound dispatch stays separate from the shot:
-`ADD_SHOT` first, then optional `INCREMENT_STAT(oreb|dreb)`, so F12 recent-events undo
-shows the rebound above the miss.
+**Resolved:** Default off. Off rebound defaults to the missed-shot side's team
+pseudo-player; Def rebound defaults to the opposite side's team pseudo-player. The shot and
+rebound stay separate undo entries.
 
 ---
 
-## F10 — Shot sequence numbers / recency highlight
+## F10 - Shot sequence numbers / recency highlight
 
-**Goal:** Optionally number shot markers chronologically and/or highlight the most recent
-N, so a coach can reconstruct game flow.
+> **Status:** No longer needed as a standalone feature. Superseded by
+> [PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md).
 
-**Depends on:** F1; orthogonal to capture. **Effort:** S.
+**Original goal:** Number shot markers chronologically and/or highlight the most recent N
+shots so a coach could reconstruct game flow.
 
-**Phases:**
-- **P1:** Render order/recency in `BasketballCourt` (markers already carry `timestamp` and
-  array order). Either small sequence numbers or a fade for older shots.
-- **P2:** A toggle to show/hide numbering (keep the default clean).
+**Resolution:** Do not add visible marker numbers as a standalone overlay. Shot numbering
+belongs at the metadata/detail level:
 
-**Key files:** `BasketballCourt.tsx`, `ShotChartPanel.tsx`.
+- keep the court visually clean
+- assign or derive a shot number for each shot
+- show that number in a shot detail modal
+- use the same modal as the future correction/edit surface
 
-**Open question:** Sequence numbers (precise but busier) vs. recency fade (cleaner).
-Default: recency highlight off by default, numbering behind a toggle.
+**Replacement:** F13 shot detail + linked metadata + edit modal.
 
 ---
 
-## F11 — Hybrid quick buttons for block / steal / assist (Option B)
+## F13 - Shot detail + linked metadata + edit modal
 
-**Goal:** For coaches who log many blocks/steals/assists, add dedicated **1-tap** buttons
-next to the court (no popup), while keeping the popup's secondary row. Restores the
-1-tap speed those events had before Option A.
+> **Expanded to a draft plan:** [PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md).
+> **Status:** Planning draft for review.
 
-**Depends on:** F1 (and ideally after live testing of Option A). **Effort:** S.
+**Goal:** Tap an existing shot marker to inspect the shot event: shot number, shooter,
+result/value, zone/location, timestamp/order, and any F7 assist or F9 rebound linked to
+that shot. Later phases make those fields editable and update stat totals safely.
+
+**Depends on:** F1, F7, F9, F12. **Effort:** M-L depending on edit/cloud scope.
 
 **Phases:**
+
+- **P1:** Read-only shot details modal with derived shot number and core shot data.
+- **P2:** Persist linked metadata on new shots (`sequenceNumber`, `assistPlayerId`,
+  `reboundPlayerId`, `reboundStatId`) while still incrementing totals.
+- **P3:** Add cloud persistence for linked metadata on `shot_chart`.
+- **P4:** Add shot editing for shooter/result/value/assist/rebound with stat-total
+  corrections.
+- **P5:** Add edit undo/audit polish, likely via a `shot_edit` action-log snapshot.
+
+**Key files:** `ShotRecord` in `src/types.ts`, `GameContext.tsx`, `BasketballCourt.tsx`,
+`ShotChartPanel.tsx`, `CourtEventPopup.tsx`, `src/lib/cloudSync.ts`, and a future
+Supabase migration.
+
+**Open questions:** sequence assignment vs derived display order; local-first vs
+cloud-in-same-PR; edit scope; undo model for edits; whether legacy local action logs should
+ever infer F7/F9 links (recommended no).
+
+---
+
+## F11 - Hybrid quick buttons for block / steal / assist (Option B)
+
+**Goal:** For coaches who log many blocks/steals/assists, add dedicated one-tap buttons
+next to the court while keeping the popup's secondary row.
+
+**Depends on:** F1 and live testing of Option A. **Effort:** S.
+
+**Phases:**
+
 - **P1:** A compact quick-button row (Steal / Block / Assist, maybe Off/Def Reb) adjacent
   to the court that dispatches `INCREMENT_STAT` for the active player in one tap.
-- **P2:** A setting to choose input mode — **A** (popup only), **B** (quick buttons only),
-  or **both** — and reconcile with the popup's secondary row to avoid duplication.
+- **P2:** A setting to choose input mode: A (popup only), B (quick buttons only), or both.
 
 **Key files:** `ShotChartPanel.tsx`, `src/context/SettingsContext.tsx`.
 
 **Open question:** Ship B as always-on extra buttons vs. a user setting. Default: a
-setting (A default), built **only if** Option A testing shows the extra tap is real
-friction.
+setting, built only if Option A testing shows real friction.
 
 ---
 
-## F12 — Recent-events undo popup
+## F12 - Recent-events undo popup
 
-> **Expanded to a full plan:** [PLAN_F12_RECENT_EVENTS_UNDO.md](PLAN_F12_RECENT_EVENTS_UNDO.md)
-> (tasks + pre-handoff decisions). **Implemented before F7.**
+> **Expanded to a full plan:** [PLAN_F12_RECENT_EVENTS_UNDO.md](PLAN_F12_RECENT_EVENTS_UNDO.md).
+> **Status:** Implemented before F7.
 
-**Goal:** Replace the silent single-Undo with a popup listing the **last ~5 events** in
-plain language (`<player> — <event>`) so the user can see and undo recent actions. Reads the
-existing `actionLog`; undoes via the existing LIFO `UNDO`.
-
-**Depends on:** F1 (enhances its undo bar). Pairs with F7 (makes two-step assist undo
-transparent). **Effort:** S. **Status:** Implemented.
-
-**Phases:**
-- **P1:** Implemented: `describeActionLogEntry` label helper (+ test); `RecentEventsPopup`
-  showing the last ~5 entries; the bottom Undo opens it; top-row undo = today's single `UNDO`.
-- **P2 (optional):** cascade-to-row undo (B) — undo everything newer than a tapped row via
-  sequential `UNDO`s.
+**Goal:** Replace silent single Undo with a popup listing the last few events in plain
+language so the user can see and undo recent actions.
 
 **Key files:** `src/lib/actionLogLabels.ts`, `src/components/RecentEventsPopup.tsx`,
 `src/pages/GameTracker.tsx`.
 
-**FUTURE NOTE — Option C (arbitrary out-of-order undo):** undoing a *middle* event is unsafe
+**FUTURE NOTE - Option C (arbitrary out-of-order undo):** undoing a middle event is unsafe
 with today's stored-`previousValue` LIFO model and needs a bigger refactor (inverse deltas
-or event-sourced recompute). **Gather usage data first** before committing to it; v1 is
-LIFO (A) + optional cascade (B). See the F12 plan §6.
+or event-sourced recompute). Gather usage data first.
 
 ---
 
 ## Notes
 
-- **No data-model changes** across F5–F12; all map to existing `ADD_SHOT` /
-  `INCREMENT_STAT` / `UNDO` and existing stat ids. (F7 uses two-step undo + F12 instead of a
-  reducer change.)
-- **F2/F3 interplay:** F2's `shotsForSelection` filtering and F3's all-recorder review
-  apply to the inline court from F1 regardless of these enhancements; F5–F12 only change
-  the *capture/correction* experience, not the stored shape.
-- When promoting any item to active work, expand it into its own
-  `PLAN_F{n}_*.md` with full tasks + a Pre-handoff design decisions section (same format
-  as F1–F4).
+- F5-F12 intentionally avoided data-model changes. They map to `ADD_SHOT`,
+  `INCREMENT_STAT`, `UNDO`, and existing stat ids.
+- F13 is the planned exception: durable shot metadata and editing likely require
+  `ShotRecord`, reducer, cloud sync, and Supabase `shot_chart` changes.
+- F2/F3 interplay: F2's `shotsForSelection` filtering and F3's all-recorder review apply
+  to the inline court regardless of these enhancements.
+- When promoting any item to active work, expand it into its own `PLAN_F{n}_*.md` with full
+  tasks and a Pre-handoff design decisions section.

--- a/docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md
+++ b/docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md
@@ -1,0 +1,235 @@
+# F13 - Shot detail + linked metadata + edit modal
+
+> Supersedes the old F10 "shot sequence numbers / recency highlight" sketch. F10's
+> visible numbering is no longer needed as a standalone feature; the useful version is a
+> tappable shot detail surface with durable shot number and linked F7/F9 metadata.
+>
+> Status: planning draft for review.
+
+## Goal
+
+Let a scorer tap an existing shot marker and inspect the full shot event: shot number in
+the game, shooter, result, shot value, zone/location, timestamp, and any assist or rebound
+captured through F7/F9. In later phases, make those fields editable so the shot chart can
+serve as a correction surface, not only a capture surface.
+
+## Why This Replaces F10
+
+The original F10 proposed visible sequence numbers or recency styling on markers. That is
+useful only if it helps reconstruct what happened. A details modal does that better:
+
+- The court can stay visually clean.
+- Shot number becomes metadata instead of marker clutter.
+- F7 assists and F9 rebounds can be shown with the shot they belong to.
+- The same modal can become the natural edit/correction surface.
+
+## Current Architecture Constraint
+
+Today `ShotRecord` contains only shot-local data:
+
+```ts
+interface ShotRecord {
+  id: string
+  x: number
+  y: number
+  made: boolean
+  shotType: '2pt' | '3pt'
+  zone: ShotZone
+  playerId: string
+  timestamp: number
+}
+```
+
+F7 and F9 intentionally avoided data-model changes:
+
+- F7 assist: `ADD_SHOT`, then separate `INCREMENT_STAT(ast)`.
+- F9 rebound: `ADD_SHOT`, then optional separate `INCREMENT_STAT(oreb|dreb)`.
+- F12 recent-events makes those adjacent undo rows visible.
+
+That is enough for live capture and LIFO undo, but not enough for a reliable shot-detail
+modal after reload/cloud sync. A modal could guess from action order while the local
+`actionLog` is intact, but the relationship is not durable.
+
+## Proposed Data Model
+
+Extend `ShotRecord` with optional linked metadata:
+
+```ts
+interface ShotRecord {
+  id: string
+  x: number
+  y: number
+  made: boolean
+  shotType: '2pt' | '3pt'
+  zone: ShotZone
+  playerId: string
+  timestamp: number
+  sequenceNumber?: number
+  assistPlayerId?: string
+  reboundPlayerId?: string
+  reboundStatId?: 'oreb' | 'dreb'
+}
+```
+
+Cloud persistence likely needs a new migration adding nullable columns to `shot_chart`:
+
+- `sequence_number integer`
+- `assist_player_id uuid null references players(id)`
+- `rebound_player_id uuid null references players(id)`
+- `rebound_stat_id text null check (rebound_stat_id in ('oreb', 'dreb'))`
+
+Existing rows can remain valid with nulls. The app can backfill display-only shot numbers
+from array order/timestamp when `sequenceNumber` is absent.
+
+## Phase Plan
+
+### Phase 1 - Read-only shot details modal
+
+**Purpose:** deliver immediate user value with low risk.
+
+- Add `selectedShotId` state to the court surface.
+- Make existing shot markers tappable without interfering with court-tap capture.
+- Add `ShotDetailModal` showing:
+  - shot number: `sequenceNumber` if present, otherwise derived display order
+  - shooter/player label
+  - made/miss and 2PT/3PT
+  - zone
+  - timestamp/game order context
+  - assist/rebound only when durable metadata exists
+- For old shots, show assist/rebound as "Not linked" rather than guessing.
+
+**Data changes:** none required if this phase derives shot number only.
+
+### Phase 2 - Link F7/F9 metadata at capture time
+
+**Purpose:** make new assists/rebounds durable on the shot record.
+
+- Assign a stable `sequenceNumber` when creating a shot.
+- When F7 assist is selected, write `assistPlayerId` into the shot and still increment
+  `ast` for totals.
+- When F9 rebound is selected, write `reboundPlayerId` + `reboundStatId` into the shot and
+  still increment `oreb`/`dreb` for totals.
+- Update local display paths and Game Summary shot chart review to understand the fields.
+
+**Data changes:** `ShotRecord` type change. LocalStorage migration is passive because all
+new fields are optional.
+
+### Phase 3 - Cloud persistence
+
+**Purpose:** preserve shot detail metadata across devices and cloud game review.
+
+- Add Supabase migration for the new `shot_chart` columns.
+- Update `cloudSync` shot upsert rows.
+- Update local hydration from cloud rows.
+- Update F3 all-recorder review loader to include linked metadata.
+- Define behavior when linked player rows are no longer present locally:
+  - retain ids for cloud display if possible
+  - gracefully show "Unknown player" when not mappable
+
+**Data changes:** Supabase migration plus cloud sync/read mapping.
+
+### Phase 4 - Shot edit modal
+
+**Purpose:** allow correction from the shot itself.
+
+Editable fields:
+
+- shooter/player
+- made vs missed
+- 2PT vs 3PT
+- assist player for made shots
+- rebound player/stat for missed shots
+
+Reducer work:
+
+- Add an `UPDATE_SHOT` action that receives previous and next shot details.
+- Reverse old stat impacts:
+  - old shooter shot stat (`2pt`, `3pt`, `2pt_miss`, `3pt_miss`)
+  - old assist `ast`, if present
+  - old rebound `oreb`/`dreb`, if present
+- Apply new stat impacts.
+- Update the `ShotRecord`.
+
+UX rules:
+
+- Made shots can have an assist; missed shots cannot.
+- Missed shots can have a rebound; made shots cannot.
+- Changing made <-> missed clears incompatible linked metadata unless the user chooses a
+  new valid linked event.
+- Editing location can be deferred; shot value can be edited without moving the marker,
+  matching F5.
+
+### Phase 5 - Undo and audit polish
+
+**Purpose:** make edits explainable and reversible.
+
+Options:
+
+- **A: Edit has no one-tap undo.** Simpler, but inconsistent with current tracker
+  expectations.
+- **B: Add `shot_edit` action log entries with a full before/after snapshot.**
+  Recommended if editing ships.
+- **C: Event-sourced recompute.** Most robust, but much larger than F13 needs initially.
+
+Recommended path: Phase 4 can ship with a `shot_edit` action log entry that restores the
+previous shot and stat impacts.
+
+## Pre-handoff Design Decisions Needed
+
+- **D1 - Sequence source:** assign `sequenceNumber` at capture time, or derive forever from
+  sorted shot order? Recommendation: assign at capture for durability; derive only for
+  legacy rows.
+- **D2 - Cloud timing:** implement local metadata first, or include cloud migration in the
+  same PR? Recommendation: split local read-only/modal from cloud persistence.
+- **D3 - Edit scope v1:** allow only player/result/value edits, or include assist/rebound
+  edits immediately? Recommendation: include assist/rebound once metadata exists; otherwise
+  the modal solves only half the correction problem.
+- **D4 - Undo for edits:** require undo support in the first editable phase?
+  Recommendation: yes, but via a specific `shot_edit` log snapshot rather than many small
+  synthetic increments/decrements.
+- **D5 - Historical F7/F9 rows:** should the app attempt to infer links for old local
+  action logs? Recommendation: no. Show only durable links; do not guess.
+- **D6 - Marker affordance:** marker tap opens details; court background tap opens capture.
+  Need mobile QA to ensure marker taps do not leak through to court capture.
+
+## Key Files
+
+- `src/types.ts` - `ShotRecord`, `ActionLogEntry`, `GameAction`
+- `src/context/GameContext.tsx` - `ADD_SHOT`, future `UPDATE_SHOT`, undo
+- `src/components/shot-chart/BasketballCourt.tsx` - marker tap affordance
+- `src/components/shot-chart/ShotChartPanel.tsx` - selected shot state and modal wiring
+- `src/components/shot-chart/CourtEventPopup.tsx` - F7/F9 metadata capture
+- `src/lib/cloudSync.ts` - shot_chart read/write mapping
+- `supabase/migrations/` - new nullable `shot_chart` metadata columns
+- `docs/REGRESSION_TESTING.md` - marker tap/detail/edit/cloud review cases
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Stat totals drift after editing | Centralize shot stat impact calculations in a pure helper with tests. |
+| Undo gets confusing for edits | Add a dedicated `shot_edit` action log entry with a snapshot. |
+| Cloud review cannot map linked players | Store nullable ids, map when possible, show fallback labels when not. |
+| Modal tap conflicts with court tap | Stop event propagation on markers and add Playwright/manual mobile checks. |
+| Scope grows too large | Ship read-only modal first, then metadata, then editing. |
+
+## Suggested Acceptance Criteria
+
+Phase 1:
+
+- Tapping a shot marker opens a modal without adding a new shot.
+- Modal shows shot number, shooter, result/value, zone, and timestamp/order.
+- Closing the modal returns to the same court view.
+
+Phase 2-3:
+
+- New made shots with F7 assist show the assister in the shot modal after reload/cloud sync.
+- New missed shots with F9 rebound show rebound player/team and offensive/defensive type
+  after reload/cloud sync.
+- Legacy shots without metadata still show core shot details.
+
+Phase 4-5:
+
+- Editing shot player/result/value updates shot marker details and stat totals.
+- Editing assist/rebound updates linked metadata and stat totals.
+- Undo after a shot edit restores previous shot details and totals.

--- a/docs/PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md
+++ b/docs/PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md
@@ -255,8 +255,9 @@ Goal: make the two input paths understandable and document the flow (no grid shr
 
 - Filtering the court by player/team (→ **F2**).
 - 2/3 override chip (→ **F5**), in-popup player switch (→ **F6**), assist-linking
-  (→ **F7**), per-player line (→ **F8**), rebound-after-miss prompt (→ **F9**), sequence
-  numbers (→ **F10**), 1-tap court-adjacent quick buttons / Option B (→ **F11**).
+  (→ **F7**), per-player line (→ **F8**), rebound-after-miss prompt (→ **F9**), shot
+  detail/edit workflow (→ **F13**; supersedes standalone F10 numbering), 1-tap
+  court-adjacent quick buttons / Option B (→ **F11**).
 - Cloud/multi-recorder review (→ **F3**); resume-UI scores (→ **F4**).
 
 ## 7. Pre-handoff design decisions — RESOLVED


### PR DESCRIPTION
Summary:
- mark F10 visible marker numbering as no longer needed and superseded by F13
- add F13 draft plan for shot detail modal, durable F7/F9 linked metadata, cloud persistence, editing, and edit undo
- update roadmap, README, agent overview, and F1/design references for the F13 direction

Review focus:
- whether F13 should start with read-only modal only or include local metadata immediately
- whether sequenceNumber should be assigned at capture time or derived forever
- whether edit undo should be required in the first editable phase

Verification:
- git diff --check (line-ending warnings only)
- docs-only change; app tests not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates to planning and agent pointers; no runtime, auth, or data-path changes.
> 
> **Overview**
> Documentation realigns the court-capture roadmap: **standalone F10 visible marker numbering is dropped** in favor of **F13** (tappable shot detail, durable F7/F9 links, cloud fields, editing, and edit undo).
> 
> Adds **`docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md`** as a review draft (phased P1–P5, optional `ShotRecord` metadata, `shot_chart` migration, `UPDATE_SHOT`, pre-handoff decisions). Updates **`PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md`**, **`DESIGN_SHOT_TRACKER_UI_REVAMP.md`**, **`README.md`**, **`AGENT_CODEBASE_OVERVIEW.md`**, and **F1** out-of-scope text so **F11** stays gated and **F13** is the next planned court work.
> 
> No application or schema changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4c7ef1ed299016a71e88dd1beeeadff8ec9320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->