### PR TITLE
docs: hold F11 and F13 pending feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 
 ### What's Next
 
-- [ ] **Court capture polish** — F5 shot-value override, F6 in-popup player switching, F12 recent-events undo, F7 assist-linking, F8 popup stat line, and F9 rebound-after-miss prompt are implemented; F10 visible numbering is superseded by F13 shot detail/edit planning, while F11 remains gated on live-use feedback ([roadmap](docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md), [F13 plan](docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md))
+- [ ] **Court capture polish** — F5 shot-value override, F6 in-popup player switching, F12 recent-events undo, F7 assist-linking, F8 popup stat line, and F9 rebound-after-miss prompt are implemented; F10 visible numbering is superseded by F13, and both F11 quick buttons and F13 shot detail/editing are held pending further user feedback ([roadmap](docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md), [F13 plan](docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md))
 - [ ] **Team Info hub + drill-downs** — canonical `/team?teamId=` route with roster, schedule, player/game/season drill-downs ([plan](docs/PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md))
 - [ ] **Multi-game parking + sync queue** — multiple in-progress/paused games per device, offline-safe snapshots, ordered cloud sync ([plan](docs/PLAN_MULTI_GAME_PARKING.md))
 - [ ] **Stat view follow-ups** — the major career/season/team/tournament stat views are shipped; use [DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md) and [completed/STAT_TRACKING_UI_PROGRESS.md](docs/completed/STAT_TRACKING_UI_PROGRESS.md) as references for smaller refinements

--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -205,14 +205,14 @@ flowchart LR
 | Doc | Topic |
 |-----|-------|
 | [`PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md`](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | Court-capture roadmap; F10 superseded by F13 |
-| [`PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md`](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md) | Draft plan for shot detail, linked metadata, and editing |
+| [`PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md`](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md) | Held draft plan for shot detail, linked metadata, and editing |
 | [`PLAN_MULTI_GAME_PARKING.md`](PLAN_MULTI_GAME_PARKING.md) | Multiple parked games + sync queue |
 | [`PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md`](PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md) | Team hub drill-down routes |
 
 **Court program status:** F1-F9 and F12 are implemented; manual Supabase-heavy QA remains in
 [`REGRESSION_TESTING.md`](REGRESSION_TESTING.md). F10 standalone marker numbering is no
-longer needed and is superseded by F13 shot detail/edit planning. F11 should stay gated on
-live-use feedback.
+longer needed and is superseded by F13 shot detail/edit planning. F11 and F13 are both
+held pending further user feedback.
 
 ### Verification norms
 

--- a/docs/DESIGN_SHOT_TRACKER_UI_REVAMP.md
+++ b/docs/DESIGN_SHOT_TRACKER_UI_REVAMP.md
@@ -5,8 +5,8 @@ context, the data model the work builds on, the recommended build order, and the
 cross-cutting decisions so the individual plans stay consistent.
 
 > **Status:** F1-F9 and F12 are implemented in the app and documented in the linked plans.
-> F10 is no longer needed as a standalone feature and is superseded by F13. F13 is a
-> planning draft; F11 remains gated on live-use feedback. Manual Supabase-heavy QA is still tracked in
+> F10 is no longer needed as a standalone feature and is superseded by F13. F11 and F13
+> are both held pending further user feedback. Manual Supabase-heavy QA is still tracked in
 > [REGRESSION_TESTING.md](REGRESSION_TESTING.md).
 >
 > **Major pivot (recorded):** F1 was originally "make the shot chart a tab." After
@@ -31,7 +31,7 @@ cross-cutting decisions so the individual plans stay consistent.
 | **F12** | Recent-events undo popup | [PLAN_F12_RECENT_EVENTS_UNDO.md](PLAN_F12_RECENT_EVENTS_UNDO.md) | **Implemented.** The bottom Undo opens a recent-events popup; the newest event can be undone via existing LIFO `UNDO`. |
 | **F7** | Assist-linking on a made shot | [PLAN_F7_ASSIST_LINKING.md](PLAN_F7_ASSIST_LINKING.md) | **Implemented.** After a made court shot, optionally credit a same-side teammate assist as a separate `ast` increment. |
 | **F8** | Live per-player line in popup | [PLAN_F8_LIVE_PER_PLAYER_LINE.md](PLAN_F8_LIVE_PER_PLAYER_LINE.md) | **Implemented.** Shows the selected player's compact live stat line under the popup's Log for label. |
-| **F9-F13** | Court Event Capture enhancements | [PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | F9 rebound-after-miss is implemented; F10 visible numbering is superseded by F13 shot detail/edit planning; F11 remains gated. |
+| **F9-F13** | Court Event Capture enhancements | [PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | F9 rebound-after-miss is implemented; F10 visible numbering is superseded by F13; F11 and F13 are held pending further feedback. |
 
 F1 is the foundation for F2, F3, and F5-F12. F4 is independent and has landed.
 
@@ -141,8 +141,8 @@ F1  Single-page tracker + Court Event Capture     (implemented)
  └─ F11 Hybrid quick buttons (Option B)            (only if testing shows it's needed)
 F4  In-progress scores on resume UI                (implemented; cloud-list QA pending)
 
-F9 is complete. F10 is superseded by F13 shot detail/edit planning. F13 should be reviewed
-before build; F11 should stay gated on live-use feedback.
+F9 is complete. F10 is superseded by F13 shot detail/edit planning. F11 and F13 are both
+held pending further user feedback before build work resumes.
 ```
 
 Rationale and per-feature phases: see
@@ -165,7 +165,7 @@ Resolved items are struck/marked; defaults are what the plans assume.
 | Q3 | F2: per-player marker colors? | v1 uniform; color is a follow-up. |
 | Q4 | F3: all-recorder vs primary-recorder shots on cloud review? | All-recorder via a review path, **de-duped to the primary recorder per player** (F3 §7 D1–D2). |
 | Q5 | F4: trust the synced `games` row score vs aggregate stats? | Row snapshot first; stats fallback only when `home_team_score` is null (creator-scoped). |
-| Q6 | F11 (Option B) quick buttons — build now or gate on testing? | Gate on live testing of Option A; default A. |
+| Q6 | F11 (Option B) quick buttons — build now or gate on testing? | **Held:** revisit only after further user feedback shows non-shot popup friction. |
 
 | Q7 | F10 visible numbering? | **Resolved:** no standalone marker numbering; superseded by F13 shot detail metadata. |
 

--- a/docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md
+++ b/docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md
@@ -3,8 +3,8 @@
 > **For agentic workers:** This is the roadmap for follow-on enhancements to the Court
 > Event Capture model introduced in [PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md](PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md).
 > F5, F6, F7, F8, F9, and F12 are implemented. F10 is no longer needed as a
-> standalone visible-numbering feature and is superseded by F13. F11 remains gated on
-> live-use feedback. F13 is drafted for review in
+> standalone visible-numbering feature and is superseded by F13. F11 and F13 are both
+> held pending further user feedback before any build work. F13 is drafted for review in
 > [PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md).
 
 F5-F12 depend on F1 (the single-page tracker + `CourtEventPopup`) and avoid data-model
@@ -44,19 +44,20 @@ F1  Single-page tracker + Court Event Capture       (implemented)
  |-- F8  Live per-player line in popup              (implemented)
  |-- F9  Rebound-after-miss prompt                  (implemented; opt-in)
  |-- F10 Shot sequence numbers / recency            (superseded; no standalone work)
- |-- F13 Shot detail + linked metadata/edit modal   (planned; review draft)
- `-- F11 Hybrid quick buttons (Option B)            (only if live testing shows friction)
+ |-- F13 Shot detail + linked metadata/edit modal   (hold pending user feedback)
+ `-- F11 Hybrid quick buttons (Option B)            (hold pending user feedback)
 F4  In-progress scores on resume UI                 (implemented; cloud-list QA pending)
 ```
 
-**Remaining work:** F13 should be reviewed and phased before build. F11 should stay gated
-on live-use feedback.
+**Remaining work:** F11 and F13 are both paused. Revisit only after further user feedback
+clarifies whether quick non-shot buttons or shot detail/editing are worth prioritizing.
 
 **Why this order:** F12 gives F7's two-step assist undo a visible event list without a
 reducer change. F13 is the natural successor to F7/F9 because it turns their
 adjacent-but-unlinked stat increments into durable shot metadata and an eventual edit
-surface. F11 is intentionally last: build it only if live testing shows the extra tap for
-block/steal/assist is real friction.
+surface. Both are intentionally held now: build F11 only if live testing shows the extra
+tap for block/steal/assist is real friction, and build F13 only if shot detail/editing
+proves important enough for the larger data-model work.
 
 ---
 
@@ -157,7 +158,7 @@ belongs at the metadata/detail level:
 ## F13 - Shot detail + linked metadata + edit modal
 
 > **Expanded to a draft plan:** [PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md).
-> **Status:** Planning draft for review.
+> **Status:** Held pending further user feedback.
 
 **Goal:** Tap an existing shot marker to inspect the shot event: shot number, shooter,
 result/value, zone/location, timestamp/order, and any F7 assist or F9 rebound linked to
@@ -186,6 +187,8 @@ ever infer F7/F9 links (recommended no).
 ---
 
 ## F11 - Hybrid quick buttons for block / steal / assist (Option B)
+
+> **Status:** Held pending further user feedback.
 
 **Goal:** For coaches who log many blocks/steals/assists, add dedicated one-tap buttons
 next to the court while keeping the popup's secondary row.

--- a/docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md
+++ b/docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md
@@ -4,7 +4,10 @@
 > visible numbering is no longer needed as a standalone feature; the useful version is a
 > tappable shot detail surface with durable shot number and linked F7/F9 metadata.
 >
-> Status: planning draft for review.
+> Status: held pending further user feedback.
+>
+> **Hold note:** Do not start implementation until further live-use/user feedback confirms
+> that shot detail/editing is worth prioritizing over smaller court-capture refinements.
 
 ## Goal
 


### PR DESCRIPTION
Summary:
- mark F11 quick buttons as held pending further user feedback
- mark F13 shot detail/editing as held pending further user feedback
- update roadmap, README, agent overview, design overview, and F13 plan status

Verification:
- git diff --check (line-ending warnings only)
- docs-only change; app tests not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only status updates; no application or database changes.
> 
> **Overview**
> **Court-capture roadmap docs** now treat **F11** (hybrid quick buttons) and **F13** (shot detail / linked metadata / edit modal) as **on hold** until more live-use feedback, instead of F11 being gated on testing and F13 being an active planning draft.
> 
> Updates are aligned across `README.md` (What's Next), `docs/AGENT_CODEBASE_OVERVIEW.md`, `docs/DESIGN_SHOT_TRACKER_UI_REVAMP.md`, `docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md`, and `docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md`—including roadmap trees, remaining-work notes, and open question **Q6**. **F13** adds an explicit **do not implement** hold note; status lines change from “planning draft for review” to **held pending further user feedback**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c8b72bb7aa3fd2a5c7a0e2dcf9db4061fb288d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->