### PR TITLE
Add Team Info MVP

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -66,6 +66,8 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.6 | Remove player | Player removed from roster (soft deactivate) |
 | 4.7 | Season Stats link (when team selected) | Navigate to Leaderboard with that team pre-selected |
 | 4.8 | Reload → Teams | Same teams and roster (from Supabase) |
+| 4.9 | Teams → tap a team card's primary name area | Opens `/team?teamId=<id>`; Team Info shows display name, season, sport, record, roster count, game count, and links back to Season Stats, Team Stats, and Manage Team |
+| 4.10 | Teams → tap **Manage** on a team card | Stays on `/teams`; roster/member management switches to that team |
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import GameCheckout from './pages/GameCheckout'
 import GameSummary from './pages/GameSummary'
 import Admin from './pages/Admin'
 import Teams from './pages/Teams'
+import TeamInfo from './pages/TeamInfo'
 import Games from './pages/Games'
 import Leaderboard from './pages/Leaderboard'
 import PlayerProfile from './pages/PlayerProfile'
@@ -59,6 +60,7 @@ function AppRoutes() {
           <Route path="/summary" element={<GameSummary />} />
           <Route path="/admin" element={<Admin />} />
           <Route path="/teams" element={<Teams />} />
+          <Route path="/team" element={<TeamInfo />} />
           <Route path="/games" element={<Games />} />
           <Route path="/leaderboard" element={<Leaderboard />} />
           <Route path="/player" element={<PlayerProfile />} />

--- a/src/components/team-info/RecordBadge.tsx
+++ b/src/components/team-info/RecordBadge.tsx
@@ -1,0 +1,21 @@
+import type { TeamRecord } from '../../lib/teamInfo'
+
+interface RecordBadgeProps {
+  record: TeamRecord
+}
+
+export default function RecordBadge({ record }: RecordBadgeProps) {
+  const label =
+    record.ties > 0
+      ? `${record.wins}-${record.losses}-${record.ties}`
+      : `${record.wins}-${record.losses}`
+
+  return (
+    <div className="inline-flex items-center rounded-lg border border-slate-200 bg-white px-3 py-2">
+      <div>
+        <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Record</p>
+        <p className="text-lg font-bold text-slate-900 leading-tight">{label}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/team-info/TeamHero.tsx
+++ b/src/components/team-info/TeamHero.tsx
@@ -1,0 +1,56 @@
+import type { TeamRecord } from '../../lib/teamInfo'
+import RecordBadge from './RecordBadge'
+
+interface TeamHeroProps {
+  teamName: string
+  legalName?: string | null
+  seasonName: string
+  sportName: string
+  sportIcon: string
+  record: TeamRecord
+  rosterCount: number
+  gameCount: number
+}
+
+export default function TeamHero({
+  teamName,
+  legalName,
+  seasonName,
+  sportName,
+  sportIcon,
+  record,
+  rosterCount,
+  gameCount,
+}: TeamHeroProps) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-slate-500">
+            {sportIcon} {sportName}{seasonName ? ` / ${seasonName}` : ''}
+          </p>
+          <h1 className="mt-1 text-2xl font-bold text-slate-900 break-words">{teamName}</h1>
+          {legalName && legalName !== teamName && (
+            <p className="mt-1 text-sm text-slate-500 break-words">{legalName}</p>
+          )}
+        </div>
+        <RecordBadge record={record} />
+      </div>
+
+      <div className="mt-4 grid grid-cols-3 gap-2">
+        <div className="rounded-lg bg-slate-50 px-3 py-2">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Roster</p>
+          <p className="text-lg font-bold text-slate-800">{rosterCount}</p>
+        </div>
+        <div className="rounded-lg bg-slate-50 px-3 py-2">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Games</p>
+          <p className="text-lg font-bold text-slate-800">{gameCount}</p>
+        </div>
+        <div className="rounded-lg bg-slate-50 px-3 py-2">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Finals</p>
+          <p className="text-lg font-bold text-slate-800">{record.gamesPlayed}</p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/team-info/TeamHero.tsx
+++ b/src/components/team-info/TeamHero.tsx
@@ -6,7 +6,7 @@ interface TeamHeroProps {
   legalName?: string | null
   seasonName: string
   sportName: string
-  sportIcon: string
+  sportIcon?: string
   record: TeamRecord
   rosterCount: number
   gameCount: number
@@ -27,7 +27,7 @@ export default function TeamHero({
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <p className="text-sm font-semibold text-slate-500">
-            {sportIcon} {sportName}{seasonName ? ` / ${seasonName}` : ''}
+            {sportIcon ? `${sportIcon} ` : ''}{sportName}{seasonName ? ` / ${seasonName}` : ''}
           </p>
           <h1 className="mt-1 text-2xl font-bold text-slate-900 break-words">{teamName}</h1>
           {legalName && legalName !== teamName && (

--- a/src/lib/teamInfo.test.ts
+++ b/src/lib/teamInfo.test.ts
@@ -50,6 +50,20 @@ describe('computeTeamRecord', () => {
 
     expect(record).toEqual({ wins: 0, losses: 0, ties: 0, gamesPlayed: 0 })
   })
+
+  it('skips legacy final games when resolved stat totals are unavailable', () => {
+    const record = computeTeamRecord(basketball, [
+      {
+        id: 'legacy-missing-stats',
+        status: 'final',
+        opponent_score: 10,
+        home_team_score: null,
+        home_score_adjustment: 0,
+      },
+    ])
+
+    expect(record).toEqual({ wins: 0, losses: 0, ties: 0, gamesPlayed: 0 })
+  })
 })
 
 describe('splitTeamGames', () => {

--- a/src/lib/teamInfo.test.ts
+++ b/src/lib/teamInfo.test.ts
@@ -64,6 +64,15 @@ describe('computeTeamRecord', () => {
 
     expect(record).toEqual({ wins: 0, losses: 0, ties: 0, gamesPlayed: 0 })
   })
+
+  it('counts stored scores even when sport config is unavailable', () => {
+    const record = computeTeamRecord(null, [
+      { id: 'win', status: 'final', opponent_score: 40, home_team_score: 41 },
+      { id: 'legacy', status: 'final', opponent_score: 10, home_team_score: null },
+    ])
+
+    expect(record).toEqual({ wins: 1, losses: 0, ties: 0, gamesPlayed: 1 })
+  })
 })
 
 describe('splitTeamGames', () => {

--- a/src/lib/teamInfo.test.ts
+++ b/src/lib/teamInfo.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { sports } from '../config/sports'
+import {
+  computeTeamRecord,
+  splitTeamGames,
+  teamInfoPath,
+  teamLeaderboardPath,
+  teamManagementPath,
+  teamStatsPath,
+} from './teamInfo'
+
+const basketball = sports.find(sport => sport.id === 'basketball')!
+
+describe('computeTeamRecord', () => {
+  it('counts wins, losses, and ties from finalized game row scores', () => {
+    const record = computeTeamRecord(basketball, [
+      { id: 'win', status: 'final', opponent_score: 40, home_team_score: 41 },
+      { id: 'loss', status: 'final', opponent_score: 52, home_team_score: 48 },
+      { id: 'tie', status: 'final', opponent_score: 33, home_team_score: 33 },
+      { id: 'active', status: 'in_progress', opponent_score: 10, home_team_score: 12 },
+    ])
+
+    expect(record).toEqual({ wins: 1, losses: 1, ties: 1, gamesPlayed: 3 })
+  })
+
+  it('falls back to stat totals and home score adjustment for legacy rows', () => {
+    const record = computeTeamRecord(
+      basketball,
+      [
+        {
+          id: 'legacy-win',
+          status: 'final',
+          opponent_score: 46,
+          home_team_score: null,
+          home_score_adjustment: 2,
+        },
+      ],
+      {
+        'legacy-win': { '2pt': 20, ft: 5 },
+      }
+    )
+
+    expect(record).toEqual({ wins: 1, losses: 0, ties: 0, gamesPlayed: 1 })
+  })
+
+  it('skips final games without opponent scores', () => {
+    const record = computeTeamRecord(basketball, [
+      { id: 'missing', status: 'final', opponent_score: null, home_team_score: 12 },
+    ])
+
+    expect(record).toEqual({ wins: 0, losses: 0, ties: 0, gamesPlayed: 0 })
+  })
+})
+
+describe('splitTeamGames', () => {
+  it('groups team games by status', () => {
+    const games = [
+      { id: 'scheduled', status: 'scheduled' },
+      { id: 'active', status: 'in_progress' },
+      { id: 'final', status: 'final' },
+      { id: 'draft', status: 'draft' },
+    ]
+
+    expect(splitTeamGames(games)).toEqual({
+      upcoming: [games[0], games[3]],
+      inProgress: [games[1]],
+      completed: [games[2]],
+    })
+  })
+})
+
+describe('team info paths', () => {
+  it('builds query-param team routes', () => {
+    expect(teamInfoPath('team 1')).toBe('/team?teamId=team%201')
+    expect(teamLeaderboardPath('team 1', 'season 1')).toBe(
+      '/leaderboard?teamId=team+1&seasonId=season+1'
+    )
+    expect(teamStatsPath('team 1')).toBe('/team-stats?teamId=team%201')
+    expect(teamManagementPath('team 1')).toBe('/teams?teamId=team%201')
+  })
+})

--- a/src/lib/teamInfo.ts
+++ b/src/lib/teamInfo.ts
@@ -23,7 +23,7 @@ export interface SplitTeamGames<T> {
 }
 
 export function computeTeamRecord(
-  sport: SportConfig,
+  sport: SportConfig | null,
   games: TeamInfoGame[],
   statsTotalsByGameId: Record<string, Record<string, number>> = {}
 ): TeamRecord {
@@ -31,13 +31,18 @@ export function computeTeamRecord(
 
   for (const game of games) {
     if (game.status !== 'final' || game.opponent_score == null) continue
-    if (game.home_team_score == null && !(game.id in statsTotalsByGameId)) continue
+    if (game.home_team_score == null && (!sport || !(game.id in statsTotalsByGameId))) {
+      continue
+    }
 
-    const homeScore = resolveFinalHomeScoreFromGameRow(
-      sport,
-      statsTotalsByGameId[game.id] ?? {},
-      game
-    )
+    const homeScore =
+      game.home_team_score != null
+        ? game.home_team_score
+        : resolveFinalHomeScoreFromGameRow(
+            sport!,
+            statsTotalsByGameId[game.id] ?? {},
+            game
+          )
     record.gamesPlayed += 1
 
     if (homeScore > game.opponent_score) record.wins += 1

--- a/src/lib/teamInfo.ts
+++ b/src/lib/teamInfo.ts
@@ -1,0 +1,74 @@
+import type { SportConfig } from '../types'
+import { resolveFinalHomeScoreFromGameRow } from './gameScore'
+
+export interface TeamInfoGame {
+  id: string
+  status: string
+  opponent_score: number | null
+  home_team_score?: number | null
+  home_score_adjustment?: number | null
+}
+
+export interface TeamRecord {
+  wins: number
+  losses: number
+  ties: number
+  gamesPlayed: number
+}
+
+export interface SplitTeamGames<T> {
+  upcoming: T[]
+  inProgress: T[]
+  completed: T[]
+}
+
+export function computeTeamRecord(
+  sport: SportConfig,
+  games: TeamInfoGame[],
+  statsTotalsByGameId: Record<string, Record<string, number>> = {}
+): TeamRecord {
+  const record: TeamRecord = { wins: 0, losses: 0, ties: 0, gamesPlayed: 0 }
+
+  for (const game of games) {
+    if (game.status !== 'final' || game.opponent_score == null) continue
+
+    const homeScore = resolveFinalHomeScoreFromGameRow(
+      sport,
+      statsTotalsByGameId[game.id] ?? {},
+      game
+    )
+    record.gamesPlayed += 1
+
+    if (homeScore > game.opponent_score) record.wins += 1
+    else if (homeScore < game.opponent_score) record.losses += 1
+    else record.ties += 1
+  }
+
+  return record
+}
+
+export function splitTeamGames<T extends { status: string }>(games: T[]): SplitTeamGames<T> {
+  return {
+    upcoming: games.filter(game => game.status !== 'final' && game.status !== 'in_progress'),
+    inProgress: games.filter(game => game.status === 'in_progress'),
+    completed: games.filter(game => game.status === 'final'),
+  }
+}
+
+export function teamInfoPath(teamId: string): string {
+  return `/team?teamId=${encodeURIComponent(teamId)}`
+}
+
+export function teamLeaderboardPath(teamId: string, seasonId?: string | null): string {
+  const params = new URLSearchParams({ teamId })
+  if (seasonId) params.set('seasonId', seasonId)
+  return `/leaderboard?${params.toString()}`
+}
+
+export function teamStatsPath(teamId: string): string {
+  return `/team-stats?teamId=${encodeURIComponent(teamId)}`
+}
+
+export function teamManagementPath(teamId: string): string {
+  return `/teams?teamId=${encodeURIComponent(teamId)}`
+}

--- a/src/lib/teamInfo.ts
+++ b/src/lib/teamInfo.ts
@@ -31,6 +31,7 @@ export function computeTeamRecord(
 
   for (const game of games) {
     if (game.status !== 'final' || game.opponent_score == null) continue
+    if (game.home_team_score == null && !(game.id in statsTotalsByGameId)) continue
 
     const homeScore = resolveFinalHomeScoreFromGameRow(
       sport,

--- a/src/pages/TeamInfo.tsx
+++ b/src/pages/TeamInfo.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import TeamHero from '../components/team-info/TeamHero'
+import { sports } from '../config/sports'
+import { useAuth } from '../context/AuthContext'
+import { teamDisplayName } from '../lib/display'
+import { supabase } from '../lib/supabase'
+import {
+  computeTeamRecord,
+  splitTeamGames,
+  teamLeaderboardPath,
+  teamManagementPath,
+  teamStatsPath,
+  type TeamInfoGame,
+  type TeamRecord,
+} from '../lib/teamInfo'
+
+interface TeamRow {
+  id: string
+  name: string
+  nickname: string | null
+  season_id: string
+  seasons: {
+    id: string
+    name: string
+    sport: string
+  }
+}
+
+interface GameRow extends TeamInfoGame {
+  game_date: string
+  opponent_name: string
+}
+
+function emptyRecord(): TeamRecord {
+  return { wins: 0, losses: 0, ties: 0, gamesPlayed: 0 }
+}
+
+export default function TeamInfo() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const teamId = searchParams.get('teamId')
+  const { isConfigured } = useAuth()
+  const supabaseClient = supabase
+
+  const [team, setTeam] = useState<TeamRow | null>(null)
+  const [rosterCount, setRosterCount] = useState(0)
+  const [games, setGames] = useState<GameRow[]>([])
+  const [statsTotalsByGameId, setStatsTotalsByGameId] = useState<Record<string, Record<string, number>>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const sport = useMemo(
+    () => (team ? sports.find(item => item.id === team.seasons.sport) ?? null : null),
+    [team]
+  )
+
+  const record = useMemo(
+    () => (sport ? computeTeamRecord(sport, games, statsTotalsByGameId) : emptyRecord()),
+    [games, sport, statsTotalsByGameId]
+  )
+
+  const gameGroups = useMemo(() => splitTeamGames(games), [games])
+
+  useEffect(() => {
+    if (!teamId || !isConfigured || !supabaseClient) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      setTeam(null)
+      setGames([])
+      setStatsTotalsByGameId({})
+
+      const [teamRes, rosterRes, gamesRes] = await Promise.all([
+        supabaseClient
+          .from('teams')
+          .select('id,name,nickname,season_id,seasons!inner(id,name,sport)')
+          .eq('id', teamId)
+          .single(),
+        supabaseClient
+          .from('team_players')
+          .select('id', { count: 'exact', head: true })
+          .eq('team_id', teamId)
+          .eq('is_active', true),
+        supabaseClient
+          .from('games')
+          .select('id,game_date,opponent_name,opponent_score,home_team_score,home_score_adjustment,status')
+          .eq('team_id', teamId)
+          .order('game_date', { ascending: false }),
+      ])
+
+      if (cancelled) return
+
+      if (teamRes.error || !teamRes.data) {
+        setError(teamRes.error?.message ?? 'Team not found')
+        setLoading(false)
+        return
+      }
+      if (rosterRes.error) {
+        setError(rosterRes.error.message)
+        setLoading(false)
+        return
+      }
+      if (gamesRes.error) {
+        setError(gamesRes.error.message)
+        setLoading(false)
+        return
+      }
+
+      const loadedTeam = teamRes.data as unknown as TeamRow
+      const loadedGames = (gamesRes.data ?? []) as GameRow[]
+      setTeam(loadedTeam)
+      setRosterCount(rosterRes.count ?? 0)
+      setGames(loadedGames)
+
+      const legacyFinals = loadedGames.filter(
+        game => game.status === 'final' && game.home_team_score == null
+      )
+      if (legacyFinals.length > 0) {
+        const totals: Record<string, Record<string, number>> = {}
+        await Promise.all(
+          legacyFinals.map(async game => {
+            const { data, error: statsError } = await supabaseClient.rpc('get_game_stats_resolved', {
+              p_game_id: game.id,
+            })
+            if (statsError) return
+            totals[game.id] = {}
+            for (const row of (data ?? []) as { stat_id: string; value: number }[]) {
+              totals[game.id][row.stat_id] =
+                (totals[game.id][row.stat_id] ?? 0) + Number(row.value)
+            }
+          })
+        )
+        if (!cancelled) setStatsTotalsByGameId(totals)
+      }
+
+      if (!cancelled) setLoading(false)
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [teamId, isConfigured, supabaseClient])
+
+  if (!isConfigured) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Supabase not configured</p>
+          <p className="text-sm text-slate-500 mb-4">
+            Configure Supabase credentials to view cloud team info.
+          </p>
+          <button type="button" onClick={() => navigate('/admin')} className="btn-primary w-full">
+            Back to Settings
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!teamId) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Missing team</p>
+          <p className="text-sm text-slate-500 mb-4">Choose a team before opening Team Info.</p>
+          <button type="button" onClick={() => navigate('/teams')} className="btn-primary w-full">
+            Teams
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-3xl mx-auto px-4 py-5 space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => navigate('/teams')}
+            className="text-sm font-semibold text-blue-600"
+          >
+            Back to Teams
+          </button>
+          {loading && <span className="text-xs text-slate-400 animate-pulse">Loading...</span>}
+        </div>
+
+        {error ? (
+          <section className="card text-center space-y-3">
+            <p className="font-semibold text-slate-700">Team Info unavailable</p>
+            <p className="text-sm text-slate-500">{error}</p>
+            <button type="button" onClick={() => navigate('/teams')} className="btn-primary w-full">
+              Teams
+            </button>
+          </section>
+        ) : team && sport ? (
+          <>
+            <TeamHero
+              teamName={teamDisplayName(team)}
+              legalName={team.name}
+              seasonName={team.seasons.name}
+              sportName={sport.name}
+              sportIcon={sport.icon}
+              record={record}
+              rosterCount={rosterCount}
+              gameCount={games.length}
+            />
+
+            <section className="card space-y-3">
+              <h2 className="font-semibold text-slate-800">Team Links</h2>
+              <div className="grid gap-2 sm:grid-cols-3">
+                <Link
+                  to={teamLeaderboardPath(team.id, team.season_id)}
+                  className="rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300"
+                >
+                  Season Stats
+                </Link>
+                <Link
+                  to={teamStatsPath(team.id)}
+                  className="rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300"
+                >
+                  Team Stats
+                </Link>
+                <Link
+                  to={teamManagementPath(team.id)}
+                  className="rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300"
+                >
+                  Manage Team
+                </Link>
+              </div>
+            </section>
+
+            <section className="card space-y-3">
+              <h2 className="font-semibold text-slate-800">Game Snapshot</h2>
+              <div className="grid grid-cols-3 gap-2">
+                <div className="rounded-lg bg-slate-50 px-3 py-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Upcoming</p>
+                  <p className="text-lg font-bold text-slate-800">{gameGroups.upcoming.length}</p>
+                </div>
+                <div className="rounded-lg bg-slate-50 px-3 py-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Live</p>
+                  <p className="text-lg font-bold text-slate-800">{gameGroups.inProgress.length}</p>
+                </div>
+                <div className="rounded-lg bg-slate-50 px-3 py-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Final</p>
+                  <p className="text-lg font-bold text-slate-800">{gameGroups.completed.length}</p>
+                </div>
+              </div>
+            </section>
+          </>
+        ) : (
+          <section className="card">
+            <p className="text-sm text-slate-500 animate-pulse">Loading Team Info...</p>
+          </section>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/TeamInfo.tsx
+++ b/src/pages/TeamInfo.tsx
@@ -200,7 +200,7 @@ export default function TeamInfo() {
               Teams
             </button>
           </section>
-        ) : team ? (
+        ) : team && !loading ? (
           <>
             <TeamHero
               teamName={teamDisplayName(team)}

--- a/src/pages/TeamInfo.tsx
+++ b/src/pages/TeamInfo.tsx
@@ -12,7 +12,6 @@ import {
   teamManagementPath,
   teamStatsPath,
   type TeamInfoGame,
-  type TeamRecord,
 } from '../lib/teamInfo'
 
 interface TeamRow {
@@ -30,10 +29,6 @@ interface TeamRow {
 interface GameRow extends TeamInfoGame {
   game_date: string
   opponent_name: string
-}
-
-function emptyRecord(): TeamRecord {
-  return { wins: 0, losses: 0, ties: 0, gamesPlayed: 0 }
 }
 
 export default function TeamInfo() {
@@ -56,7 +51,7 @@ export default function TeamInfo() {
   )
 
   const record = useMemo(
-    () => (sport ? computeTeamRecord(sport, games, statsTotalsByGameId) : emptyRecord()),
+    () => computeTeamRecord(sport, games, statsTotalsByGameId),
     [games, sport, statsTotalsByGameId]
   )
 

--- a/src/pages/TeamInfo.tsx
+++ b/src/pages/TeamInfo.tsx
@@ -200,14 +200,14 @@ export default function TeamInfo() {
               Teams
             </button>
           </section>
-        ) : team && sport ? (
+        ) : team ? (
           <>
             <TeamHero
               teamName={teamDisplayName(team)}
               legalName={team.name}
               seasonName={team.seasons.name}
-              sportName={sport.name}
-              sportIcon={sport.icon}
+              sportName={sport?.name ?? team.seasons.sport}
+              sportIcon={sport?.icon ?? ''}
               record={record}
               rosterCount={rosterCount}
               gameCount={games.length}
@@ -255,11 +255,11 @@ export default function TeamInfo() {
               </div>
             </section>
           </>
-        ) : (
+        ) : loading ? (
           <section className="card">
             <p className="text-sm text-slate-500 animate-pulse">Loading Team Info...</p>
           </section>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -55,7 +55,7 @@ interface PoolPlayer {
 
 export default function Teams() {
   const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
   const { user, isConfigured } = useAuth()
   const { state: gameState, dispatch: gameDispatch } = useGame()
   const userId = user?.id ?? null
@@ -1063,7 +1063,11 @@ export default function Teams() {
                         <div className="flex items-center gap-0.5 shrink-0">
                           <button
                             type="button"
-                            onClick={e => { e.stopPropagation(); setSelectedTeamId(team.id) }}
+                            onClick={e => {
+                              e.stopPropagation()
+                              setSelectedTeamId(team.id)
+                              setSearchParams({ teamId: team.id }, { replace: true })
+                            }}
                             className="text-xs font-semibold text-blue-600 px-1.5 py-1"
                             title="Manage roster and members on this page"
                           >

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { sports } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName, playerDisplayName, playerRosterSelectLabel } from '../lib/display'
+import { teamInfoPath } from '../lib/teamInfo'
 import ConfirmDialog from '../components/ConfirmDialog'
 import MergePlayerWizard, { type MergePlayerOption } from '../components/MergePlayerWizard'
 import { fetchMergePlayerScope } from '../lib/mergePlayerScope'
@@ -54,9 +55,11 @@ interface PoolPlayer {
 
 export default function Teams() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { user, isConfigured } = useAuth()
   const { state: gameState, dispatch: gameDispatch } = useGame()
   const userId = user?.id ?? null
+  const requestedTeamId = searchParams.get('teamId')
   const supabaseClient = supabase
 
   const [teams, setTeams] = useState<TeamRow[]>([])
@@ -149,6 +152,9 @@ export default function Teams() {
       const loadedTeams = (data ?? []) as unknown as TeamRow[]
       setTeams(loadedTeams)
       setSelectedTeamId(prev => {
+        if (requestedTeamId && loadedTeams.some(team => team.id === requestedTeamId)) {
+          return requestedTeamId
+        }
         if (prev && loadedTeams.some(team => team.id === prev)) return prev
         return loadedTeams[0]?.id ?? ''
       })
@@ -159,7 +165,7 @@ export default function Teams() {
     return () => {
       cancelled = true
     }
-  }, [isConfigured, supabaseClient, userId])
+  }, [isConfigured, requestedTeamId, supabaseClient, userId])
 
   useEffect(() => {
     if (!isConfigured || !userId || !supabaseClient) {
@@ -1039,7 +1045,7 @@ export default function Teams() {
                       <div className="flex items-start justify-between gap-2">
                         <button
                           type="button"
-                          onClick={() => setSelectedTeamId(team.id)}
+                          onClick={() => navigate(teamInfoPath(team.id))}
                           className="flex-1 text-left"
                         >
                           <p className="font-medium text-slate-700">
@@ -1055,6 +1061,14 @@ export default function Teams() {
                           </p>
                         </button>
                         <div className="flex items-center gap-0.5 shrink-0">
+                          <button
+                            type="button"
+                            onClick={e => { e.stopPropagation(); setSelectedTeamId(team.id) }}
+                            className="text-xs font-semibold text-blue-600 px-1.5 py-1"
+                            title="Manage roster and members on this page"
+                          >
+                            Manage
+                          </button>
                           <button
                             type="button"
                             onClick={e => { e.stopPropagation(); startEditTeam(team) }}


### PR DESCRIPTION
## Summary
- add shared Team Info record, game grouping, and route helpers with Vitest coverage
- add /team?teamId= MVP page with hero, record, roster/game counts, and links to existing stat/management pages
- wire /teams primary team action to Team Info while keeping management reachable via Manage and /teams?teamId=
- add regression steps for the new Team Info flow

## Verification
- pnpm.cmd test -- src/lib/teamInfo.test.ts
- pnpm.cmd lint (passes with existing Fast Refresh warnings in context files)
- pnpm.cmd build
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and navigation changes reusing existing Supabase RLS and score helpers; record logic is unit-tested but should stay aligned with Team Stats W/L behavior.
> 
> **Overview**
> Adds a **Team Info** hub at `/team?teamId=` and changes how users reach roster management from the Teams list.
> 
> **New route and page:** `TeamInfo` loads team, roster count, and games from Supabase, computes W-L-T via shared `computeTeamRecord` (including legacy finals without `home_team_score` via `get_game_stats_resolved`), and shows a hero (`TeamHero` / `RecordBadge`), links to Season Stats, Team Stats, and Manage Team, plus upcoming/live/final game counts.
> 
> **Shared helpers:** `teamInfo.ts` adds record computation, game grouping, and path builders; covered by `teamInfo.test.ts`.
> 
> **Teams UX:** Tapping a team card’s name area navigates to Team Info instead of selecting the team; **Manage** selects the team on `/teams` and sets `?teamId=` in the URL (deep-linkable management). Team load honors `teamId` query param when present.
> 
> **Docs:** Regression steps 4.9–4.10 document the new flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c9c9566c759ab627bd7375996ee806c31f470f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->