### PR TITLE
Add Team Info overview shell

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -68,6 +68,10 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.8 | Reload → Teams | Same teams and roster (from Supabase) |
 | 4.9 | Teams → tap a team card's primary name area | Opens `/team?teamId=<id>`; Team Info shows display name, season, sport, record, roster count, game count, and links back to Season Stats, Team Stats, and Manage Team |
 | 4.10 | Teams → tap **Manage** on a team card | Stays on `/teams`; roster/member management switches to that team |
+| 4.11 | Team Info → switch **Overview / Roster / Schedule** segments | Segment content changes in place; URL stays `/team?teamId=<id>`; no management actions move off `/teams` |
+| 4.12 | Team Info → Overview | Shows stat links, roster preview, schedule preview, recent results, tournaments, and read-only team members when data exists |
+| 4.13 | Team Info → Roster | Shows the full active roster and read-only member list; player rows link to existing Player Profile |
+| 4.14 | Team Info → Schedule | Shows upcoming/live games, recent finalized results, and tournament links; Cloud Games remains the management/resume backstop |
 
 ---
 

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -1,0 +1,44 @@
+interface SegmentOption<T extends string> {
+  value: T
+  label: string
+}
+
+interface SegmentedControlProps<T extends string> {
+  options: SegmentOption<T>[]
+  value: T
+  onChange: (value: T) => void
+  label: string
+}
+
+export default function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  label,
+}: SegmentedControlProps<T>) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-1" role="tablist" aria-label={label}>
+      <div className="grid grid-cols-3 gap-1">
+        {options.map(option => {
+          const selected = option.value === value
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              onClick={() => onChange(option.value)}
+              className={`min-h-10 rounded-lg px-2 text-sm font-semibold transition-colors ${
+                selected
+                  ? 'bg-blue-600 text-white'
+                  : 'text-slate-600 hover:bg-slate-100'
+              }`}
+            >
+              {option.label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/team-info/QuickStatsCard.tsx
+++ b/src/components/team-info/QuickStatsCard.tsx
@@ -1,0 +1,42 @@
+import { Link } from 'react-router-dom'
+import { teamLeaderboardPath, teamStatsPath } from '../../lib/teamInfo'
+
+interface QuickStatsCardProps {
+  teamId: string
+  seasonId: string
+  firstTournamentId?: string | null
+}
+
+export default function QuickStatsCard({ teamId, seasonId, firstTournamentId }: QuickStatsCardProps) {
+  return (
+    <section className="card space-y-3">
+      <div>
+        <h2 className="font-semibold text-slate-800">Stats</h2>
+        <p className="text-xs text-slate-500">Existing stat views</p>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Link
+          to={teamLeaderboardPath(teamId, seasonId)}
+          className="rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300"
+        >
+          Season Stats
+        </Link>
+        <Link
+          to={teamStatsPath(teamId)}
+          className="rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300"
+        >
+          Team Stats
+        </Link>
+        {firstTournamentId && (
+          <Link
+            to={`/tournament-stats?tournamentId=${encodeURIComponent(firstTournamentId)}&teamId=${encodeURIComponent(teamId)}`}
+            className="rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300 sm:col-span-2"
+          >
+            Tournament Stats
+          </Link>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/team-info/RecentResultsCard.tsx
+++ b/src/components/team-info/RecentResultsCard.tsx
@@ -1,0 +1,47 @@
+import ResultBadge from './ResultBadge'
+import type { TeamGameResult } from '../../lib/teamInfo'
+
+export interface TeamInfoResultGame {
+  id: string
+  game_date: string
+  opponent_name: string
+  tournament_name: string | null
+  scoreLine: string | null
+  result: TeamGameResult | null
+}
+
+interface RecentResultsCardProps {
+  games: TeamInfoResultGame[]
+}
+
+export default function RecentResultsCard({ games }: RecentResultsCardProps) {
+  return (
+    <section className="card space-y-3">
+      <div>
+        <h2 className="font-semibold text-slate-800">Recent Results</h2>
+        <p className="text-xs text-slate-500">{games.length} recent finals</p>
+      </div>
+
+      {games.length === 0 ? (
+        <p className="text-sm text-slate-500">No finalized games yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {games.map(game => (
+            <div key={game.id} className="rounded-xl border border-slate-100 bg-white px-3 py-2">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="font-medium text-slate-800 truncate">vs {game.opponent_name}</p>
+                  <p className="text-xs text-slate-500">{game.game_date}</p>
+                </div>
+                <ResultBadge result={game.result} scoreLine={game.scoreLine} />
+              </div>
+              {game.tournament_name && (
+                <p className="mt-1 text-xs text-slate-500 truncate">{game.tournament_name}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/team-info/ResultBadge.tsx
+++ b/src/components/team-info/ResultBadge.tsx
@@ -1,0 +1,23 @@
+import type { TeamGameResult } from '../../lib/teamInfo'
+
+interface ResultBadgeProps {
+  result: TeamGameResult | null
+  scoreLine: string | null
+}
+
+export default function ResultBadge({ result, scoreLine }: ResultBadgeProps) {
+  const color =
+    result === 'W'
+      ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
+      : result === 'L'
+        ? 'bg-rose-50 text-rose-700 border-rose-200'
+        : result === 'T'
+          ? 'bg-slate-100 text-slate-700 border-slate-200'
+          : 'bg-slate-50 text-slate-500 border-slate-200'
+
+  return (
+    <span className={`inline-flex items-center rounded-lg border px-2 py-1 text-xs font-bold tabular-nums ${color}`}>
+      {result && scoreLine ? `${result} ${scoreLine}` : scoreLine ?? 'TBD'}
+    </span>
+  )
+}

--- a/src/components/team-info/RosterPreviewCard.tsx
+++ b/src/components/team-info/RosterPreviewCard.tsx
@@ -1,0 +1,65 @@
+import { Link } from 'react-router-dom'
+import { playerDisplayName } from '../../lib/display'
+import { teamManagementPath } from '../../lib/teamInfo'
+
+export interface TeamInfoRosterPlayer {
+  id: string
+  first_name: string
+  last_name: string | null
+  nickname: string | null
+  jersey_number: string | null
+}
+
+interface RosterPreviewCardProps {
+  teamId: string
+  players: TeamInfoRosterPlayer[]
+  limit?: number
+}
+
+export default function RosterPreviewCard({ teamId, players, limit }: RosterPreviewCardProps) {
+  const visiblePlayers = typeof limit === 'number' ? players.slice(0, limit) : players
+  const hiddenCount = Math.max(0, players.length - visiblePlayers.length)
+
+  return (
+    <section className="card space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="font-semibold text-slate-800">Roster</h2>
+          <p className="text-xs text-slate-500">{players.length} active players</p>
+        </div>
+        <Link to={teamManagementPath(teamId)} className="text-xs font-semibold text-blue-600">
+          Manage
+        </Link>
+      </div>
+
+      {players.length === 0 ? (
+        <p className="text-sm text-slate-500">No active players yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {visiblePlayers.map(player => (
+            <Link
+              key={player.id}
+              to={`/player?playerId=${encodeURIComponent(player.id)}&teamId=${encodeURIComponent(teamId)}`}
+              className="flex items-center justify-between gap-3 rounded-xl border border-slate-100 bg-white px-3 py-2 hover:border-blue-200"
+            >
+              <div className="min-w-0">
+                <p className="font-medium text-slate-800 truncate">{playerDisplayName(player)}</p>
+                {player.nickname?.trim() && (
+                  <p className="text-xs text-slate-500 truncate">
+                    {[player.first_name, player.last_name].filter(Boolean).join(' ')}
+                  </p>
+                )}
+              </div>
+              <span className="shrink-0 text-sm font-semibold text-slate-500">
+                #{player.jersey_number || '-'}
+              </span>
+            </Link>
+          ))}
+          {hiddenCount > 0 && (
+            <p className="text-xs text-slate-500">+{hiddenCount} more on the active roster</p>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/team-info/SchedulePreviewCard.tsx
+++ b/src/components/team-info/SchedulePreviewCard.tsx
@@ -1,0 +1,70 @@
+import { Link } from 'react-router-dom'
+
+export interface TeamInfoScheduleGame {
+  id: string
+  game_date: string
+  opponent_name: string
+  status: string
+  tournament_name: string | null
+  tournament_id: string | null
+}
+
+interface SchedulePreviewCardProps {
+  games: TeamInfoScheduleGame[]
+  title?: string
+  emptyText?: string
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case 'in_progress':
+      return 'Live'
+    case 'scheduled':
+      return 'Scheduled'
+    default:
+      return status
+  }
+}
+
+export default function SchedulePreviewCard({
+  games,
+  title = 'Schedule',
+  emptyText = 'No upcoming games.',
+}: SchedulePreviewCardProps) {
+  return (
+    <section className="card space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="font-semibold text-slate-800">{title}</h2>
+          <p className="text-xs text-slate-500">{games.length} games ahead</p>
+        </div>
+        <Link to="/games" className="text-xs font-semibold text-blue-600">
+          Cloud Games
+        </Link>
+      </div>
+
+      {games.length === 0 ? (
+        <p className="text-sm text-slate-500">{emptyText}</p>
+      ) : (
+        <div className="space-y-2">
+          {games.map(game => (
+            <div key={game.id} className="rounded-xl border border-slate-100 bg-white px-3 py-2">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="font-medium text-slate-800 truncate">vs {game.opponent_name}</p>
+                  <p className="text-xs text-slate-500">{game.game_date}</p>
+                </div>
+                <span className="shrink-0 rounded-lg bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-700">
+                  {statusLabel(game.status)}
+                </span>
+              </div>
+              {game.tournament_name && (
+                <p className="mt-1 text-xs text-slate-500 truncate">{game.tournament_name}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/team-info/TeamMembersCard.tsx
+++ b/src/components/team-info/TeamMembersCard.tsx
@@ -10,6 +10,7 @@ export interface TeamInfoMember {
 interface TeamMembersCardProps {
   members: TeamInfoMember[]
   error?: string | null
+  limit?: number
 }
 
 function memberDisplayName(member: TeamInfoMember): string {
@@ -18,7 +19,10 @@ function memberDisplayName(member: TeamInfoMember): string {
   return 'Unknown'
 }
 
-export default function TeamMembersCard({ members, error }: TeamMembersCardProps) {
+export default function TeamMembersCard({ members, error, limit }: TeamMembersCardProps) {
+  const visibleMembers = typeof limit === 'number' ? members.slice(0, limit) : members
+  const hiddenCount = Math.max(0, members.length - visibleMembers.length)
+
   return (
     <section className="card space-y-3">
       <div>
@@ -32,7 +36,7 @@ export default function TeamMembersCard({ members, error }: TeamMembersCardProps
         <p className="text-sm text-slate-500">No members found.</p>
       ) : (
         <div className="space-y-2">
-          {members.slice(0, 5).map(member => (
+          {visibleMembers.map(member => (
             <div key={member.id} className="rounded-xl border border-slate-100 bg-white px-3 py-2">
               <div className="flex items-center justify-between gap-3">
                 <p className="font-medium text-slate-800 truncate">{memberDisplayName(member)}</p>
@@ -45,6 +49,9 @@ export default function TeamMembersCard({ members, error }: TeamMembersCardProps
               </p>
             </div>
           ))}
+          {hiddenCount > 0 && (
+            <p className="text-xs text-slate-500">+{hiddenCount} more members</p>
+          )}
         </div>
       )}
     </section>

--- a/src/components/team-info/TeamMembersCard.tsx
+++ b/src/components/team-info/TeamMembersCard.tsx
@@ -1,0 +1,52 @@
+export interface TeamInfoMember {
+  id: string
+  user_id: string
+  role: string
+  accepted_at: string | null
+  display_name: string | null
+  email: string | null
+}
+
+interface TeamMembersCardProps {
+  members: TeamInfoMember[]
+  error?: string | null
+}
+
+function memberDisplayName(member: TeamInfoMember): string {
+  if (member.display_name?.trim()) return member.display_name.trim()
+  if (member.email?.trim()) return member.email.trim()
+  return 'Unknown'
+}
+
+export default function TeamMembersCard({ members, error }: TeamMembersCardProps) {
+  return (
+    <section className="card space-y-3">
+      <div>
+        <h2 className="font-semibold text-slate-800">Team Members</h2>
+        <p className="text-xs text-slate-500">{members.length} people with access</p>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-slate-500">{error}</p>
+      ) : members.length === 0 ? (
+        <p className="text-sm text-slate-500">No members found.</p>
+      ) : (
+        <div className="space-y-2">
+          {members.slice(0, 5).map(member => (
+            <div key={member.id} className="rounded-xl border border-slate-100 bg-white px-3 py-2">
+              <div className="flex items-center justify-between gap-3">
+                <p className="font-medium text-slate-800 truncate">{memberDisplayName(member)}</p>
+                <span className="shrink-0 text-xs font-semibold capitalize text-slate-500">
+                  {member.role}
+                </span>
+              </div>
+              <p className="text-xs text-slate-500">
+                {member.accepted_at ? 'Accepted' : 'Pending'}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/team-info/TeamOverviewCards.tsx
+++ b/src/components/team-info/TeamOverviewCards.tsx
@@ -1,0 +1,49 @@
+import QuickStatsCard from './QuickStatsCard'
+import RecentResultsCard, { type TeamInfoResultGame } from './RecentResultsCard'
+import RosterPreviewCard, { type TeamInfoRosterPlayer } from './RosterPreviewCard'
+import SchedulePreviewCard, { type TeamInfoScheduleGame } from './SchedulePreviewCard'
+import TeamMembersCard, { type TeamInfoMember } from './TeamMembersCard'
+import TournamentCard, { type TeamInfoTournament } from './TournamentCard'
+
+interface TeamOverviewCardsProps {
+  teamId: string
+  seasonId: string
+  roster: TeamInfoRosterPlayer[]
+  upcomingGames: TeamInfoScheduleGame[]
+  recentResults: TeamInfoResultGame[]
+  tournaments: TeamInfoTournament[]
+  members: TeamInfoMember[]
+  tournamentError?: string | null
+  membersError?: string | null
+}
+
+export default function TeamOverviewCards({
+  teamId,
+  seasonId,
+  roster,
+  upcomingGames,
+  recentResults,
+  tournaments,
+  members,
+  tournamentError,
+  membersError,
+}: TeamOverviewCardsProps) {
+  return (
+    <div className="space-y-4">
+      <QuickStatsCard
+        teamId={teamId}
+        seasonId={seasonId}
+        firstTournamentId={tournaments[0]?.id ?? null}
+      />
+      <div className="grid gap-4 lg:grid-cols-2">
+        <RosterPreviewCard teamId={teamId} players={roster} limit={5} />
+        <SchedulePreviewCard games={upcomingGames.slice(0, 3)} />
+      </div>
+      <RecentResultsCard games={recentResults.slice(0, 3)} />
+      <div className="grid gap-4 lg:grid-cols-2">
+        <TournamentCard teamId={teamId} tournaments={tournaments} error={tournamentError} />
+        <TeamMembersCard members={members} error={membersError} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/team-info/TeamOverviewCards.tsx
+++ b/src/components/team-info/TeamOverviewCards.tsx
@@ -42,7 +42,7 @@ export default function TeamOverviewCards({
       <RecentResultsCard games={recentResults.slice(0, 3)} />
       <div className="grid gap-4 lg:grid-cols-2">
         <TournamentCard teamId={teamId} tournaments={tournaments} error={tournamentError} />
-        <TeamMembersCard members={members} error={membersError} />
+        <TeamMembersCard members={members} error={membersError} limit={5} />
       </div>
     </div>
   )

--- a/src/components/team-info/TournamentCard.tsx
+++ b/src/components/team-info/TournamentCard.tsx
@@ -1,0 +1,48 @@
+import { Link } from 'react-router-dom'
+
+export interface TeamInfoTournament {
+  id: string
+  name: string
+  placement: number | null
+  url: string | null
+}
+
+interface TournamentCardProps {
+  teamId: string
+  tournaments: TeamInfoTournament[]
+  error?: string | null
+}
+
+export default function TournamentCard({ teamId, tournaments, error }: TournamentCardProps) {
+  return (
+    <section className="card space-y-3">
+      <div>
+        <h2 className="font-semibold text-slate-800">Tournaments</h2>
+        <p className="text-xs text-slate-500">{tournaments.length} linked tournaments</p>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-slate-500">{error}</p>
+      ) : tournaments.length === 0 ? (
+        <p className="text-sm text-slate-500">No tournaments linked yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {tournaments.slice(0, 3).map(tournament => (
+            <Link
+              key={tournament.id}
+              to={`/tournament-stats?tournamentId=${encodeURIComponent(tournament.id)}&teamId=${encodeURIComponent(teamId)}`}
+              className="flex items-center justify-between gap-3 rounded-xl border border-slate-100 bg-white px-3 py-2 hover:border-blue-200"
+            >
+              <span className="font-medium text-slate-800 truncate">{tournament.name}</span>
+              {tournament.placement != null && (
+                <span className="shrink-0 text-xs font-semibold text-slate-500">
+                  Place {tournament.placement}
+                </span>
+              )}
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/lib/teamInfo.test.ts
+++ b/src/lib/teamInfo.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import { sports } from '../config/sports'
 import {
   computeTeamRecord,
+  resolveTeamInfoHomeScore,
   splitTeamGames,
+  teamGameResult,
   teamInfoPath,
   teamLeaderboardPath,
   teamManagementPath,
@@ -72,6 +74,47 @@ describe('computeTeamRecord', () => {
     ])
 
     expect(record).toEqual({ wins: 1, losses: 0, ties: 0, gamesPlayed: 1 })
+  })
+})
+
+describe('resolveTeamInfoHomeScore', () => {
+  it('uses stored home score before stat totals', () => {
+    const score = resolveTeamInfoHomeScore(
+      null,
+      { id: 'stored', status: 'final', opponent_score: 10, home_team_score: 22 },
+      { stored: { '2pt': 1 } }
+    )
+
+    expect(score).toBe(22)
+  })
+
+  it('uses resolved stats for legacy rows when sport is available', () => {
+    const score = resolveTeamInfoHomeScore(
+      basketball,
+      { id: 'legacy', status: 'final', opponent_score: 10, home_team_score: null },
+      { legacy: { '2pt': 4, ft: 1 } }
+    )
+
+    expect(score).toBe(9)
+  })
+
+  it('returns null for legacy rows without sport-specific scoring context', () => {
+    expect(
+      resolveTeamInfoHomeScore(null, {
+        id: 'legacy',
+        status: 'final',
+        opponent_score: 10,
+        home_team_score: null,
+      })
+    ).toBeNull()
+  })
+})
+
+describe('teamGameResult', () => {
+  it('labels wins, losses, and ties', () => {
+    expect(teamGameResult(12, 10)).toBe('W')
+    expect(teamGameResult(8, 10)).toBe('L')
+    expect(teamGameResult(10, 10)).toBe('T')
   })
 })
 

--- a/src/lib/teamInfo.ts
+++ b/src/lib/teamInfo.ts
@@ -16,10 +16,32 @@ export interface TeamRecord {
   gamesPlayed: number
 }
 
+export type TeamGameResult = 'W' | 'L' | 'T'
+
 export interface SplitTeamGames<T> {
   upcoming: T[]
   inProgress: T[]
   completed: T[]
+}
+
+export function resolveTeamInfoHomeScore(
+  sport: SportConfig | null,
+  game: TeamInfoGame,
+  statsTotalsByGameId: Record<string, Record<string, number>> = {}
+): number | null {
+  if (game.home_team_score != null) return game.home_team_score
+  if (!sport || !(game.id in statsTotalsByGameId)) return null
+  return resolveFinalHomeScoreFromGameRow(
+    sport,
+    statsTotalsByGameId[game.id] ?? {},
+    game
+  )
+}
+
+export function teamGameResult(homeScore: number, opponentScore: number): TeamGameResult {
+  if (homeScore > opponentScore) return 'W'
+  if (homeScore < opponentScore) return 'L'
+  return 'T'
 }
 
 export function computeTeamRecord(
@@ -31,22 +53,14 @@ export function computeTeamRecord(
 
   for (const game of games) {
     if (game.status !== 'final' || game.opponent_score == null) continue
-    if (game.home_team_score == null && (!sport || !(game.id in statsTotalsByGameId))) {
-      continue
-    }
+    const homeScore = resolveTeamInfoHomeScore(sport, game, statsTotalsByGameId)
+    if (homeScore == null) continue
 
-    const homeScore =
-      game.home_team_score != null
-        ? game.home_team_score
-        : resolveFinalHomeScoreFromGameRow(
-            sport!,
-            statsTotalsByGameId[game.id] ?? {},
-            game
-          )
     record.gamesPlayed += 1
 
-    if (homeScore > game.opponent_score) record.wins += 1
-    else if (homeScore < game.opponent_score) record.losses += 1
+    const result = teamGameResult(homeScore, game.opponent_score)
+    if (result === 'W') record.wins += 1
+    else if (result === 'L') record.losses += 1
     else record.ties += 1
   }
 

--- a/src/pages/TeamInfo.tsx
+++ b/src/pages/TeamInfo.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import SegmentedControl from '../components/SegmentedControl'
 import TeamHero from '../components/team-info/TeamHero'
+import RecentResultsCard, { type TeamInfoResultGame } from '../components/team-info/RecentResultsCard'
+import RosterPreviewCard, { type TeamInfoRosterPlayer } from '../components/team-info/RosterPreviewCard'
+import SchedulePreviewCard, { type TeamInfoScheduleGame } from '../components/team-info/SchedulePreviewCard'
+import TeamMembersCard, { type TeamInfoMember } from '../components/team-info/TeamMembersCard'
+import TeamOverviewCards from '../components/team-info/TeamOverviewCards'
+import TournamentCard, { type TeamInfoTournament } from '../components/team-info/TournamentCard'
 import { sports } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { teamDisplayName } from '../lib/display'
 import { supabase } from '../lib/supabase'
 import {
   computeTeamRecord,
+  resolveTeamInfoHomeScore,
   splitTeamGames,
-  teamLeaderboardPath,
-  teamManagementPath,
-  teamStatsPath,
+  teamGameResult,
   type TeamInfoGame,
 } from '../lib/teamInfo'
 
@@ -29,7 +35,17 @@ interface TeamRow {
 interface GameRow extends TeamInfoGame {
   game_date: string
   opponent_name: string
+  tournament_name: string | null
+  tournament_id: string | null
 }
+
+type TeamInfoSegment = 'overview' | 'roster' | 'schedule'
+
+const segmentOptions: Array<{ value: TeamInfoSegment; label: string }> = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'roster', label: 'Roster' },
+  { value: 'schedule', label: 'Schedule' },
+]
 
 export default function TeamInfo() {
   const navigate = useNavigate()
@@ -39,11 +55,16 @@ export default function TeamInfo() {
   const supabaseClient = supabase
 
   const [team, setTeam] = useState<TeamRow | null>(null)
-  const [rosterCount, setRosterCount] = useState(0)
+  const [rosterPlayers, setRosterPlayers] = useState<TeamInfoRosterPlayer[]>([])
   const [games, setGames] = useState<GameRow[]>([])
+  const [tournaments, setTournaments] = useState<TeamInfoTournament[]>([])
+  const [teamMembers, setTeamMembers] = useState<TeamInfoMember[]>([])
+  const [tournamentError, setTournamentError] = useState<string | null>(null)
+  const [membersError, setMembersError] = useState<string | null>(null)
   const [statsTotalsByGameId, setStatsTotalsByGameId] = useState<Record<string, Record<string, number>>>({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [activeSegment, setActiveSegment] = useState<TeamInfoSegment>('overview')
 
   const sport = useMemo(
     () => (team ? sports.find(item => item.id === team.seasons.sport) ?? null : null),
@@ -57,6 +78,45 @@ export default function TeamInfo() {
 
   const gameGroups = useMemo(() => splitTeamGames(games), [games])
 
+  const gamesWithScores = useMemo(
+    () =>
+      games.map(game => {
+        const homeScore = resolveTeamInfoHomeScore(sport, game, statsTotalsByGameId)
+        const scoreLine =
+          homeScore != null && game.opponent_score != null
+            ? `${homeScore}-${game.opponent_score}`
+            : null
+        const result =
+          game.status === 'final' && homeScore != null && game.opponent_score != null
+            ? teamGameResult(homeScore, game.opponent_score)
+            : null
+        return { ...game, scoreLine, result }
+      }),
+    [games, sport, statsTotalsByGameId]
+  )
+
+  const upcomingPreviewGames = useMemo<TeamInfoScheduleGame[]>(() => {
+    const active = gameGroups.inProgress
+    const upcoming = [...gameGroups.upcoming].sort((a, b) => a.game_date.localeCompare(b.game_date))
+    return [...active, ...upcoming]
+  }, [gameGroups])
+
+  const recentResults = useMemo<TeamInfoResultGame[]>(
+    () =>
+      gamesWithScores
+        .filter(game => game.status === 'final')
+        .sort((a, b) => b.game_date.localeCompare(a.game_date))
+        .map(game => ({
+          id: game.id,
+          game_date: game.game_date,
+          opponent_name: game.opponent_name,
+          tournament_name: game.tournament_name,
+          scoreLine: game.scoreLine,
+          result: game.result,
+        })),
+    [gamesWithScores]
+  )
+
   useEffect(() => {
     if (!teamId || !isConfigured || !supabaseClient) {
       setLoading(false)
@@ -68,10 +128,15 @@ export default function TeamInfo() {
       setLoading(true)
       setError(null)
       setTeam(null)
+      setRosterPlayers([])
       setGames([])
+      setTournaments([])
+      setTeamMembers([])
+      setTournamentError(null)
+      setMembersError(null)
       setStatsTotalsByGameId({})
 
-      const [teamRes, rosterRes, gamesRes] = await Promise.all([
+      const [teamRes, rosterRes, gamesRes, tournamentsRes, membersRes] = await Promise.all([
         supabaseClient
           .from('teams')
           .select('id,name,nickname,season_id,seasons!inner(id,name,sport)')
@@ -79,14 +144,24 @@ export default function TeamInfo() {
           .single(),
         supabaseClient
           .from('team_players')
-          .select('id', { count: 'exact', head: true })
+          .select('jersey_number,players!inner(id,first_name,last_name,nickname)')
           .eq('team_id', teamId)
-          .eq('is_active', true),
+          .eq('is_active', true)
+          .order('joined_at', { ascending: true }),
         supabaseClient
           .from('games')
-          .select('id,game_date,opponent_name,opponent_score,home_team_score,home_score_adjustment,status')
+          .select(
+            'id,game_date,opponent_name,opponent_score,home_team_score,home_score_adjustment,status,tournament_name,tournament_id'
+          )
           .eq('team_id', teamId)
           .order('game_date', { ascending: false }),
+        supabaseClient
+          .from('tournaments')
+          .select('id,name,placement,url')
+          .eq('team_id', teamId),
+        supabaseClient.rpc('get_team_members_with_profiles', {
+          p_team_id: teamId,
+        }),
       ])
 
       if (cancelled) return
@@ -108,10 +183,36 @@ export default function TeamInfo() {
       }
 
       const loadedTeam = teamRes.data as unknown as TeamRow
+      type TeamPlayerJoin = {
+        jersey_number: string | null
+        players: {
+          id: string
+          first_name: string
+          last_name: string | null
+          nickname: string | null
+        }
+      }
       const loadedGames = (gamesRes.data ?? []) as GameRow[]
       setTeam(loadedTeam)
-      setRosterCount(rosterRes.count ?? 0)
+      setRosterPlayers(((rosterRes.data ?? []) as unknown as TeamPlayerJoin[]).map(row => ({
+        id: row.players.id,
+        first_name: row.players.first_name,
+        last_name: row.players.last_name,
+        nickname: row.players.nickname,
+        jersey_number: row.jersey_number,
+      })))
       setGames(loadedGames)
+      if (tournamentsRes.error) {
+        setTournamentError(tournamentsRes.error.message)
+      } else {
+        setTournaments((tournamentsRes.data ?? []) as TeamInfoTournament[])
+      }
+      if (membersRes.error) {
+        setMembersError(membersRes.error.message)
+      } else {
+        const rows = (membersRes.data ?? []) as Array<TeamInfoMember & { team_id?: string }>
+        setTeamMembers(rows)
+      }
 
       const legacyFinals = loadedGames.filter(
         game => game.status === 'final' && game.home_team_score == null
@@ -204,51 +305,49 @@ export default function TeamInfo() {
               sportName={sport?.name ?? team.seasons.sport}
               sportIcon={sport?.icon ?? ''}
               record={record}
-              rosterCount={rosterCount}
+              rosterCount={rosterPlayers.length}
               gameCount={games.length}
             />
 
-            <section className="card space-y-3">
-              <h2 className="font-semibold text-slate-800">Team Links</h2>
-              <div className="grid gap-2 sm:grid-cols-3">
-                <Link
-                  to={teamLeaderboardPath(team.id, team.season_id)}
-                  className="rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300"
-                >
-                  Season Stats
-                </Link>
-                <Link
-                  to={teamStatsPath(team.id)}
-                  className="rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300"
-                >
-                  Team Stats
-                </Link>
-                <Link
-                  to={teamManagementPath(team.id)}
-                  className="rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300"
-                >
-                  Manage Team
-                </Link>
-              </div>
-            </section>
+            <SegmentedControl
+              label="Team Info sections"
+              options={segmentOptions}
+              value={activeSegment}
+              onChange={setActiveSegment}
+            />
 
-            <section className="card space-y-3">
-              <h2 className="font-semibold text-slate-800">Game Snapshot</h2>
-              <div className="grid grid-cols-3 gap-2">
-                <div className="rounded-lg bg-slate-50 px-3 py-2">
-                  <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Upcoming</p>
-                  <p className="text-lg font-bold text-slate-800">{gameGroups.upcoming.length}</p>
-                </div>
-                <div className="rounded-lg bg-slate-50 px-3 py-2">
-                  <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Live</p>
-                  <p className="text-lg font-bold text-slate-800">{gameGroups.inProgress.length}</p>
-                </div>
-                <div className="rounded-lg bg-slate-50 px-3 py-2">
-                  <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Final</p>
-                  <p className="text-lg font-bold text-slate-800">{gameGroups.completed.length}</p>
-                </div>
+            {activeSegment === 'overview' && (
+              <TeamOverviewCards
+                teamId={team.id}
+                seasonId={team.season_id}
+                roster={rosterPlayers}
+                upcomingGames={upcomingPreviewGames}
+                recentResults={recentResults}
+                tournaments={tournaments}
+                members={teamMembers}
+                tournamentError={tournamentError}
+                membersError={membersError}
+              />
+            )}
+
+            {activeSegment === 'roster' && (
+              <div className="space-y-4">
+                <RosterPreviewCard teamId={team.id} players={rosterPlayers} />
+                <TeamMembersCard members={teamMembers} error={membersError} />
               </div>
-            </section>
+            )}
+
+            {activeSegment === 'schedule' && (
+              <div className="space-y-4">
+                <SchedulePreviewCard games={upcomingPreviewGames} />
+                <RecentResultsCard games={recentResults} />
+                <TournamentCard
+                  teamId={team.id}
+                  tournaments={tournaments}
+                  error={tournamentError}
+                />
+              </div>
+            )}
           </>
         ) : loading ? (
           <section className="card">


### PR DESCRIPTION
## Summary
- add Team Info segmented shell for Overview, Roster, and Schedule sections
- add read-only overview cards for stat links, roster preview, schedule preview, recent results, tournaments, and team members
- extend shared Team Info helpers for score lines/results used by preview cards
- expand regression steps for the new Team Info segments

## Verification
- pnpm.cmd test -- src/lib/teamInfo.test.ts
- pnpm.cmd lint (passes with existing Fast Refresh warnings in context files)
- pnpm.cmd build
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and existing Supabase/RPC access patterns; scoring logic is refactored with unit tests and no auth or write-path changes.
> 
> **Overview**
> **Team Info** replaces the flat link list and game-count snapshot with an **Overview / Roster / Schedule** segmented shell (URL stays `/team?teamId=…`; roster management still links to `/teams`).
> 
> **Overview** composes read-only cards: stat deep-links (Season, Team, optional Tournament), roster and schedule previews, recent finals with W/L/T badges, tournaments, and team members. **Roster** shows the full active roster (player profile links) plus members; **Schedule** shows upcoming/live games, recent results, and tournaments, with **Cloud Games** as the management backstop.
> 
> `TeamInfo` now loads full roster rows, tournament fields on games, `tournaments`, and `get_team_members_with_profiles` (errors surfaced per section). `teamInfo` gains `resolveTeamInfoHomeScore` and `teamGameResult` for record and preview score lines; regression doc steps **4.11–4.14** cover the new segments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e156234e68d39cba73dcf22118e8c08c7232b118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->