### PR TITLE
Add Team roster drilldown

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -71,7 +71,9 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.11 | Team Info → switch **Overview / Roster / Schedule** segments | Segment content changes in place; URL stays `/team?teamId=<id>`; no management actions move off `/teams` |
 | 4.12 | Team Info → Overview | Shows stat links, roster preview, schedule preview, recent results, tournaments, and read-only team members when data exists |
 | 4.13 | Team Info → Roster | Shows the full active roster and read-only member list; player rows link to existing Player Profile |
-| 4.14 | Team Info → Schedule | Shows upcoming/live games, recent finalized results, and tournament links; Cloud Games remains the management/resume backstop |
+| 4.14 | Team Info → Overview roster preview → View roster | Opens `/team/roster?teamId=<id>`; shows the same active roster as a read-only Team Roster page |
+| 4.15 | Team Roster → Back to Team | Returns to `/team?teamId=<id>` |
+| 4.16 | Team Info → Schedule | Shows upcoming/live games, recent finalized results, and tournament links; Cloud Games remains the management/resume backstop |
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import GameSummary from './pages/GameSummary'
 import Admin from './pages/Admin'
 import Teams from './pages/Teams'
 import TeamInfo from './pages/TeamInfo'
+import TeamRoster from './pages/TeamRoster'
 import Games from './pages/Games'
 import Leaderboard from './pages/Leaderboard'
 import PlayerProfile from './pages/PlayerProfile'
@@ -61,6 +62,7 @@ function AppRoutes() {
           <Route path="/admin" element={<Admin />} />
           <Route path="/teams" element={<Teams />} />
           <Route path="/team" element={<TeamInfo />} />
+          <Route path="/team/roster" element={<TeamRoster />} />
           <Route path="/games" element={<Games />} />
           <Route path="/leaderboard" element={<Leaderboard />} />
           <Route path="/player" element={<PlayerProfile />} />

--- a/src/components/team-info/PlayerRow.tsx
+++ b/src/components/team-info/PlayerRow.tsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom'
+import { playerDisplayName } from '../../lib/display'
+
+export interface TeamInfoRosterPlayer {
+  id: string
+  first_name: string
+  last_name: string | null
+  nickname: string | null
+  jersey_number: string | null
+}
+
+interface PlayerRowProps {
+  teamId: string
+  player: TeamInfoRosterPlayer
+}
+
+export default function PlayerRow({ teamId, player }: PlayerRowProps) {
+  return (
+    <Link
+      to={`/player?playerId=${encodeURIComponent(player.id)}&teamId=${encodeURIComponent(teamId)}`}
+      className="flex items-center justify-between gap-3 rounded-lg border border-slate-100 bg-white px-3 py-2 hover:border-blue-200"
+    >
+      <div className="min-w-0">
+        <p className="font-medium text-slate-800 truncate">{playerDisplayName(player)}</p>
+        {player.nickname?.trim() && (
+          <p className="text-xs text-slate-500 truncate">
+            {[player.first_name, player.last_name].filter(Boolean).join(' ')}
+          </p>
+        )}
+      </div>
+      <span className="shrink-0 text-sm font-semibold text-slate-500">
+        #{player.jersey_number || '-'}
+      </span>
+    </Link>
+  )
+}

--- a/src/components/team-info/RosterPreviewCard.tsx
+++ b/src/components/team-info/RosterPreviewCard.tsx
@@ -1,14 +1,8 @@
 import { Link } from 'react-router-dom'
-import { playerDisplayName } from '../../lib/display'
-import { teamManagementPath } from '../../lib/teamInfo'
+import { teamManagementPath, teamRosterPath } from '../../lib/teamInfo'
+import PlayerRow, { type TeamInfoRosterPlayer } from './PlayerRow'
 
-export interface TeamInfoRosterPlayer {
-  id: string
-  first_name: string
-  last_name: string | null
-  nickname: string | null
-  jersey_number: string | null
-}
+export type { TeamInfoRosterPlayer } from './PlayerRow'
 
 interface RosterPreviewCardProps {
   teamId: string
@@ -19,6 +13,7 @@ interface RosterPreviewCardProps {
 export default function RosterPreviewCard({ teamId, players, limit }: RosterPreviewCardProps) {
   const visiblePlayers = typeof limit === 'number' ? players.slice(0, limit) : players
   const hiddenCount = Math.max(0, players.length - visiblePlayers.length)
+  const isPreview = typeof limit === 'number'
 
   return (
     <section className="card space-y-3">
@@ -27,9 +22,16 @@ export default function RosterPreviewCard({ teamId, players, limit }: RosterPrev
           <h2 className="font-semibold text-slate-800">Roster</h2>
           <p className="text-xs text-slate-500">{players.length} active players</p>
         </div>
-        <Link to={teamManagementPath(teamId)} className="text-xs font-semibold text-blue-600">
-          Manage
-        </Link>
+        <div className="flex shrink-0 items-center gap-3">
+          {isPreview && (
+            <Link to={teamRosterPath(teamId)} className="text-xs font-semibold text-blue-600">
+              View roster
+            </Link>
+          )}
+          <Link to={teamManagementPath(teamId)} className="text-xs font-semibold text-blue-600">
+            Manage
+          </Link>
+        </div>
       </div>
 
       {players.length === 0 ? (
@@ -37,23 +39,7 @@ export default function RosterPreviewCard({ teamId, players, limit }: RosterPrev
       ) : (
         <div className="space-y-2">
           {visiblePlayers.map(player => (
-            <Link
-              key={player.id}
-              to={`/player?playerId=${encodeURIComponent(player.id)}&teamId=${encodeURIComponent(teamId)}`}
-              className="flex items-center justify-between gap-3 rounded-xl border border-slate-100 bg-white px-3 py-2 hover:border-blue-200"
-            >
-              <div className="min-w-0">
-                <p className="font-medium text-slate-800 truncate">{playerDisplayName(player)}</p>
-                {player.nickname?.trim() && (
-                  <p className="text-xs text-slate-500 truncate">
-                    {[player.first_name, player.last_name].filter(Boolean).join(' ')}
-                  </p>
-                )}
-              </div>
-              <span className="shrink-0 text-sm font-semibold text-slate-500">
-                #{player.jersey_number || '-'}
-              </span>
-            </Link>
+            <PlayerRow key={player.id} teamId={teamId} player={player} />
           ))}
           {hiddenCount > 0 && (
             <p className="text-xs text-slate-500">+{hiddenCount} more on the active roster</p>

--- a/src/lib/teamInfo.test.ts
+++ b/src/lib/teamInfo.test.ts
@@ -8,6 +8,7 @@ import {
   teamInfoPath,
   teamLeaderboardPath,
   teamManagementPath,
+  teamRosterPath,
   teamStatsPath,
 } from './teamInfo'
 
@@ -138,6 +139,7 @@ describe('splitTeamGames', () => {
 describe('team info paths', () => {
   it('builds query-param team routes', () => {
     expect(teamInfoPath('team 1')).toBe('/team?teamId=team%201')
+    expect(teamRosterPath('team 1')).toBe('/team/roster?teamId=team%201')
     expect(teamLeaderboardPath('team 1', 'season 1')).toBe(
       '/leaderboard?teamId=team+1&seasonId=season+1'
     )

--- a/src/lib/teamInfo.ts
+++ b/src/lib/teamInfo.ts
@@ -79,6 +79,10 @@ export function teamInfoPath(teamId: string): string {
   return `/team?teamId=${encodeURIComponent(teamId)}`
 }
 
+export function teamRosterPath(teamId: string): string {
+  return `/team/roster?teamId=${encodeURIComponent(teamId)}`
+}
+
 export function teamLeaderboardPath(teamId: string, seasonId?: string | null): string {
   const params = new URLSearchParams({ teamId })
   if (seasonId) params.set('seasonId', seasonId)

--- a/src/pages/TeamRoster.tsx
+++ b/src/pages/TeamRoster.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import RosterPreviewCard, {
+  type TeamInfoRosterPlayer,
+} from '../components/team-info/RosterPreviewCard'
+import { sports } from '../config/sports'
+import { useAuth } from '../context/AuthContext'
+import { teamDisplayName } from '../lib/display'
+import { supabase } from '../lib/supabase'
+import { teamInfoPath } from '../lib/teamInfo'
+
+interface TeamRosterTeamRow {
+  id: string
+  name: string
+  nickname: string | null
+  seasons: {
+    id: string
+    name: string
+    sport: string
+  }
+}
+
+export default function TeamRoster() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const teamId = searchParams.get('teamId')
+  const { isConfigured } = useAuth()
+  const supabaseClient = supabase
+
+  const [team, setTeam] = useState<TeamRosterTeamRow | null>(null)
+  const [players, setPlayers] = useState<TeamInfoRosterPlayer[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const sport = useMemo(
+    () => (team ? sports.find(item => item.id === team.seasons.sport) ?? null : null),
+    [team]
+  )
+  const displayName = team ? teamDisplayName(team) : ''
+
+  useEffect(() => {
+    if (!teamId || !isConfigured || !supabaseClient) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      setTeam(null)
+      setPlayers([])
+
+      const [teamRes, rosterRes] = await Promise.all([
+        supabaseClient
+          .from('teams')
+          .select('id,name,nickname,seasons!inner(id,name,sport)')
+          .eq('id', teamId)
+          .single(),
+        supabaseClient
+          .from('team_players')
+          .select('jersey_number,players!inner(id,first_name,last_name,nickname)')
+          .eq('team_id', teamId)
+          .eq('is_active', true)
+          .order('joined_at', { ascending: true }),
+      ])
+
+      if (cancelled) return
+
+      if (teamRes.error || !teamRes.data) {
+        setError(teamRes.error?.message ?? 'Team not found')
+        setLoading(false)
+        return
+      }
+      if (rosterRes.error) {
+        setError(rosterRes.error.message)
+        setLoading(false)
+        return
+      }
+
+      type TeamPlayerJoin = {
+        jersey_number: string | null
+        players: {
+          id: string
+          first_name: string
+          last_name: string | null
+          nickname: string | null
+        }
+      }
+
+      setTeam(teamRes.data as unknown as TeamRosterTeamRow)
+      setPlayers(((rosterRes.data ?? []) as unknown as TeamPlayerJoin[]).map(row => ({
+        id: row.players.id,
+        first_name: row.players.first_name,
+        last_name: row.players.last_name,
+        nickname: row.players.nickname,
+        jersey_number: row.jersey_number,
+      })))
+      setLoading(false)
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [teamId, isConfigured, supabaseClient])
+
+  if (!isConfigured) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Supabase not configured</p>
+          <p className="text-sm text-slate-500 mb-4">
+            Configure Supabase credentials to view cloud team rosters.
+          </p>
+          <button type="button" onClick={() => navigate('/admin')} className="btn-primary w-full">
+            Back to Settings
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!teamId) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Missing team</p>
+          <p className="text-sm text-slate-500 mb-4">Choose a team before opening the roster.</p>
+          <button type="button" onClick={() => navigate('/teams')} className="btn-primary w-full">
+            Teams
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-3xl mx-auto px-4 py-5 space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <Link to={teamInfoPath(teamId)} className="text-sm font-semibold text-blue-600">
+            Back to Team
+          </Link>
+          {loading && <span className="text-xs text-slate-400 animate-pulse">Loading...</span>}
+        </div>
+
+        {error ? (
+          <section className="card text-center space-y-3">
+            <p className="font-semibold text-slate-700">Team roster unavailable</p>
+            <p className="text-sm text-slate-500">{error}</p>
+            <button type="button" onClick={() => navigate('/teams')} className="btn-primary w-full">
+              Teams
+            </button>
+          </section>
+        ) : team && !loading ? (
+          <>
+            <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <p className="text-sm font-semibold text-slate-500">
+                {sport?.icon ? `${sport.icon} ` : ''}
+                {sport?.name ?? team.seasons.sport} / {team.seasons.name}
+              </p>
+              <h1 className="mt-1 text-2xl font-bold text-slate-900 break-words">
+                {displayName}
+              </h1>
+              {team.name !== displayName && (
+                <p className="mt-1 text-sm text-slate-500 break-words">{team.name}</p>
+              )}
+              <div className="mt-4 rounded-lg bg-slate-50 px-3 py-2">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                  Active roster
+                </p>
+                <p className="text-lg font-bold text-slate-800">{players.length}</p>
+              </div>
+            </section>
+
+            <RosterPreviewCard teamId={team.id} players={players} />
+          </>
+        ) : loading ? (
+          <section className="card">
+            <p className="text-sm text-slate-500 animate-pulse">Loading Team Roster...</p>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Summary: Adds a read-only /team/roster?teamId= route, extracts shared PlayerRow rendering for embedded/full roster views, links the Team Info roster preview to the new page, and updates regression coverage for Team Roster navigation. Verification: pnpm.cmd test -- src/lib/teamInfo.test.ts; pnpm.cmd lint (existing Fast Refresh warnings only); pnpm.cmd build; git diff --cached --check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only navigation and UI reuse; no roster mutations or auth changes beyond existing Supabase reads.
> 
> **Overview**
> Adds a **read-only Team Roster** page at `/team/roster?teamId=` so users can open the full active roster without going through Teams management.
> 
> The new `TeamRoster` page loads team + active `team_players` from Supabase, shows a header with **Back to Team**, and reuses `RosterPreviewCard` without a preview limit (full list). Routing is wired in `App.tsx`; `teamRosterPath` centralizes the URL and is covered in `teamInfo.test.ts`.
> 
> **Roster UI** is refactored: player rows move into `PlayerRow` (display name, jersey, link to Player Profile). On Team Info **Overview**, when `RosterPreviewCard` is in preview mode (`limit` set), a **View roster** link appears next to **Manage** and navigates to the new page.
> 
> `docs/REGRESSION_TESTING.md` adds steps **4.14–4.15** for View roster → full page → Back to Team (schedule step renumbered to **4.16**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7abeabf792fef9e0e0d9804b4970cba91fd4aa89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->