### PR TITLE
Add Team schedule drilldown

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -73,7 +73,10 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.13 | Team Info → Roster | Shows the full active roster and read-only member list; player rows link to existing Player Profile |
 | 4.14 | Team Info → Overview roster preview → View roster | Opens `/team/roster?teamId=<id>`; shows the same active roster as a read-only Team Roster page |
 | 4.15 | Team Roster → Back to Team | Returns to `/team?teamId=<id>` |
-| 4.16 | Team Info → Schedule | Shows upcoming/live games, recent finalized results, and tournament links; Cloud Games remains the management/resume backstop |
+| 4.16 | Team Info → Schedule | Shows upcoming/live games, recent finalized results, and tournament links; game rows open Game Info |
+| 4.17 | Team Info → Schedule preview → View schedule | Opens `/team/schedule?teamId=<id>`; groups games into live, upcoming, and finals with final scores/results |
+| 4.18 | Team Schedule → tap a scheduled/live/final game | Opens `/game-info?gameId=<id>&teamId=<id>`; shows game details, status/score, and stat leaders when resolved stats exist |
+| 4.19 | Game Info → View full summary on a finalized game | Hydrates the cloud game through the existing flow and opens `/summary`; pending local sync still blocks hydration |
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import Admin from './pages/Admin'
 import Teams from './pages/Teams'
 import TeamInfo from './pages/TeamInfo'
 import TeamRoster from './pages/TeamRoster'
+import TeamSchedule from './pages/TeamSchedule'
+import GameInfo from './pages/GameInfo'
 import Games from './pages/Games'
 import Leaderboard from './pages/Leaderboard'
 import PlayerProfile from './pages/PlayerProfile'
@@ -63,6 +65,8 @@ function AppRoutes() {
           <Route path="/teams" element={<Teams />} />
           <Route path="/team" element={<TeamInfo />} />
           <Route path="/team/roster" element={<TeamRoster />} />
+          <Route path="/team/schedule" element={<TeamSchedule />} />
+          <Route path="/game-info" element={<GameInfo />} />
           <Route path="/games" element={<Games />} />
           <Route path="/leaderboard" element={<Leaderboard />} />
           <Route path="/player" element={<PlayerProfile />} />

--- a/src/components/team-info/GameCard.tsx
+++ b/src/components/team-info/GameCard.tsx
@@ -1,0 +1,60 @@
+import { Link } from 'react-router-dom'
+import { gameInfoPath, type TeamGameResult } from '../../lib/teamInfo'
+import ResultBadge from './ResultBadge'
+
+export interface TeamInfoGameCardGame {
+  id: string
+  team_id?: string
+  game_date: string
+  opponent_name: string
+  status: string
+  tournament_name: string | null
+  scoreLine?: string | null
+  result?: TeamGameResult | null
+}
+
+interface GameCardProps {
+  game: TeamInfoGameCardGame
+  teamId?: string
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case 'final':
+      return 'Final'
+    case 'in_progress':
+      return 'Live'
+    case 'scheduled':
+      return 'Scheduled'
+    default:
+      return status
+  }
+}
+
+export default function GameCard({ game, teamId }: GameCardProps) {
+  const resolvedTeamId = teamId ?? game.team_id ?? null
+
+  return (
+    <Link
+      to={gameInfoPath(game.id, resolvedTeamId)}
+      className="block rounded-lg border border-slate-100 bg-white px-3 py-2 hover:border-blue-200"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="font-medium text-slate-800 truncate">vs {game.opponent_name}</p>
+          <p className="text-xs text-slate-500">{game.game_date}</p>
+        </div>
+        {game.status === 'final' ? (
+          <ResultBadge result={game.result ?? null} scoreLine={game.scoreLine ?? null} />
+        ) : (
+          <span className="shrink-0 rounded-lg bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-700">
+            {statusLabel(game.status)}
+          </span>
+        )}
+      </div>
+      {game.tournament_name && (
+        <p className="mt-1 text-xs text-slate-500 truncate">{game.tournament_name}</p>
+      )}
+    </Link>
+  )
+}

--- a/src/components/team-info/RecentResultsCard.tsx
+++ b/src/components/team-info/RecentResultsCard.tsx
@@ -1,5 +1,5 @@
-import ResultBadge from './ResultBadge'
 import type { TeamGameResult } from '../../lib/teamInfo'
+import GameCard from './GameCard'
 
 export interface TeamInfoResultGame {
   id: string
@@ -12,9 +12,10 @@ export interface TeamInfoResultGame {
 
 interface RecentResultsCardProps {
   games: TeamInfoResultGame[]
+  teamId?: string
 }
 
-export default function RecentResultsCard({ games }: RecentResultsCardProps) {
+export default function RecentResultsCard({ games, teamId }: RecentResultsCardProps) {
   return (
     <section className="card space-y-3">
       <div>
@@ -27,18 +28,7 @@ export default function RecentResultsCard({ games }: RecentResultsCardProps) {
       ) : (
         <div className="space-y-2">
           {games.map(game => (
-            <div key={game.id} className="rounded-xl border border-slate-100 bg-white px-3 py-2">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="font-medium text-slate-800 truncate">vs {game.opponent_name}</p>
-                  <p className="text-xs text-slate-500">{game.game_date}</p>
-                </div>
-                <ResultBadge result={game.result} scoreLine={game.scoreLine} />
-              </div>
-              {game.tournament_name && (
-                <p className="mt-1 text-xs text-slate-500 truncate">{game.tournament_name}</p>
-              )}
-            </div>
+            <GameCard key={game.id} game={{ ...game, status: 'final' }} teamId={teamId} />
           ))}
         </div>
       )}

--- a/src/components/team-info/SchedulePreviewCard.tsx
+++ b/src/components/team-info/SchedulePreviewCard.tsx
@@ -1,33 +1,21 @@
 import { Link } from 'react-router-dom'
+import { teamSchedulePath } from '../../lib/teamInfo'
+import GameCard, { type TeamInfoGameCardGame } from './GameCard'
 
-export interface TeamInfoScheduleGame {
-  id: string
-  game_date: string
-  opponent_name: string
-  status: string
-  tournament_name: string | null
+export type TeamInfoScheduleGame = TeamInfoGameCardGame & {
   tournament_id: string | null
 }
 
 interface SchedulePreviewCardProps {
   games: TeamInfoScheduleGame[]
+  teamId?: string
   title?: string
   emptyText?: string
 }
 
-function statusLabel(status: string): string {
-  switch (status) {
-    case 'in_progress':
-      return 'Live'
-    case 'scheduled':
-      return 'Scheduled'
-    default:
-      return status
-  }
-}
-
 export default function SchedulePreviewCard({
   games,
+  teamId,
   title = 'Schedule',
   emptyText = 'No upcoming games.',
 }: SchedulePreviewCardProps) {
@@ -38,8 +26,11 @@ export default function SchedulePreviewCard({
           <h2 className="font-semibold text-slate-800">{title}</h2>
           <p className="text-xs text-slate-500">{games.length} games ahead</p>
         </div>
-        <Link to="/games" className="text-xs font-semibold text-blue-600">
-          Cloud Games
+        <Link
+          to={teamId ? teamSchedulePath(teamId) : '/games'}
+          className="text-xs font-semibold text-blue-600"
+        >
+          {teamId ? 'View schedule' : 'Cloud Games'}
         </Link>
       </div>
 
@@ -48,20 +39,7 @@ export default function SchedulePreviewCard({
       ) : (
         <div className="space-y-2">
           {games.map(game => (
-            <div key={game.id} className="rounded-xl border border-slate-100 bg-white px-3 py-2">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="font-medium text-slate-800 truncate">vs {game.opponent_name}</p>
-                  <p className="text-xs text-slate-500">{game.game_date}</p>
-                </div>
-                <span className="shrink-0 rounded-lg bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-700">
-                  {statusLabel(game.status)}
-                </span>
-              </div>
-              {game.tournament_name && (
-                <p className="mt-1 text-xs text-slate-500 truncate">{game.tournament_name}</p>
-              )}
-            </div>
+            <GameCard key={game.id} game={game} teamId={teamId} />
           ))}
         </div>
       )}

--- a/src/components/team-info/TeamOverviewCards.tsx
+++ b/src/components/team-info/TeamOverviewCards.tsx
@@ -37,9 +37,9 @@ export default function TeamOverviewCards({
       />
       <div className="grid gap-4 lg:grid-cols-2">
         <RosterPreviewCard teamId={teamId} players={roster} limit={5} />
-        <SchedulePreviewCard games={upcomingGames.slice(0, 3)} />
+        <SchedulePreviewCard teamId={teamId} games={upcomingGames.slice(0, 3)} />
       </div>
-      <RecentResultsCard games={recentResults.slice(0, 3)} />
+      <RecentResultsCard teamId={teamId} games={recentResults.slice(0, 3)} />
       <div className="grid gap-4 lg:grid-cols-2">
         <TournamentCard teamId={teamId} tournaments={tournaments} error={tournamentError} />
         <TeamMembersCard members={members} error={membersError} limit={5} />

--- a/src/lib/teamInfo.test.ts
+++ b/src/lib/teamInfo.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { sports } from '../config/sports'
 import {
   computeTeamRecord,
+  gameInfoPath,
   resolveTeamInfoHomeScore,
   splitTeamGames,
   teamGameResult,
@@ -9,6 +10,7 @@ import {
   teamLeaderboardPath,
   teamManagementPath,
   teamRosterPath,
+  teamSchedulePath,
   teamStatsPath,
 } from './teamInfo'
 
@@ -140,6 +142,8 @@ describe('team info paths', () => {
   it('builds query-param team routes', () => {
     expect(teamInfoPath('team 1')).toBe('/team?teamId=team%201')
     expect(teamRosterPath('team 1')).toBe('/team/roster?teamId=team%201')
+    expect(teamSchedulePath('team 1')).toBe('/team/schedule?teamId=team%201')
+    expect(gameInfoPath('game 1', 'team 1')).toBe('/game-info?gameId=game+1&teamId=team+1')
     expect(teamLeaderboardPath('team 1', 'season 1')).toBe(
       '/leaderboard?teamId=team+1&seasonId=season+1'
     )

--- a/src/lib/teamInfo.ts
+++ b/src/lib/teamInfo.ts
@@ -83,6 +83,16 @@ export function teamRosterPath(teamId: string): string {
   return `/team/roster?teamId=${encodeURIComponent(teamId)}`
 }
 
+export function teamSchedulePath(teamId: string): string {
+  return `/team/schedule?teamId=${encodeURIComponent(teamId)}`
+}
+
+export function gameInfoPath(gameId: string, teamId?: string | null): string {
+  const params = new URLSearchParams({ gameId })
+  if (teamId) params.set('teamId', teamId)
+  return `/game-info?${params.toString()}`
+}
+
 export function teamLeaderboardPath(teamId: string, seasonId?: string | null): string {
   const params = new URLSearchParams({ teamId })
   if (seasonId) params.set('seasonId', seasonId)

--- a/src/pages/GameInfo.tsx
+++ b/src/pages/GameInfo.tsx
@@ -1,0 +1,497 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import ResultBadge from '../components/team-info/ResultBadge'
+import { computePlayerScore, sports } from '../config/sports'
+import { useAuth } from '../context/AuthContext'
+import { useGame } from '../context/GameContext'
+import { loadCloudGameById, touchCloudGameLastOpened } from '../lib/cloudSync'
+import { teamDisplayName, playerDisplayName } from '../lib/display'
+import {
+  currentPeriodForCloudHydrate,
+  shouldBlockManualCloudHydrate,
+  withLastSyncedGameFingerprint,
+} from '../lib/gameSyncFingerprint'
+import { getPendingSyncFlag } from '../lib/gameStorageKeys'
+import { supabase } from '../lib/supabase'
+import {
+  resolveTeamInfoHomeScore,
+  teamGameResult,
+  teamInfoPath,
+  type TeamInfoGame,
+} from '../lib/teamInfo'
+import type { GameState, SportConfig, StatAction } from '../types'
+
+interface GameInfoGameRow extends TeamInfoGame {
+  id: string
+  team_id: string
+  game_date: string
+  opponent_name: string
+  tournament_name: string | null
+  tournament_id: string | null
+  notes: string | null
+}
+
+interface GameInfoTeamRow {
+  id: string
+  name: string
+  nickname: string | null
+  season_id: string
+  seasons: {
+    id: string
+    name: string
+    sport: string
+  }
+}
+
+interface GameInfoRosterPlayer {
+  id: string
+  first_name: string
+  last_name: string | null
+  nickname: string | null
+}
+
+interface GameStatRow {
+  player_id: string
+  stat_id: string
+  value: number
+}
+
+interface StatLeader {
+  key: string
+  label: string
+  playerName: string
+  value: number
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case 'final':
+      return 'Final'
+    case 'in_progress':
+      return 'Live'
+    case 'scheduled':
+      return 'Scheduled'
+    default:
+      return status
+  }
+}
+
+function findAction(sport: SportConfig, statId: string): StatAction | null {
+  for (const category of sport.categories) {
+    const action = category.actions.find(item => item.id === statId)
+    if (action) return action
+  }
+  return null
+}
+
+function buildStatLeaders(
+  sport: SportConfig,
+  roster: GameInfoRosterPlayer[],
+  rows: GameStatRow[]
+): StatLeader[] {
+  const playerNames = new Map(roster.map(player => [player.id, playerDisplayName(player)]))
+  const statsByPlayer = new Map<string, Record<string, number>>()
+
+  for (const row of rows) {
+    if (!playerNames.has(row.player_id)) continue
+    const stats = statsByPlayer.get(row.player_id) ?? {}
+    stats[row.stat_id] = (stats[row.stat_id] ?? 0) + Number(row.value)
+    statsByPlayer.set(row.player_id, stats)
+  }
+
+  const leaders: StatLeader[] = []
+  let topScore: StatLeader | null = null
+  for (const [playerId, stats] of statsByPlayer) {
+    const value = computePlayerScore(sport, stats)
+    if (value <= 0) continue
+    if (!topScore || value > topScore.value) {
+      topScore = {
+        key: 'score',
+        label: sport.scoreLabel,
+        playerName: playerNames.get(playerId) ?? 'Unknown player',
+        value,
+      }
+    }
+  }
+  if (topScore) leaders.push(topScore)
+
+  const statIds = sport.keyStatIds ?? []
+  for (const statId of statIds) {
+    const action = findAction(sport, statId)
+    if (action?.pointValue) continue
+
+    let top: StatLeader | null = null
+    for (const [playerId, stats] of statsByPlayer) {
+      const value = stats[statId] ?? 0
+      if (value <= 0) continue
+      if (!top || value > top.value) {
+        top = {
+          key: statId,
+          label: action?.shortLabel ?? statId,
+          playerName: playerNames.get(playerId) ?? 'Unknown player',
+          value,
+        }
+      }
+    }
+    if (top) leaders.push(top)
+  }
+
+  return leaders.slice(0, 6)
+}
+
+export default function GameInfo() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const gameId = searchParams.get('gameId')
+  const fallbackTeamId = searchParams.get('teamId')
+  const { user, isConfigured } = useAuth()
+  const { state, dispatch } = useGame()
+  const supabaseClient = supabase
+
+  const [game, setGame] = useState<GameInfoGameRow | null>(null)
+  const [team, setTeam] = useState<GameInfoTeamRow | null>(null)
+  const [leaders, setLeaders] = useState<StatLeader[]>([])
+  const [statTotals, setStatTotals] = useState<Record<string, number>>({})
+  const [statsError, setStatsError] = useState<string | null>(null)
+  const [openingGame, setOpeningGame] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const sport = useMemo(
+    () => (team ? sports.find(item => item.id === team.seasons.sport) ?? null : null),
+    [team]
+  )
+
+  const score = useMemo(() => {
+    if (!game) return { scoreLine: null, result: null }
+    const homeScore = resolveTeamInfoHomeScore(sport, game, {
+      [game.id]: statTotals,
+    })
+    const scoreLine =
+      homeScore != null && game.opponent_score != null
+        ? `${homeScore}-${game.opponent_score}`
+        : null
+    const result =
+      game.status === 'final' && homeScore != null && game.opponent_score != null
+        ? teamGameResult(homeScore, game.opponent_score)
+        : null
+    return { scoreLine, result }
+  }, [game, sport, statTotals])
+
+  useEffect(() => {
+    if (!gameId || !isConfigured || !supabaseClient) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      setStatsError(null)
+      setGame(null)
+      setTeam(null)
+      setLeaders([])
+      setStatTotals({})
+
+      const { data: gameData, error: gameError } = await supabaseClient
+        .from('games')
+        .select(
+          'id,team_id,game_date,opponent_name,opponent_score,home_team_score,home_score_adjustment,status,tournament_name,tournament_id,notes'
+        )
+        .eq('id', gameId)
+        .single()
+
+      if (cancelled) return
+
+      if (gameError || !gameData) {
+        setError(gameError?.message ?? 'Game not found')
+        setLoading(false)
+        return
+      }
+
+      const loadedGame = gameData as GameInfoGameRow
+      const [teamRes, rosterRes, statsRes] = await Promise.all([
+        supabaseClient
+          .from('teams')
+          .select('id,name,nickname,season_id,seasons!inner(id,name,sport)')
+          .eq('id', loadedGame.team_id)
+          .single(),
+        supabaseClient
+          .from('team_players')
+          .select('players!inner(id,first_name,last_name,nickname)')
+          .eq('team_id', loadedGame.team_id)
+          .eq('is_active', true),
+        supabaseClient.rpc('get_game_stats_resolved', {
+          p_game_id: loadedGame.id,
+        }),
+      ])
+
+      if (cancelled) return
+
+      if (teamRes.error || !teamRes.data) {
+        setError(teamRes.error?.message ?? 'Team not found')
+        setLoading(false)
+        return
+      }
+      if (rosterRes.error) {
+        setError(rosterRes.error.message)
+        setLoading(false)
+        return
+      }
+
+      const loadedTeam = teamRes.data as unknown as GameInfoTeamRow
+      const loadedSport = sports.find(item => item.id === loadedTeam.seasons.sport) ?? null
+      type TeamPlayerJoin = {
+        players: GameInfoRosterPlayer
+      }
+      const roster = ((rosterRes.data ?? []) as unknown as TeamPlayerJoin[]).map(row => row.players)
+      const statRows = ((statsRes.data ?? []) as GameStatRow[]).map(row => ({
+        ...row,
+        value: Number(row.value),
+      }))
+      const nextStatTotals: Record<string, number> = {}
+      for (const row of statRows) {
+        nextStatTotals[row.stat_id] = (nextStatTotals[row.stat_id] ?? 0) + row.value
+      }
+
+      setGame(loadedGame)
+      setTeam(loadedTeam)
+      setStatTotals(nextStatTotals)
+      if (statsRes.error) {
+        setStatsError(statsRes.error.message)
+      } else if (loadedSport) {
+        setLeaders(buildStatLeaders(loadedSport, roster, statRows))
+      }
+      setLoading(false)
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [gameId, isConfigured, supabaseClient])
+
+  const openFullGame = async () => {
+    if (!game || !user) return
+    if (shouldBlockManualCloudHydrate(state, getPendingSyncFlag())) {
+      setError('Finish syncing your current game before opening another.')
+      return
+    }
+
+    setOpeningGame(true)
+    setError(null)
+
+    const cloudGame = await loadCloudGameById(user.id, game.id).catch(err => {
+      setError(err instanceof Error ? err.message : 'Could not load game')
+      setOpeningGame(false)
+      return null
+    })
+
+    if (!cloudGame) {
+      setOpeningGame(false)
+      return
+    }
+
+    await touchCloudGameLastOpened(cloudGame.gameId).catch(() => {})
+
+    const loadedSport = sports.find(item => item.id === cloudGame.sportId)
+    if (!loadedSport) {
+      setError(`Unsupported sport: ${cloudGame.sportId}`)
+      setOpeningGame(false)
+      return
+    }
+
+    const nextState: GameState = {
+      sport: loadedSport,
+      gameInfo: cloudGame.gameInfo,
+      players: cloudGame.players,
+      activePlayerId: cloudGame.activePlayerId,
+      opponentScore: cloudGame.opponentScore,
+      homeTeamScore: cloudGame.homeTeamScore,
+      homeScoreAdjustment: cloudGame.homeScoreAdjustment,
+      notes: cloudGame.notes,
+      currentPeriod: currentPeriodForCloudHydrate(state, cloudGame.gameId),
+      teamStatsConfig: cloudGame.teamStatsConfig ?? null,
+      actionLog: [],
+      shotChart: cloudGame.shotChart ?? [],
+      cloudSync: {
+        seasonId: cloudGame.seasonId ?? null,
+        teamId: cloudGame.teamId,
+        gameId: cloudGame.gameId,
+        gameStatus: cloudGame.status,
+        playerIdMap: cloudGame.playerIdMap,
+        status: 'synced',
+        lastSyncedAt: cloudGame.hydratedAt,
+        lastError: null,
+        shotChartHydrationDroppedRows: cloudGame.shotChartHydrationDroppedRows ?? 0,
+        lastSyncedGameFingerprint: null,
+      },
+    }
+
+    dispatch({ type: 'HYDRATE_STATE', state: withLastSyncedGameFingerprint(nextState) })
+    setOpeningGame(false)
+    navigate(cloudGame.status === 'final' ? '/summary' : '/game')
+  }
+
+  if (!isConfigured) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Supabase not configured</p>
+          <p className="text-sm text-slate-500 mb-4">
+            Configure Supabase credentials to view cloud game info.
+          </p>
+          <button type="button" onClick={() => navigate('/admin')} className="btn-primary w-full">
+            Back to Settings
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!gameId) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Missing game</p>
+          <p className="text-sm text-slate-500 mb-4">Choose a game before opening Game Info.</p>
+          <button type="button" onClick={() => navigate('/games')} className="btn-primary w-full">
+            Cloud Games
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const backTeamId = game?.team_id ?? fallbackTeamId
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-3xl mx-auto px-4 py-5 space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          {backTeamId ? (
+            <Link to={teamInfoPath(backTeamId)} className="text-sm font-semibold text-blue-600">
+              Back to Team
+            </Link>
+          ) : (
+            <button
+              type="button"
+              onClick={() => navigate('/games')}
+              className="text-sm font-semibold text-blue-600"
+            >
+              Cloud Games
+            </button>
+          )}
+          {loading && <span className="text-xs text-slate-400 animate-pulse">Loading...</span>}
+        </div>
+
+        {error && (!game || loading) ? (
+          <section className="card text-center space-y-3">
+            <p className="font-semibold text-slate-700">Game Info unavailable</p>
+            <p className="text-sm text-slate-500">{error}</p>
+          </section>
+        ) : game && team && !loading ? (
+          <>
+            <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <p className="text-sm font-semibold text-slate-500">
+                {sport?.icon ? `${sport.icon} ` : ''}
+                {sport?.name ?? team.seasons.sport} / {team.seasons.name}
+              </p>
+              <h1 className="mt-1 text-2xl font-bold text-slate-900 break-words">
+                {teamDisplayName(team)} vs {game.opponent_name}
+              </h1>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {game.status === 'final' ? (
+                  <ResultBadge result={score.result} scoreLine={score.scoreLine} />
+                ) : (
+                  <span className="rounded-lg bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-700">
+                    {statusLabel(game.status)}
+                  </span>
+                )}
+                <span className="text-sm text-slate-500">{game.game_date}</span>
+              </div>
+            </section>
+
+            <section className="card space-y-3">
+              <div>
+                <h2 className="font-semibold text-slate-800">Game Details</h2>
+                <p className="text-xs text-slate-500">{statusLabel(game.status)}</p>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <div className="rounded-lg bg-slate-50 px-3 py-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                    Team
+                  </p>
+                  <p className="font-semibold text-slate-800">{teamDisplayName(team)}</p>
+                </div>
+                <div className="rounded-lg bg-slate-50 px-3 py-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                    Opponent
+                  </p>
+                  <p className="font-semibold text-slate-800">{game.opponent_name}</p>
+                </div>
+              </div>
+              {game.tournament_name && (
+                <p className="text-sm text-slate-600">{game.tournament_name}</p>
+              )}
+              {game.notes?.trim() && <p className="text-sm text-slate-600">{game.notes}</p>}
+            </section>
+
+            <section className="card space-y-3">
+              <div>
+                <h2 className="font-semibold text-slate-800">Stat Leaders</h2>
+                <p className="text-xs text-slate-500">Resolved game stats</p>
+              </div>
+              {statsError ? (
+                <p className="text-sm text-slate-500">{statsError}</p>
+              ) : leaders.length === 0 ? (
+                <p className="text-sm text-slate-500">No stat leaders yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {leaders.map(leader => (
+                    <div
+                      key={leader.key}
+                      className="flex items-center justify-between gap-3 rounded-lg bg-slate-50 px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <p className="font-medium text-slate-800 truncate">
+                          {leader.playerName}
+                        </p>
+                        <p className="text-xs text-slate-500">{leader.label}</p>
+                      </div>
+                      <p className="text-lg font-bold text-slate-800">{leader.value}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            {error && (
+              <section className="rounded-lg border border-rose-100 bg-rose-50 px-3 py-2">
+                <p className="text-sm font-medium text-rose-700">{error}</p>
+              </section>
+            )}
+
+            <button
+              type="button"
+              onClick={openFullGame}
+              disabled={openingGame}
+              className="btn-primary w-full disabled:opacity-60"
+            >
+              {openingGame
+                ? 'Opening...'
+                : game.status === 'final'
+                  ? 'View full summary'
+                  : 'Open game'}
+            </button>
+          </>
+        ) : loading ? (
+          <section className="card">
+            <p className="text-sm text-slate-500 animate-pulse">Loading Game Info...</p>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/TeamInfo.tsx
+++ b/src/pages/TeamInfo.tsx
@@ -339,8 +339,8 @@ export default function TeamInfo() {
 
             {activeSegment === 'schedule' && (
               <div className="space-y-4">
-                <SchedulePreviewCard games={upcomingPreviewGames} />
-                <RecentResultsCard games={recentResults} />
+                <SchedulePreviewCard teamId={team.id} games={upcomingPreviewGames} />
+                <RecentResultsCard teamId={team.id} games={recentResults} />
                 <TournamentCard
                   teamId={team.id}
                   tournaments={tournaments}

--- a/src/pages/TeamSchedule.tsx
+++ b/src/pages/TeamSchedule.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import GameCard, { type TeamInfoGameCardGame } from '../components/team-info/GameCard'
+import { sports } from '../config/sports'
+import { useAuth } from '../context/AuthContext'
+import { teamDisplayName } from '../lib/display'
+import { supabase } from '../lib/supabase'
+import {
+  resolveTeamInfoHomeScore,
+  splitTeamGames,
+  teamGameResult,
+  teamInfoPath,
+  type TeamInfoGame,
+} from '../lib/teamInfo'
+
+interface TeamScheduleTeamRow {
+  id: string
+  name: string
+  nickname: string | null
+  season_id: string
+  seasons: {
+    id: string
+    name: string
+    sport: string
+  }
+}
+
+interface TeamScheduleGameRow extends TeamInfoGame {
+  team_id: string
+  game_date: string
+  opponent_name: string
+  tournament_name: string | null
+  tournament_id: string | null
+}
+
+export default function TeamSchedule() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const teamId = searchParams.get('teamId')
+  const { isConfigured } = useAuth()
+  const supabaseClient = supabase
+
+  const [team, setTeam] = useState<TeamScheduleTeamRow | null>(null)
+  const [games, setGames] = useState<TeamScheduleGameRow[]>([])
+  const [statsTotalsByGameId, setStatsTotalsByGameId] = useState<
+    Record<string, Record<string, number>>
+  >({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const sport = useMemo(
+    () => (team ? sports.find(item => item.id === team.seasons.sport) ?? null : null),
+    [team]
+  )
+
+  const gamesWithScores = useMemo<TeamInfoGameCardGame[]>(
+    () =>
+      games.map(game => {
+        const homeScore = resolveTeamInfoHomeScore(sport, game, statsTotalsByGameId)
+        const scoreLine =
+          homeScore != null && game.opponent_score != null
+            ? `${homeScore}-${game.opponent_score}`
+            : null
+        const result =
+          game.status === 'final' && homeScore != null && game.opponent_score != null
+            ? teamGameResult(homeScore, game.opponent_score)
+            : null
+        return { ...game, scoreLine, result }
+      }),
+    [games, sport, statsTotalsByGameId]
+  )
+
+  const gameGroups = useMemo(() => {
+    const groups = splitTeamGames(gamesWithScores)
+    return {
+      inProgress: groups.inProgress.sort((a, b) => b.game_date.localeCompare(a.game_date)),
+      upcoming: groups.upcoming.sort((a, b) => a.game_date.localeCompare(b.game_date)),
+      completed: groups.completed.sort((a, b) => b.game_date.localeCompare(a.game_date)),
+    }
+  }, [gamesWithScores])
+
+  useEffect(() => {
+    if (!teamId || !isConfigured || !supabaseClient) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      setTeam(null)
+      setGames([])
+      setStatsTotalsByGameId({})
+
+      const [teamRes, gamesRes] = await Promise.all([
+        supabaseClient
+          .from('teams')
+          .select('id,name,nickname,season_id,seasons!inner(id,name,sport)')
+          .eq('id', teamId)
+          .single(),
+        supabaseClient
+          .from('games')
+          .select(
+            'id,team_id,game_date,opponent_name,opponent_score,home_team_score,home_score_adjustment,status,tournament_name,tournament_id'
+          )
+          .eq('team_id', teamId)
+          .order('game_date', { ascending: false }),
+      ])
+
+      if (cancelled) return
+
+      if (teamRes.error || !teamRes.data) {
+        setError(teamRes.error?.message ?? 'Team not found')
+        setLoading(false)
+        return
+      }
+      if (gamesRes.error) {
+        setError(gamesRes.error.message)
+        setLoading(false)
+        return
+      }
+
+      const loadedGames = (gamesRes.data ?? []) as TeamScheduleGameRow[]
+      setTeam(teamRes.data as unknown as TeamScheduleTeamRow)
+      setGames(loadedGames)
+
+      const legacyFinals = loadedGames.filter(
+        game => game.status === 'final' && game.home_team_score == null
+      )
+      if (legacyFinals.length > 0) {
+        const totals: Record<string, Record<string, number>> = {}
+        await Promise.all(
+          legacyFinals.map(async game => {
+            const { data, error: statsError } = await supabaseClient.rpc('get_game_stats_resolved', {
+              p_game_id: game.id,
+            })
+            if (statsError) return
+            totals[game.id] = {}
+            for (const row of (data ?? []) as { stat_id: string; value: number }[]) {
+              totals[game.id][row.stat_id] =
+                (totals[game.id][row.stat_id] ?? 0) + Number(row.value)
+            }
+          })
+        )
+        if (!cancelled) setStatsTotalsByGameId(totals)
+      }
+
+      if (!cancelled) setLoading(false)
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [teamId, isConfigured, supabaseClient])
+
+  const renderGameSection = (
+    title: string,
+    sectionGames: TeamInfoGameCardGame[],
+    emptyText: string
+  ) => (
+    <section className="card space-y-3">
+      <div>
+        <h2 className="font-semibold text-slate-800">{title}</h2>
+        <p className="text-xs text-slate-500">{sectionGames.length} games</p>
+      </div>
+      {sectionGames.length === 0 ? (
+        <p className="text-sm text-slate-500">{emptyText}</p>
+      ) : (
+        <div className="space-y-2">
+          {sectionGames.map(game => (
+            <GameCard key={game.id} game={game} teamId={teamId ?? undefined} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+
+  if (!isConfigured) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Supabase not configured</p>
+          <p className="text-sm text-slate-500 mb-4">
+            Configure Supabase credentials to view cloud schedules.
+          </p>
+          <button type="button" onClick={() => navigate('/admin')} className="btn-primary w-full">
+            Back to Settings
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!teamId) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4">
+        <div className="card max-w-md w-full text-center">
+          <p className="font-semibold text-slate-700 mb-2">Missing team</p>
+          <p className="text-sm text-slate-500 mb-4">Choose a team before opening Schedule.</p>
+          <button type="button" onClick={() => navigate('/teams')} className="btn-primary w-full">
+            Teams
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-3xl mx-auto px-4 py-5 space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <Link to={teamInfoPath(teamId)} className="text-sm font-semibold text-blue-600">
+            Back to Team
+          </Link>
+          {loading && <span className="text-xs text-slate-400 animate-pulse">Loading...</span>}
+        </div>
+
+        {error ? (
+          <section className="card text-center space-y-3">
+            <p className="font-semibold text-slate-700">Schedule unavailable</p>
+            <p className="text-sm text-slate-500">{error}</p>
+            <button type="button" onClick={() => navigate('/teams')} className="btn-primary w-full">
+              Teams
+            </button>
+          </section>
+        ) : team && !loading ? (
+          <>
+            <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <p className="text-sm font-semibold text-slate-500">
+                {sport?.icon ? `${sport.icon} ` : ''}
+                {sport?.name ?? team.seasons.sport} / {team.seasons.name}
+              </p>
+              <h1 className="mt-1 text-2xl font-bold text-slate-900 break-words">
+                {teamDisplayName(team)}
+              </h1>
+              <div className="mt-4 rounded-lg bg-slate-50 px-3 py-2">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                  Total games
+                </p>
+                <p className="text-lg font-bold text-slate-800">{games.length}</p>
+              </div>
+            </section>
+
+            {renderGameSection('Live', gameGroups.inProgress, 'No live games right now.')}
+            {renderGameSection('Upcoming', gameGroups.upcoming, 'No upcoming games.')}
+            {renderGameSection('Finals', gameGroups.completed, 'No finalized games yet.')}
+          </>
+        ) : loading ? (
+          <section className="card">
+            <p className="text-sm text-slate-500 animate-pulse">Loading Schedule...</p>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Summary: Adds /team/schedule?teamId= for grouped team games, adds /game-info?gameId=&teamId= with game details and resolved stat leaders, refactors Team Info schedule/result rows through a shared GameCard, and keeps full-game hydration on the existing protected cloud flow. Verification: pnpm.cmd test -- src/lib/teamInfo.test.ts; pnpm.cmd lint (existing Fast Refresh warnings only); pnpm.cmd build; git diff --cached --check.