### PR TITLE
Add Team player info route

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -70,13 +70,15 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.10 | Teams → tap **Manage** on a team card | Stays on `/teams`; roster/member management switches to that team |
 | 4.11 | Team Info → switch **Overview / Roster / Schedule** segments | Segment content changes in place; URL stays `/team?teamId=<id>`; no management actions move off `/teams` |
 | 4.12 | Team Info → Overview | Shows stat links, roster preview, schedule preview, recent results, tournaments, and read-only team members when data exists |
-| 4.13 | Team Info → Roster | Shows the full active roster and read-only member list; player rows link to existing Player Profile |
+| 4.13 | Team Info → Roster | Shows the full active roster and read-only member list; player rows link to `/player-info?playerId=<id>&teamId=<id>` |
 | 4.14 | Team Info → Overview roster preview → View roster | Opens `/team/roster?teamId=<id>`; shows the same active roster as a read-only Team Roster page |
 | 4.15 | Team Roster → Back to Team | Returns to `/team?teamId=<id>` |
 | 4.16 | Team Info → Schedule | Shows upcoming/live games, recent finalized results, and tournament links; game rows open Game Info |
 | 4.17 | Team Info → Schedule preview → View schedule | Opens `/team/schedule?teamId=<id>`; groups games into live, upcoming, and finals with final scores/results |
 | 4.18 | Team Schedule → tap a scheduled/live/final game | Opens `/game-info?gameId=<id>&teamId=<id>`; shows game details, status/score, and stat leaders when resolved stats exist |
 | 4.19 | Game Info → View full summary on a finalized game | Hydrates the cloud game through the existing flow and opens `/summary`; pending local sync still blocks hydration |
+| 4.20 | Team Roster → tap a player | Opens `/player-info?playerId=<id>&teamId=<id>` with **Player Info**, season totals, game log, career link, and **Back to Team** returning to `/team?teamId=<id>` |
+| 4.21 | Leaderboard → tap a player row | Existing `/player?teamId=<id>&playerId=<id>&seasonId=<id>` route still opens **Player Profile** and backs to Leaderboard |
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,7 @@ function AppRoutes() {
           <Route path="/games" element={<Games />} />
           <Route path="/leaderboard" element={<Leaderboard />} />
           <Route path="/player" element={<PlayerProfile />} />
+          <Route path="/player-info" element={<PlayerProfile />} />
           <Route path="/career" element={<CareerStats />} />
           <Route path="/team-stats" element={<TeamStats />} />
           <Route path="/tournament-stats" element={<TournamentStats />} />

--- a/src/components/team-info/PlayerRow.tsx
+++ b/src/components/team-info/PlayerRow.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { playerDisplayName } from '../../lib/display'
+import { playerInfoPath } from '../../lib/teamInfo'
 
 export interface TeamInfoRosterPlayer {
   id: string
@@ -17,7 +18,7 @@ interface PlayerRowProps {
 export default function PlayerRow({ teamId, player }: PlayerRowProps) {
   return (
     <Link
-      to={`/player?playerId=${encodeURIComponent(player.id)}&teamId=${encodeURIComponent(teamId)}`}
+      to={playerInfoPath(player.id, teamId)}
       className="flex items-center justify-between gap-3 rounded-lg border border-slate-100 bg-white px-3 py-2 hover:border-blue-200"
     >
       <div className="min-w-0">

--- a/src/lib/teamInfo.test.ts
+++ b/src/lib/teamInfo.test.ts
@@ -3,6 +3,7 @@ import { sports } from '../config/sports'
 import {
   computeTeamRecord,
   gameInfoPath,
+  playerInfoPath,
   resolveTeamInfoHomeScore,
   splitTeamGames,
   teamGameResult,
@@ -144,6 +145,9 @@ describe('team info paths', () => {
     expect(teamRosterPath('team 1')).toBe('/team/roster?teamId=team%201')
     expect(teamSchedulePath('team 1')).toBe('/team/schedule?teamId=team%201')
     expect(gameInfoPath('game 1', 'team 1')).toBe('/game-info?gameId=game+1&teamId=team+1')
+    expect(playerInfoPath('player 1', 'team 1', 'season 1')).toBe(
+      '/player-info?playerId=player+1&teamId=team+1&seasonId=season+1'
+    )
     expect(teamLeaderboardPath('team 1', 'season 1')).toBe(
       '/leaderboard?teamId=team+1&seasonId=season+1'
     )

--- a/src/lib/teamInfo.ts
+++ b/src/lib/teamInfo.ts
@@ -93,6 +93,12 @@ export function gameInfoPath(gameId: string, teamId?: string | null): string {
   return `/game-info?${params.toString()}`
 }
 
+export function playerInfoPath(playerId: string, teamId: string, seasonId?: string | null): string {
+  const params = new URLSearchParams({ playerId, teamId })
+  if (seasonId) params.set('seasonId', seasonId)
+  return `/player-info?${params.toString()}`
+}
+
 export function teamLeaderboardPath(teamId: string, seasonId?: string | null): string {
   const params = new URLSearchParams({ teamId })
   if (seasonId) params.set('seasonId', seasonId)

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { sports } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
@@ -12,6 +12,7 @@ import { playerDisplayName, teamDisplayName } from '../lib/display'
 import { formatCompactGameStatLine } from '../lib/statDisplay'
 import PlayerStatSummaryTables, { type StatHighGameMap } from '../components/PlayerStatSummaryTables'
 import { buildResolvedByGameForPlayer } from '../lib/playerStatSummaryTables'
+import { teamInfoPath } from '../lib/teamInfo'
 
 interface TeamRow {
   id: string
@@ -62,6 +63,7 @@ function isMissingRpcError(msg: string): boolean {
 
 export default function PlayerProfile() {
   const navigate = useNavigate()
+  const location = useLocation()
   const [searchParams] = useSearchParams()
   const teamId = searchParams.get('teamId')
   const playerId = searchParams.get('playerId')
@@ -313,6 +315,10 @@ export default function PlayerProfile() {
   const leaderboardHref = team
     ? `/leaderboard?teamId=${team.id}&seasonId=${team.season_id}`
     : '/leaderboard'
+  const isPlayerInfoRoute = location.pathname === '/player-info'
+  const backHref = isPlayerInfoRoute && team ? teamInfoPath(team.id) : leaderboardHref
+  const backLabel = isPlayerInfoRoute ? 'Back to Team' : 'Back'
+  const pageTitle = isPlayerInfoRoute ? 'Player Info' : 'Player Profile'
 
   if (!teamId || !playerId) {
     return (
@@ -378,14 +384,14 @@ export default function PlayerProfile() {
       <header className="bg-gradient-to-r from-slate-700 to-slate-600 text-white px-4 py-4">
         <div className="max-w-lg mx-auto flex items-center gap-3">
           <button
-            onClick={() => navigate(leaderboardHref)}
-            className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center
-                       active:scale-90 transition-transform"
+            onClick={() => navigate(backHref)}
+            className="shrink-0 rounded-lg bg-white/20 px-2.5 py-1.5 text-xs font-semibold
+                       hover:bg-white/30 active:scale-95 transition-transform"
           >
-            ←
+            {backLabel}
           </button>
           <div className="flex-1 min-w-0">
-            <h1 className="text-lg font-bold">Player Profile</h1>
+            <h1 className="text-lg font-bold">{pageTitle}</h1>
             <p className="text-sm opacity-80">
               #{player.jersey_number || '—'} {playerDisplayName(player)}
             </p>


### PR DESCRIPTION
Summary: Adds /player-info?playerId=&teamId= as the team-context player route, keeps /player compatibility, updates Team Info roster rows to use the new route, and makes PlayerProfile show Player Info plus Back to Team when opened through the team hierarchy. Verification: pnpm.cmd test -- src/lib/teamInfo.test.ts; pnpm.cmd lint (existing Fast Refresh warnings only); pnpm.cmd build; git diff --cached --check.