### PR TITLE
Move team management into hierarchy

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -68,6 +68,8 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.8 | Reload → Teams | Same teams and roster (from Supabase) |
 | 4.9 | Teams → tap a team card's primary name area | Opens `/team?teamId=<id>`; Team Info shows display name, season, sport, record, roster count, game count, and links back to Season Stats, Team Stats, and Manage Team |
 | 4.10 | Teams → tap **Manage** on a team card | Opens `/team/manage?teamId=<id>` with roster and member management for that team |
+| 4.10b | Open legacy `/teams?teamId=<id>` link | Redirects to `/team/manage?teamId=<id>` |
+| 4.10c | Open `/team/manage` without a team id or with an invalid id | Shows Team unavailable state; does not auto-select or manage another team |
 | 4.11 | Team Info → switch **Overview / Roster / Schedule** segments | Segment content changes in place; URL stays `/team?teamId=<id>`; Manage links open `/team/manage?teamId=<id>` |
 | 4.12 | Team Info → Overview | Shows stat links, roster preview, schedule preview, recent results, tournaments, and read-only team members when data exists |
 | 4.13 | Team Info → Roster | Shows the full active roster and read-only member list; player rows link to `/player-info?playerId=<id>&teamId=<id>` |

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -57,22 +57,23 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | Step | Action | Expected |
 |------|--------|----------|
 | 4.1 | Home → Teams | Cloud Teams page; Create Team form |
-| 4.2 | Create team (name, sport, season) | Team appears in list; selected |
-| 4.3 | Add players (number, first, last) | Players appear in Roster |
+| 4.2 | Create team (name, sport, season) | Opens `/team/manage?teamId=<id>` for the created team |
+| 4.3 | Team Manage → add players (number, first, last) | Players appear in Roster |
 | 4.4 | Edit team name (pencil) → change primary name → Save | Team name updates in list; reflected in Game Setup dropdown and Games page |
 | 4.4b | Edit team nickname (pencil) → set or clear display name → Save | If set: display name shown in list with primary name in parens; if cleared: primary name shown directly |
 | 4.5 | Edit player (pencil) → change first name, last name, jersey number → Save | Player row updates with new values; reflected in cloud roster |
 | 4.5b | Edit player nickname | Display name updates; primary name shown in parentheses if nickname set |
 | 4.6 | Remove player | Player removed from roster (soft deactivate) |
-| 4.7 | Season Stats link (when team selected) | Navigate to Leaderboard with that team pre-selected |
+| 4.7 | Team Manage → Season Stats link | Navigate to Leaderboard with that team pre-selected |
 | 4.8 | Reload → Teams | Same teams and roster (from Supabase) |
 | 4.9 | Teams → tap a team card's primary name area | Opens `/team?teamId=<id>`; Team Info shows display name, season, sport, record, roster count, game count, and links back to Season Stats, Team Stats, and Manage Team |
-| 4.10 | Teams → tap **Manage** on a team card | Stays on `/teams`; roster/member management switches to that team |
-| 4.11 | Team Info → switch **Overview / Roster / Schedule** segments | Segment content changes in place; URL stays `/team?teamId=<id>`; no management actions move off `/teams` |
+| 4.10 | Teams → tap **Manage** on a team card | Opens `/team/manage?teamId=<id>` with roster and member management for that team |
+| 4.11 | Team Info → switch **Overview / Roster / Schedule** segments | Segment content changes in place; URL stays `/team?teamId=<id>`; Manage links open `/team/manage?teamId=<id>` |
 | 4.12 | Team Info → Overview | Shows stat links, roster preview, schedule preview, recent results, tournaments, and read-only team members when data exists |
 | 4.13 | Team Info → Roster | Shows the full active roster and read-only member list; player rows link to `/player-info?playerId=<id>&teamId=<id>` |
 | 4.14 | Team Info → Overview roster preview → View roster | Opens `/team/roster?teamId=<id>`; shows the same active roster as a read-only Team Roster page |
 | 4.15 | Team Roster → Back to Team | Returns to `/team?teamId=<id>` |
+| 4.15b | Team Manage → Back | Returns to `/team?teamId=<id>` |
 | 4.16 | Team Info → Schedule | Shows upcoming/live games, recent finalized results, and tournament links; game rows open Game Info |
 | 4.17 | Team Info → Schedule preview → View schedule | Opens `/team/schedule?teamId=<id>`; groups games into live, upcoming, and finals with final scores/results |
 | 4.18 | Team Schedule → tap a scheduled/live/final game | Opens `/game-info?gameId=<id>&teamId=<id>`; shows game details, status/score, and stat leaders when resolved stats exist |
@@ -90,15 +91,15 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 
 | Step | Action | Expected |
 |------|--------|----------|
-| 4a.1 | As **scorer-only** (not owner/admin): Teams → select a team | **Merge players** link next to Season Stats is **not** shown |
-| 4a.2 | As **owner** or **admin**: Teams → select that team; ensure ≥2 players exist across teams you admin | **Merge players** (amber) appears in Roster header |
+| 4a.1 | As **scorer-only** (not owner/admin): Teams → Manage a team | **Merge players** link next to Season Stats is **not** shown |
+| 4a.2 | As **owner** or **admin**: Teams → Manage that team; ensure ≥2 players exist across teams you admin | **Merge players** (amber) appears in Roster header |
 | 4a.3 | Tap **Merge players** → read intro → **Continue** | Pick survivor / duplicate step |
 | 4a.4 | Choose **survivor** (keep) and **duplicate** (remove) → **Load conflicts** | Either conflict sections appear, or message that there are no overlapping stat/roster conflicts |
 | 4a.5 | If **game_stats** conflicts: pick **keep survivor** vs **keep duplicate** row for each | Radios work; one choice per conflict |
 | 4a.6 | If **stat_corrections** conflicts: pick survivor / duplicate / **discard both** per row | Choices stick |
 | 4a.7 | If **team_players** conflicts (same team on both profiles): set jersey, **Active**, position → **Continue to confirm** | Confirm step shows summary |
 | 4a.8 | Type **MERGE** (all caps) → **Merge players** | Success: modal closes; duplicate gone from candidate pool / roster lists after refresh |
-| 4a.9 | Teams → roster / Leaderboard / Player profile for **survivor** | Stats and games that belonged to duplicate now attribute to survivor (where applicable) |
+| 4a.9 | Team Manage roster / Leaderboard / Player profile for **survivor** | Stats and games that belonged to duplicate now attribute to survivor (where applicable) |
 | 4a.10 | (Optional) Supabase Table Editor → `player_merge_audit` | New row with `duplicate_player_id`, `survivor_player_id`, `merged_by`, `resolutions` json |
 | 4a.11 | Settings (Admin) → expand **Player merge (advanced)** | Section opens; **Your recent merges** loads or shows migration **025** hint if RLS blocks reads |
 | 4a.12 | **Open merge wizard** from Admin (with ≥2 candidates) | Same modal as Teams; complete a test merge → row appears under **Your recent merges** (after **025** applied) |
@@ -338,13 +339,13 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 
 | Step | Action | Expected |
 |------|--------|----------|
-| 10.1 | As owner: Teams → select team → Team Members | Member list; "Invite by email" section |
+| 10.1 | As owner: Teams → Manage team → Team Members | Member list; "Invite by email" section |
 | 10.2 | Enter invitee email → Lookup | User found; display name shown |
 | 10.3 | Choose role (Scorer / Admin) → Send Invite | Invite sent; member row shows "Pending" |
 | 10.4 | As invitee: sign in → Teams | "Pending invites" banner with team name |
 | 10.5 | Accept | Banner clears; team appears in list; member shows "Accepted" |
 | 10.6 | As invitee: open team | Can see roster; can start games for that team |
-| 10.7 | As owner: Team Members | Invitee listed with role; Remove available |
+| 10.7 | As owner: Team Manage → Team Members | Invitee listed with role; Remove available |
 | 10.8 | As invitee: Decline (alternative flow) | Invite removed; team no longer in list |
 | 10.9 | As admin (invited as admin): same team → Invite by email | Can lookup and send invite |
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ function AppRoutes() {
           <Route path="/admin" element={<Admin />} />
           <Route path="/teams" element={<Teams />} />
           <Route path="/team" element={<TeamInfo />} />
+          <Route path="/team/manage" element={<Teams />} />
           <Route path="/team/roster" element={<TeamRoster />} />
           <Route path="/team/schedule" element={<TeamSchedule />} />
           <Route path="/team/season" element={<SeasonInfo />} />

--- a/src/lib/teamInfo.test.ts
+++ b/src/lib/teamInfo.test.ts
@@ -156,6 +156,6 @@ describe('team info paths', () => {
       '/leaderboard?teamId=team+1&seasonId=season+1'
     )
     expect(teamStatsPath('team 1')).toBe('/team-stats?teamId=team%201')
-    expect(teamManagementPath('team 1')).toBe('/teams?teamId=team%201')
+    expect(teamManagementPath('team 1')).toBe('/team/manage?teamId=team%201')
   })
 })

--- a/src/lib/teamInfo.ts
+++ b/src/lib/teamInfo.ts
@@ -116,5 +116,5 @@ export function teamStatsPath(teamId: string): string {
 }
 
 export function teamManagementPath(teamId: string): string {
-  return `/teams?teamId=${encodeURIComponent(teamId)}`
+  return `/team/manage?teamId=${encodeURIComponent(teamId)}`
 }

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -132,6 +132,27 @@ export default function Teams() {
     [teams, selectedTeamId]
   )
 
+  const managementRouteMessage = useMemo(() => {
+    if (!isManagementRoute || loadingTeams || selectedTeam) return null
+    if (!requestedTeamId) return 'Choose a team from Cloud Teams before opening management.'
+    return 'That team could not be found or you no longer have access to it.'
+  }, [isManagementRoute, loadingTeams, requestedTeamId, selectedTeam])
+  const backPath = isManagementRoute
+    ? selectedTeam ? teamInfoPath(selectedTeam.id) : '/teams'
+    : '/admin'
+
+  useEffect(() => {
+    if (!isManagementRoute && requestedTeamId) {
+      navigate(teamManagementPath(requestedTeamId), { replace: true })
+    }
+  }, [isManagementRoute, navigate, requestedTeamId])
+
+  useEffect(() => {
+    if (isManagementRoute && selectedTeamId && selectedTeamId !== requestedTeamId) {
+      setSelectedTeamId('')
+    }
+  }, [isManagementRoute, requestedTeamId, selectedTeamId])
+
   useEffect(() => {
     if (!isConfigured || !userId || !supabaseClient) return
 
@@ -157,6 +178,7 @@ export default function Teams() {
         if (requestedTeamId && loadedTeams.some(team => team.id === requestedTeamId)) {
           return requestedTeamId
         }
+        if (isManagementRoute) return ''
         if (prev && loadedTeams.some(team => team.id === prev)) return prev
         return loadedTeams[0]?.id ?? ''
       })
@@ -167,7 +189,7 @@ export default function Teams() {
     return () => {
       cancelled = true
     }
-  }, [isConfigured, requestedTeamId, supabaseClient, userId])
+  }, [isConfigured, isManagementRoute, requestedTeamId, supabaseClient, userId])
 
   useEffect(() => {
     if (!isConfigured || !userId || !supabaseClient) {
@@ -859,7 +881,7 @@ export default function Teams() {
       <header className="bg-gradient-to-r from-slate-700 to-slate-600 text-white px-4 py-4">
         <div className="max-w-lg mx-auto flex items-center gap-3">
           <button
-            onClick={() => navigate(isManagementRoute && selectedTeam ? teamInfoPath(selectedTeam.id) : '/admin')}
+            onClick={() => navigate(backPath)}
             className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center
                        active:scale-90 transition-transform"
           >
@@ -913,6 +935,16 @@ export default function Teams() {
           <div className="card bg-red-50 border-red-200 text-red-700 text-sm">
             {error}
           </div>
+        )}
+
+        {managementRouteMessage && (
+          <section className="card space-y-3">
+            <p className="font-semibold text-slate-700">Team unavailable</p>
+            <p className="text-sm text-slate-500">{managementRouteMessage}</p>
+            <button type="button" onClick={() => navigate('/teams')} className="btn-primary w-full">
+              Back to Cloud Teams
+            </button>
+          </section>
         )}
 
         {!isManagementRoute && (
@@ -1112,7 +1144,7 @@ export default function Teams() {
           </>
         )}
 
-        {isManagementRoute && (
+        {isManagementRoute && !managementRouteMessage && selectedTeam && (
           <section className="card space-y-3">
           <div className="flex items-center justify-between">
             <h2 className="font-semibold text-slate-700">Roster</h2>

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { sports } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName, playerDisplayName, playerRosterSelectLabel } from '../lib/display'
-import { teamInfoPath } from '../lib/teamInfo'
+import { teamInfoPath, teamManagementPath } from '../lib/teamInfo'
 import ConfirmDialog from '../components/ConfirmDialog'
 import MergePlayerWizard, { type MergePlayerOption } from '../components/MergePlayerWizard'
 import { fetchMergePlayerScope } from '../lib/mergePlayerScope'
@@ -54,12 +54,14 @@ interface PoolPlayer {
 }
 
 export default function Teams() {
+  const location = useLocation()
   const navigate = useNavigate()
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [searchParams] = useSearchParams()
   const { user, isConfigured } = useAuth()
   const { state: gameState, dispatch: gameDispatch } = useGame()
   const userId = user?.id ?? null
   const requestedTeamId = searchParams.get('teamId')
+  const isManagementRoute = location.pathname === '/team/manage'
   const supabaseClient = supabase
 
   const [teams, setTeams] = useState<TeamRow[]>([])
@@ -578,6 +580,7 @@ export default function Teams() {
     setNewPlayerFirst('')
     setNewPlayerLast('')
     setNewPlayerNumber('')
+    navigate(teamManagementPath(createdTeam.id))
   }
 
   const handleAddPlayer = async () => {
@@ -856,15 +859,19 @@ export default function Teams() {
       <header className="bg-gradient-to-r from-slate-700 to-slate-600 text-white px-4 py-4">
         <div className="max-w-lg mx-auto flex items-center gap-3">
           <button
-            onClick={() => navigate('/admin')}
+            onClick={() => navigate(isManagementRoute && selectedTeam ? teamInfoPath(selectedTeam.id) : '/admin')}
             className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center
                        active:scale-90 transition-transform"
           >
             ←
           </button>
           <div>
-            <h1 className="text-lg font-bold">Cloud Teams</h1>
-            <p className="text-sm opacity-80">Create teams and manage rosters</p>
+            <h1 className="text-lg font-bold">{isManagementRoute ? 'Manage Team' : 'Cloud Teams'}</h1>
+            <p className="text-sm opacity-80">
+              {isManagementRoute && selectedTeam
+                ? teamDisplayName(selectedTeam)
+                : 'Create teams and review your cloud teams'}
+            </p>
           </div>
         </div>
       </header>
@@ -908,81 +915,83 @@ export default function Teams() {
           </div>
         )}
 
-        <section className="card space-y-3">
-          <h2 className="font-semibold text-slate-700">Create Team</h2>
-          <input
-            type="text"
-            value={newTeamName}
-            onChange={e => setNewTeamName(e.target.value)}
-            placeholder="Team name"
-            className="input-field"
-          />
-          <div>
-            <label className="block text-xs font-medium text-slate-500 mb-1">Season</label>
-            <select
-              value={seasonMode === 'existing' ? selectedSeasonId : '__new__'}
-              onChange={e => {
-                if (e.target.value === '__new__') {
-                  setSeasonMode('new')
-                  setSelectedSeasonId('')
-                } else {
-                  setSeasonMode('existing')
-                  setSelectedSeasonId(e.target.value)
-                }
-              }}
-              className="input-field"
-            >
-              <option value="__new__">Create new season...</option>
-              {existingSeasons.map(s => (
-                <option key={s.id} value={s.id}>
-                  {s.name} ({s.sport})
-                </option>
-              ))}
-            </select>
-          </div>
-          {seasonMode === 'new' && (
-            <div className="grid grid-cols-2 gap-2">
-              <select
-                value={newTeamSport}
-                onChange={e => setNewTeamSport(e.target.value)}
-                className="input-field"
-              >
-                {sports.map(sport => (
-                  <option key={sport.id} value={sport.id}>
-                    {sport.icon} {sport.name}
-                  </option>
-                ))}
-              </select>
+        {!isManagementRoute && (
+          <>
+            <section className="card space-y-3">
+              <h2 className="font-semibold text-slate-700">Create Team</h2>
               <input
                 type="text"
-                value={newTeamSeason}
-                onChange={e => setNewTeamSeason(e.target.value)}
-                placeholder="Season name (required)"
+                value={newTeamName}
+                onChange={e => setNewTeamName(e.target.value)}
+                placeholder="Team name"
                 className="input-field"
-                required
               />
-            </div>
-          )}
-          <button
-            type="button"
-            onClick={() => { void handleCreateTeam() }}
-            disabled={
-              !newTeamName.trim()
-              || creatingTeam
-              || (seasonMode === 'existing' && !selectedSeasonId)
-              || (seasonMode === 'new' && !newTeamSeason.trim())
-            }
-            className="btn-primary w-full"
-          >
-            {creatingTeam ? 'Creating...' : 'Create Team'}
-          </button>
-        </section>
+              <div>
+                <label className="block text-xs font-medium text-slate-500 mb-1">Season</label>
+                <select
+                  value={seasonMode === 'existing' ? selectedSeasonId : '__new__'}
+                  onChange={e => {
+                    if (e.target.value === '__new__') {
+                      setSeasonMode('new')
+                      setSelectedSeasonId('')
+                    } else {
+                      setSeasonMode('existing')
+                      setSelectedSeasonId(e.target.value)
+                    }
+                  }}
+                  className="input-field"
+                >
+                  <option value="__new__">Create new season...</option>
+                  {existingSeasons.map(s => (
+                    <option key={s.id} value={s.id}>
+                      {s.name} ({s.sport})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {seasonMode === 'new' && (
+                <div className="grid grid-cols-2 gap-2">
+                  <select
+                    value={newTeamSport}
+                    onChange={e => setNewTeamSport(e.target.value)}
+                    className="input-field"
+                  >
+                    {sports.map(sport => (
+                      <option key={sport.id} value={sport.id}>
+                        {sport.icon} {sport.name}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="text"
+                    value={newTeamSeason}
+                    onChange={e => setNewTeamSeason(e.target.value)}
+                    placeholder="Season name (required)"
+                    className="input-field"
+                    required
+                  />
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => { void handleCreateTeam() }}
+                disabled={
+                  !newTeamName.trim()
+                  || creatingTeam
+                  || (seasonMode === 'existing' && !selectedSeasonId)
+                  || (seasonMode === 'new' && !newTeamSeason.trim())
+                }
+                className="btn-primary w-full"
+              >
+                {creatingTeam ? 'Creating...' : 'Create Team'}
+              </button>
+            </section>
 
-        <section className="card space-y-3">
-          <div className="flex items-center justify-between">
-            <h2 className="font-semibold text-slate-700">Teams</h2>
-            {loadingTeams && <span className="text-xs text-slate-400 animate-pulse">Loading...</span>}
-          </div>
+            <section className="card space-y-3">
+              <div className="flex items-center justify-between">
+                <h2 className="font-semibold text-slate-700">Teams</h2>
+                {loadingTeams && <span className="text-xs text-slate-400 animate-pulse">Loading...</span>}
+              </div>
 
           {teams.length === 0 && !loadingTeams ? (
             <p className="text-sm text-slate-500">No teams yet. Create one above.</p>
@@ -1065,11 +1074,10 @@ export default function Teams() {
                             type="button"
                             onClick={e => {
                               e.stopPropagation()
-                              setSelectedTeamId(team.id)
-                              setSearchParams({ teamId: team.id }, { replace: true })
+                              navigate(teamManagementPath(team.id))
                             }}
                             className="text-xs font-semibold text-blue-600 px-1.5 py-1"
-                            title="Manage roster and members on this page"
+                            title="Manage roster and members"
                           >
                             Manage
                           </button>
@@ -1100,9 +1108,12 @@ export default function Teams() {
               })}
             </div>
           )}
-        </section>
+            </section>
+          </>
+        )}
 
-        <section className="card space-y-3">
+        {isManagementRoute && (
+          <section className="card space-y-3">
           <div className="flex items-center justify-between">
             <h2 className="font-semibold text-slate-700">Roster</h2>
             <div className="flex items-center gap-2">
@@ -1373,7 +1384,8 @@ export default function Teams() {
           ) : (
             <p className="text-sm text-slate-500">Select a team to manage its roster.</p>
           )}
-        </section>
+          </section>
+        )}
 
         <ConfirmDialog
           open={confirmDeleteTeam !== null}
@@ -1407,7 +1419,7 @@ export default function Teams() {
           onCancel={() => setConfirmDeletePlayer(null)}
         />
 
-        {selectedTeam && (
+        {isManagementRoute && selectedTeam && (
           <section className="card space-y-3">
             <h2 className="font-semibold text-slate-700">Team Members</h2>
             {loadingMembers ? (
@@ -1499,7 +1511,7 @@ export default function Teams() {
         )}
       </div>
 
-      {mergeWizardOpen && supabaseClient && (
+      {isManagementRoute && mergeWizardOpen && supabaseClient && (
         <MergePlayerWizard
           supabase={supabaseClient}
           candidates={mergeCandidates}


### PR DESCRIPTION
## Summary
- add /team/manage as the team management route and point Team Info manage links there
- keep /teams focused on cloud team creation/listing while preserving roster, invite, and merge workflows on Team Manage
- update regression coverage for the new Team Manage flow

## Verification
- pnpm.cmd test -- src/lib/teamInfo.test.ts
- pnpm.cmd lint (existing Fast Refresh warnings in context files)
- pnpm.cmd build (existing chunk-size warning)