### PR TITLE
Add team start game navigation

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -81,9 +81,12 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.18 | Team Schedule → tap a scheduled/live/final game | Opens `/game-info?gameId=<id>&teamId=<id>`; shows game details, status/score, and stat leaders when resolved stats exist |
 | 4.19 | Game Info → View full summary on a finalized game | Hydrates the cloud game through the existing flow and opens `/summary`; pending local sync still blocks hydration |
 | 4.20 | Team Roster → tap a player | Opens `/player-info?playerId=<id>&teamId=<id>` with **Player Info**, season totals, game log, career link, and **Back to Team** returning to `/team?teamId=<id>` |
-| 4.21 | Leaderboard → tap a player row | Existing `/player?teamId=<id>&playerId=<id>&seasonId=<id>` route still opens **Player Profile** and backs to Leaderboard |
+| 4.21 | Team Info → Season Stats → back arrow | Opens Leaderboard with that team selected; back arrow returns to `/team?teamId=<id>` |
 | 4.22 | Team Info hero → season name | Opens `/team/season?seasonId=<id>` with season name, sport, team count, and teams in that season |
 | 4.23 | Season Info → tap a team name / Season Stats | Team name opens `/team?teamId=<id>`; Season Stats opens Leaderboard with `seasonId` and `teamId` set |
+| 4.24 | Team Info → Start Game | Opens `/setup?teamId=<id>` with the team's sport and existing team preselected |
+| 4.25 | Open `/setup?teamId=<id>` directly | Loads the team sport when possible and preselects the team; invalid/inaccessible team shows Team unavailable and does not auto-select another team |
+| 4.26 | Team Stats / Tournament Stats / Game Info / Player Info → back action | Returns to `/team?teamId=<id>` when opened with team context |
 
 ---
 
@@ -322,10 +325,10 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 9.5 | View (on a game) | Loads game and navigates to Summary |
 | 9.6 | Leaderboard: change "Sort by" | Order updates (e.g. by Assists) |
 | 9.7 | Leaderboard: change **Season** dropdown | Team list filters; URL updates `seasonId` |
-| 9.8 | Leaderboard: **Team stats →** | Opens `/team-stats` with W/L and game list |
+| 9.8 | Leaderboard: **Team stats →** | Opens `/team-stats` with W/L and game list; header back returns to Team Info when opened with `teamId` |
 | 9.9 | Player Profile: **Career →** | Opens `/career` with totals; migration **020** applied for RPC |
 | 9.10 | Teams → roster **Career** on a player | Same as 9.9 |
-| 9.11 | Team stats → tournament row **Stats →** | Opens tournament stats; W/L and leaderboard when games have `tournament_id` |
+| 9.11 | Team stats → tournament row **Stats →** | Opens tournament stats; W/L and leaderboard when games have `tournament_id`; header back returns to Team Info and inline Team stats returns to `/team-stats` |
 | 9.12 | Game Summary → **Team** tab | Only team totals tables + score card; **Players** shows full grid |
 | 9.13 | Team stats → **By opponent** | Table lists opponents with W-L-T and PF-PA when multiple finals exist |
 | 9.14 | Leaderboard: tap **Career** on a row (not the main row) | Opens `/career` with that `playerId` and the season’s sport |

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -82,6 +82,7 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.19 | Game Info → View full summary on a finalized game | Hydrates the cloud game through the existing flow and opens `/summary`; pending local sync still blocks hydration |
 | 4.20 | Team Roster → tap a player | Opens `/player-info?playerId=<id>&teamId=<id>` with **Player Info**, season totals, game log, career link, and **Back to Team** returning to `/team?teamId=<id>` |
 | 4.21 | Team Info → Season Stats → back arrow | Opens Leaderboard with that team selected; back arrow returns to `/team?teamId=<id>` |
+| 4.21b | Leaderboard → tap a player row | Existing `/player?teamId=<id>&playerId=<id>&seasonId=<id>` route still opens **Player Profile** and backs to Leaderboard |
 | 4.22 | Team Info hero → season name | Opens `/team/season?seasonId=<id>` with season name, sport, team count, and teams in that season |
 | 4.23 | Season Info → tap a team name / Season Stats | Team name opens `/team?teamId=<id>`; Season Stats opens Leaderboard with `seasonId` and `teamId` set |
 | 4.24 | Team Info → Start Game | Opens `/setup?teamId=<id>` with the team's sport and existing team preselected |

--- a/src/components/team-info/QuickStatsCard.tsx
+++ b/src/components/team-info/QuickStatsCard.tsx
@@ -17,7 +17,7 @@ export default function QuickStatsCard({ teamId, seasonId, firstTournamentId }: 
 
       <div className="grid gap-2 sm:grid-cols-2">
         <Link
-          to={teamLeaderboardPath(teamId, seasonId)}
+          to={teamLeaderboardPath(teamId, seasonId, true)}
           className="rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300"
         >
           Season Stats

--- a/src/lib/teamInfo.test.ts
+++ b/src/lib/teamInfo.test.ts
@@ -157,6 +157,9 @@ describe('team info paths', () => {
     expect(teamLeaderboardPath('team 1', 'season 1')).toBe(
       '/leaderboard?teamId=team+1&seasonId=season+1'
     )
+    expect(teamLeaderboardPath('team 1', 'season 1', true)).toBe(
+      '/leaderboard?teamId=team+1&seasonId=season+1&from=team'
+    )
     expect(teamStatsPath('team 1')).toBe('/team-stats?teamId=team%201')
     expect(teamManagementPath('team 1')).toBe('/team/manage?teamId=team%201')
   })

--- a/src/lib/teamInfo.test.ts
+++ b/src/lib/teamInfo.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { sports } from '../config/sports'
 import {
   computeTeamRecord,
+  gameSetupPath,
   gameInfoPath,
   playerInfoPath,
   resolveTeamInfoHomeScore,
@@ -149,6 +150,7 @@ describe('team info paths', () => {
       '/team/season?seasonId=season+1&teamId=team+1'
     )
     expect(gameInfoPath('game 1', 'team 1')).toBe('/game-info?gameId=game+1&teamId=team+1')
+    expect(gameSetupPath('team 1')).toBe('/setup?teamId=team%201')
     expect(playerInfoPath('player 1', 'team 1', 'season 1')).toBe(
       '/player-info?playerId=player+1&teamId=team+1&seasonId=season+1'
     )

--- a/src/lib/teamInfo.ts
+++ b/src/lib/teamInfo.ts
@@ -99,6 +99,10 @@ export function gameInfoPath(gameId: string, teamId?: string | null): string {
   return `/game-info?${params.toString()}`
 }
 
+export function gameSetupPath(teamId: string): string {
+  return `/setup?teamId=${encodeURIComponent(teamId)}`
+}
+
 export function playerInfoPath(playerId: string, teamId: string, seasonId?: string | null): string {
   const params = new URLSearchParams({ playerId, teamId })
   if (seasonId) params.set('seasonId', seasonId)

--- a/src/lib/teamInfo.ts
+++ b/src/lib/teamInfo.ts
@@ -109,9 +109,14 @@ export function playerInfoPath(playerId: string, teamId: string, seasonId?: stri
   return `/player-info?${params.toString()}`
 }
 
-export function teamLeaderboardPath(teamId: string, seasonId?: string | null): string {
+export function teamLeaderboardPath(
+  teamId: string,
+  seasonId?: string | null,
+  fromTeam = false
+): string {
   const params = new URLSearchParams({ teamId })
   if (seasonId) params.set('seasonId', seasonId)
+  if (fromTeam) params.set('from', 'team')
   return `/leaderboard?${params.toString()}`
 }
 

--- a/src/pages/GameSetup.tsx
+++ b/src/pages/GameSetup.tsx
@@ -79,7 +79,7 @@ export default function GameSetup() {
   const [requestedTeamSportError, setRequestedTeamSportError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (sport || !requestedTeamId || !isCloudFlow || !supabase) return
+    if (!requestedTeamId || !isCloudFlow || !supabase) return
 
     const client = supabase
     let cancelled = false
@@ -107,7 +107,18 @@ export default function GameSetup() {
         return
       }
 
-      dispatch({ type: 'SET_SPORT', sport: requestedSport })
+      if (sport?.id !== requestedSport.id) {
+        const hasActiveGame = Boolean(state.sport && state.players.length > 0)
+        if (
+          hasActiveGame &&
+          !window.confirm('Starting a new game will discard your active game. Continue?')
+        ) {
+          navigate('/')
+          return
+        }
+
+        dispatch({ type: 'SET_SPORT', sport: requestedSport })
+      }
       setLoadingRequestedTeamSport(false)
     }
 
@@ -115,7 +126,7 @@ export default function GameSetup() {
     return () => {
       cancelled = true
     }
-  }, [dispatch, isCloudFlow, requestedTeamId, sport])
+  }, [dispatch, isCloudFlow, navigate, requestedTeamId, sport?.id, state.players.length, state.sport])
 
   useEffect(() => {
     if (!sport || !isCloudFlow || !userId) return

--- a/src/pages/GameSetup.tsx
+++ b/src/pages/GameSetup.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { sports } from '../config/sports'
 import { useGame } from '../context/GameContext'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
+import { teamInfoPath } from '../lib/teamInfo'
 import ConfirmDialog from '../components/ConfirmDialog'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -29,6 +31,8 @@ interface TournamentOption {
 
 export default function GameSetup() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const requestedTeamId = searchParams.get('teamId')
   const { state, dispatch } = useGame()
   const { user, isConfigured } = useAuth()
   const userId = user?.id ?? null
@@ -42,10 +46,10 @@ export default function GameSetup() {
     state.gameInfo?.date || new Date().toISOString().split('T')[0]
   )
   const [teamMode, setTeamMode] = useState<'existing' | 'new'>(
-    state.cloudSync.teamId ? 'existing' : 'new'
+    requestedTeamId || state.cloudSync.teamId ? 'existing' : 'new'
   )
   const [teams, setTeams] = useState<CloudTeam[]>([])
-  const [selectedTeamId, setSelectedTeamId] = useState(state.cloudSync.teamId || '')
+  const [selectedTeamId, setSelectedTeamId] = useState(requestedTeamId || state.cloudSync.teamId || '')
   const [seasonFilter, setSeasonFilter] = useState<string>('')
   const [loadingTeams, setLoadingTeams] = useState(false)
   const [teamsError, setTeamsError] = useState<string | null>(null)
@@ -71,6 +75,47 @@ export default function GameSetup() {
   const [loadingSeasonsForNewTeam, setLoadingSeasonsForNewTeam] = useState(false)
   const [selectedNewTeamSeasonId, setSelectedNewTeamSeasonId] = useState('')
   const [setupError, setSetupError] = useState<string | null>(null)
+  const [loadingRequestedTeamSport, setLoadingRequestedTeamSport] = useState(false)
+  const [requestedTeamSportError, setRequestedTeamSportError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (sport || !requestedTeamId || !isCloudFlow || !supabase) return
+
+    const client = supabase
+    let cancelled = false
+    const loadRequestedTeamSport = async () => {
+      setLoadingRequestedTeamSport(true)
+      setRequestedTeamSportError(null)
+      const { data, error } = await client
+        .from('teams')
+        .select('id,seasons!inner(sport)')
+        .eq('id', requestedTeamId)
+        .single()
+
+      if (cancelled) return
+      if (error || !data) {
+        setRequestedTeamSportError(error?.message ?? 'Team not found')
+        setLoadingRequestedTeamSport(false)
+        return
+      }
+
+      const row = data as unknown as { seasons: { sport: string } }
+      const requestedSport = sports.find(item => item.id === row.seasons.sport)
+      if (!requestedSport) {
+        setRequestedTeamSportError('This team uses a sport that is not available.')
+        setLoadingRequestedTeamSport(false)
+        return
+      }
+
+      dispatch({ type: 'SET_SPORT', sport: requestedSport })
+      setLoadingRequestedTeamSport(false)
+    }
+
+    void loadRequestedTeamSport()
+    return () => {
+      cancelled = true
+    }
+  }, [dispatch, isCloudFlow, requestedTeamId, sport])
 
   useEffect(() => {
     if (!sport || !isCloudFlow || !userId) return
@@ -101,17 +146,31 @@ export default function GameSetup() {
         return
       }
 
+      const requestedTeam = requestedTeamId
+        ? loadedTeams.find(team => team.id === requestedTeamId)
+        : null
+      if (requestedTeamId && !requestedTeam) {
+        setTeamMode('existing')
+        setSelectedTeamId('')
+        setTeamName('')
+        setSeasonFilter('')
+        setTeamsError('That team could not be found for this sport or you no longer have access to it.')
+        setLoadingTeams(false)
+        return
+      }
+
       const matchedById = state.cloudSync.teamId
         ? loadedTeams.find(team => team.id === state.cloudSync.teamId)
         : null
       const matchedByName = state.gameInfo?.teamName
         ? loadedTeams.find(team => team.name === state.gameInfo?.teamName)
         : null
-      const preferredTeam = matchedById || matchedByName || loadedTeams[0]
+      const preferredTeam = requestedTeam || matchedById || matchedByName || loadedTeams[0]
 
       setTeamMode('existing')
       setSelectedTeamId(preferredTeam.id)
       setTeamName(preferredTeam.name)
+      if (requestedTeam) setSeasonFilter(preferredTeam.season_id)
       setLoadingTeams(false)
     }
 
@@ -119,7 +178,7 @@ export default function GameSetup() {
     return () => {
       isCancelled = true
     }
-  }, [isCloudFlow, sport, state.cloudSync.teamId, state.gameInfo?.teamName, userId])
+  }, [isCloudFlow, requestedTeamId, sport, state.cloudSync.teamId, state.gameInfo?.teamName, userId])
 
   useEffect(() => {
     if (!isCloudFlow || !userId || !sport || !supabase) return
@@ -257,8 +316,30 @@ export default function GameSetup() {
     ? selectedTeam?.name ?? ''
     : teamName.trim()
   const canProceed = Boolean(resolvedTeamName && opponentName.trim())
+  const requestedTeamUnavailable = Boolean(
+    requestedTeamId && !loadingTeams && teams.length > 0 && !selectedTeam
+  )
 
   if (!sport) {
+    if (requestedTeamId && isCloudFlow) {
+      return (
+        <div className="min-h-screen flex flex-col items-center justify-center px-4">
+          <div className="card max-w-md w-full text-center space-y-3">
+            <p className="font-semibold text-slate-700">Loading team setup</p>
+            <p className="text-sm text-slate-500">
+              {loadingRequestedTeamSport
+                ? 'Finding this team sport...'
+                : requestedTeamSportError ?? 'Preparing game setup...'}
+            </p>
+            {requestedTeamSportError && (
+              <button type="button" onClick={() => navigate('/teams')} className="btn-primary w-full">
+                Back to Cloud Teams
+              </button>
+            )}
+          </div>
+        </div>
+      )
+    }
     navigate('/')
     return null
   }
@@ -388,10 +469,12 @@ export default function GameSetup() {
                 <p className="text-sm font-semibold text-slate-700">Team Source</p>
                 <button
                   type="button"
-                  onClick={() => navigate('/teams')}
+                  onClick={() =>
+                    navigate(requestedTeamId && selectedTeam ? teamInfoPath(selectedTeam.id) : '/teams')
+                  }
                   className="text-xs text-blue-600 font-medium underline"
                 >
-                  Manage Teams
+                  {requestedTeamId && selectedTeam ? 'Back to Team' : 'Manage Teams'}
                 </button>
               </div>
 
@@ -431,6 +514,13 @@ export default function GameSetup() {
 
               {loadingTeams ? (
                 <p className="text-sm text-slate-500 animate-pulse">Loading teams...</p>
+              ) : requestedTeamUnavailable ? (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 p-3">
+                  <p className="text-sm font-semibold text-amber-900">Team unavailable</p>
+                  <p className="text-xs text-amber-800 mt-1">
+                    Choose another team from Cloud Teams before starting this game.
+                  </p>
+                </div>
               ) : teamMode === 'existing' && teams.length > 0 ? (
                 <div className="space-y-2">
                   {availableSeasons.length > 1 && (

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -55,7 +55,7 @@ export default function Leaderboard() {
   const [searchParams, setSearchParams] = useSearchParams()
   const teamIdFromUrl = searchParams.get('teamId')
   const seasonIdFromUrl = searchParams.get('seasonId')
-  const hasTeamContext = Boolean(teamIdFromUrl)
+  const isTeamOrigin = searchParams.get('from') === 'team'
 
   const { user, isConfigured } = useAuth()
   const supabaseClient = supabase
@@ -93,9 +93,10 @@ export default function Leaderboard() {
       const next = new URLSearchParams()
       if (seasonId) next.set('seasonId', seasonId)
       if (teamId) next.set('teamId', teamId)
+      if (isTeamOrigin) next.set('from', 'team')
       setSearchParams(next, { replace: true })
     },
-    [setSearchParams]
+    [isTeamOrigin, setSearchParams]
   )
 
   useEffect(() => {
@@ -288,7 +289,7 @@ export default function Leaderboard() {
         <div className="max-w-lg mx-auto flex items-center gap-3">
           <button
             onClick={() =>
-              navigate(hasTeamContext && selectedTeamId ? teamInfoPath(selectedTeamId) : '/')
+              navigate(isTeamOrigin && selectedTeamId ? teamInfoPath(selectedTeamId) : '/')
             }
             className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center
                        active:scale-90 transition-transform"

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -4,6 +4,7 @@ import { sports, computePlayerScore } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName, playerDisplayName } from '../lib/display'
+import { teamInfoPath } from '../lib/teamInfo'
 
 interface TeamRow {
   id: string
@@ -54,6 +55,7 @@ export default function Leaderboard() {
   const [searchParams, setSearchParams] = useSearchParams()
   const teamIdFromUrl = searchParams.get('teamId')
   const seasonIdFromUrl = searchParams.get('seasonId')
+  const hasTeamContext = Boolean(teamIdFromUrl)
 
   const { user, isConfigured } = useAuth()
   const supabaseClient = supabase
@@ -285,7 +287,9 @@ export default function Leaderboard() {
       <header className="bg-gradient-to-r from-slate-700 to-slate-600 text-white px-4 py-4">
         <div className="max-w-lg mx-auto flex items-center gap-3">
           <button
-            onClick={() => navigate('/')}
+            onClick={() =>
+              navigate(hasTeamContext && selectedTeamId ? teamInfoPath(selectedTeamId) : '/')
+            }
             className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center
                        active:scale-90 transition-transform"
           >

--- a/src/pages/TeamInfo.tsx
+++ b/src/pages/TeamInfo.tsx
@@ -10,10 +10,12 @@ import TeamOverviewCards from '../components/team-info/TeamOverviewCards'
 import TournamentCard, { type TeamInfoTournament } from '../components/team-info/TournamentCard'
 import { sports } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
+import { useGame } from '../context/GameContext'
 import { teamDisplayName } from '../lib/display'
 import { supabase } from '../lib/supabase'
 import {
   computeTeamRecord,
+  gameSetupPath,
   resolveTeamInfoHomeScore,
   splitTeamGames,
   teamGameResult,
@@ -53,6 +55,7 @@ export default function TeamInfo() {
   const [searchParams] = useSearchParams()
   const teamId = searchParams.get('teamId')
   const { isConfigured } = useAuth()
+  const { state: gameState, dispatch: gameDispatch } = useGame()
   const supabaseClient = supabase
 
   const [team, setTeam] = useState<TeamRow | null>(null)
@@ -117,6 +120,27 @@ export default function TeamInfo() {
         })),
     [gamesWithScores]
   )
+
+  const handleStartGame = () => {
+    if (!team || !sport) return
+    const hasActiveGame = Boolean(gameState.sport && gameState.players.length > 0)
+    if (
+      hasActiveGame &&
+      !window.confirm('Starting a new game will discard your active game. Continue?')
+    ) {
+      return
+    }
+
+    gameDispatch({ type: 'SET_SPORT', sport })
+    gameDispatch({
+      type: 'SET_CLOUD_SYNC_STATE',
+      cloudSync: {
+        seasonId: team.season_id,
+        teamId: team.id,
+      },
+    })
+    navigate(gameSetupPath(team.id))
+  }
 
   useEffect(() => {
     if (!teamId || !isConfigured || !supabaseClient) {
@@ -286,7 +310,18 @@ export default function TeamInfo() {
           >
             Back to Teams
           </button>
-          {loading && <span className="text-xs text-slate-400 animate-pulse">Loading...</span>}
+          <div className="flex items-center gap-3">
+            {team && sport && !loading && (
+              <button
+                type="button"
+                onClick={handleStartGame}
+                className="btn-primary py-2 px-3 text-sm"
+              >
+                Start Game
+              </button>
+            )}
+            {loading && <span className="text-xs text-slate-400 animate-pulse">Loading...</span>}
+          </div>
         </div>
 
         {error ? (

--- a/src/pages/TeamStats.tsx
+++ b/src/pages/TeamStats.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName } from '../lib/display'
 import { formatCompactGameStatLine } from '../lib/statDisplay'
+import { teamInfoPath, teamLeaderboardPath } from '../lib/teamInfo'
 
 interface TeamRow {
   id: string
@@ -278,7 +279,7 @@ export default function TeamStats() {
     return (
       <div className="min-h-screen flex flex-col px-4 py-6 max-w-lg mx-auto">
         {error && <div className="card bg-red-50 text-red-700 text-sm mb-4">{error}</div>}
-        <button type="button" onClick={() => navigate('/leaderboard')} className="btn-primary">
+        <button type="button" onClick={() => navigate(teamInfoPath(teamId))} className="btn-primary">
           Back
         </button>
       </div>
@@ -294,7 +295,7 @@ export default function TeamStats() {
         <div className="max-w-lg mx-auto flex items-center gap-3">
           <button
             type="button"
-            onClick={() => navigate(`/leaderboard?teamId=${teamId}&seasonId=${team.season_id}`)}
+            onClick={() => navigate(teamInfoPath(teamId))}
             className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center active:scale-90 transition-transform"
           >
             ←
@@ -315,6 +316,14 @@ export default function TeamStats() {
             faster team game lines. Per-game stats unavailable.
           </p>
         )}
+
+        <button
+          type="button"
+          onClick={() => navigate(teamLeaderboardPath(teamId, team.season_id))}
+          className="text-sm font-semibold text-blue-600"
+        >
+          Season leaderboard →
+        </button>
 
         <section className="card space-y-2">
           <h2 className="font-semibold text-slate-700">Season record</h2>

--- a/src/pages/TeamStats.tsx
+++ b/src/pages/TeamStats.tsx
@@ -319,7 +319,7 @@ export default function TeamStats() {
 
         <button
           type="button"
-          onClick={() => navigate(teamLeaderboardPath(teamId, team.season_id))}
+          onClick={() => navigate(teamLeaderboardPath(teamId, team.season_id, true))}
           className="text-sm font-semibold text-blue-600"
         >
           Season leaderboard →

--- a/src/pages/TournamentStats.tsx
+++ b/src/pages/TournamentStats.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName, playerDisplayName } from '../lib/display'
 import { formatCompactGameStatLine } from '../lib/statDisplay'
+import { teamInfoPath, teamStatsPath } from '../lib/teamInfo'
 
 interface TeamRow {
   id: string
@@ -387,7 +388,7 @@ export default function TournamentStats() {
     return (
       <div className="min-h-screen flex flex-col px-4 py-6 max-w-lg mx-auto">
         {error && <div className="card bg-red-50 text-red-700 text-sm mb-4">{error}</div>}
-        <button type="button" onClick={() => navigate(`/team-stats?teamId=${teamId}`)} className="btn-primary">
+        <button type="button" onClick={() => navigate(teamStatsPath(teamId))} className="btn-primary">
           Back to team stats
         </button>
       </div>
@@ -403,7 +404,7 @@ export default function TournamentStats() {
         <div className="max-w-lg mx-auto flex items-center gap-3">
           <button
             type="button"
-            onClick={() => navigate(`/team-stats?teamId=${teamId}`)}
+            onClick={() => navigate(teamInfoPath(teamId))}
             className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center active:scale-90 transition-transform"
           >
             ←
@@ -428,6 +429,14 @@ export default function TournamentStats() {
       </header>
 
       <div className="flex-1 px-4 py-6 max-w-lg mx-auto w-full space-y-4">
+        <button
+          type="button"
+          onClick={() => navigate(teamStatsPath(teamId))}
+          className="text-sm font-semibold text-blue-600"
+        >
+          Team stats →
+        </button>
+
         <section className="card space-y-2">
           <h2 className="font-semibold text-slate-700">Record</h2>
           <div className="flex gap-3 flex-wrap">


### PR DESCRIPTION
## Summary
- add Team Info → Start Game and route it to /setup?teamId=<id>
- teach Game Setup to preselect a requested cloud team, including direct-link sport lookup and invalid-team empty state
- route team-context back actions from Leaderboard, Team Stats, and Tournament Stats toward Team Info while preserving secondary stats links
- update regression coverage for the Start Game and back-link flows

## Verification
- pnpm.cmd test -- src/lib/teamInfo.test.ts
- pnpm.cmd lint (existing Fast Refresh warnings in context files)
- pnpm.cmd build (existing chunk-size warning)