### PR TITLE
docs: clean up roadmap and completed-plan drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ The dev server starts at `http://localhost:5173`.
 ### Supabase Setup (optional)
 
 1. Create a project at [supabase.com](https://supabase.com)
-2. Copy `.env.example` to `.env` and fill in your project URL and anon key:
+2. Copy `.env.example` to `.env` and fill in your project URL and key (prefer **publishable**; **anon** still works as a fallback — see `src/lib/supabase.ts`):
    ```
    VITE_SUPABASE_URL=https://your-project.supabase.co
-   VITE_SUPABASE_ANON_KEY=your-anon-key
+   VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
+   # Legacy fallback still accepted:
+   # VITE_SUPABASE_ANON_KEY=your-anon-key
    ```
 3. Run the migration SQL files in order via the Supabase SQL Editor:
    - `supabase/migrations/001_profiles.sql`
@@ -129,7 +131,7 @@ StatKeeper is deployed to **GitHub Pages** via GitHub Actions. Each push to the 
 | **Trigger** | Push to `stattracker` branch |
 | **Build** | `pnpm build` with Supabase env vars from GitHub Actions secrets |
 
-Supabase credentials (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`) must be set as [GitHub repository secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) for cloud features to work in production. See [`GITHUB_PAGES_DEPLOY.md`](GITHUB_PAGES_DEPLOY.md) for setup steps.
+Supabase credentials must be set as [GitHub repository secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) for cloud features to work in production. The deploy workflow currently passes `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`; locally prefer `VITE_SUPABASE_PUBLISHABLE_KEY` (anon remains accepted). See [`GITHUB_PAGES_DEPLOY.md`](GITHUB_PAGES_DEPLOY.md) for setup steps.
 
 ### Other Commands
 
@@ -339,28 +341,21 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 
 ### What's Next
 
-- [ ] **Court capture held items** — F10 visible numbering is superseded by F13; F11 quick buttons and F13 shot detail/editing are held pending further user feedback ([roadmap](docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md), [F13 plan](docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md))
 - [ ] **Multi-game parking + sync queue** — multiple in-progress/paused games per device, offline-safe snapshots, ordered cloud sync ([plan](docs/PLAN_MULTI_GAME_PARKING.md))
 - [ ] **Stat view follow-ups** — the major career/season/team/tournament stat views are shipped; use [DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md) and [completed/STAT_TRACKING_UI_PROGRESS.md](docs/completed/STAT_TRACKING_UI_PROGRESS.md) as references for smaller refinements
 - [ ] Team collaboration invites: multi-parent workflows, invite links (design: [DESIGN_MULTI_PARENT_INVITE_LINKS.md](docs/archived/DESIGN_MULTI_PARENT_INVITE_LINKS.md))
 - [ ] Per-sport stat refinements and additional stats (minutes for hockey/soccer/football, missed shots for hockey)
 - [ ] Player transfer UI: search/autocomplete for adding existing players to new teams (player pool / Add Existing already ships; this is UX polish)
+- [ ] Optional stat descriptions — toggle full stat names vs abbreviations
+- [ ] Bulk / archive games — beyond per-row delete in Games and Settings Data Management
 
-### Future Enhancements
+### Held / waiting for feedback
 
-A backlog of ideas to iterate over:
+- **Court capture F11 / F13** — F10 visible numbering is superseded by F13; F11 quick buttons and F13 shot detail/editing are held pending further user feedback ([roadmap](docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md), [F13 plan](docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md))
 
-1. **Manual home team score** — Add the ability to update the home team score just like the away team; disconnect game score completely from player stats (home score is currently auto-computed from player stats). *Implemented: home score = computed from player stats + editable adjustment (+/− buttons on Scoreboard); adjustment persisted and synced (migration 015).*
-2. **Editable team names, player names, and tournaments** — Allow editing from the proper locations; editing and sync work for both local and cloud. *Implemented: team name + nickname editable from Teams page; player first/last name, jersey number, nickname editable from Teams roster; opponent name editable from Games history (inline edit). Tournaments as first-class entity — `tournaments` table (migration 016) with team-scoped picker in Game Setup; games reference `tournament_id`. Design: [DESIGN_TOURNAMENTS.md](docs/completed/DESIGN_TOURNAMENTS.md).*
-4. **Minutes played, game notes, missed shots** — Extend stat tracking. *Implemented: minutes played as per-player counter in basketball (stat `min`, Playmaking category); game notes with free-text field in Game Tracker and Game Summary, synced to cloud (migration 017); missed shots for basketball with [−][A][+] attempt buttons and M/A (%) columns in Game Summary.*
-5. **Delete editable entities** — Ability to delete all editable things (teams, players, tournaments, games, etc.). Every delete action shows a confirmation prompt with Yes/No buttons before proceeding. *Implemented: delete teams, players (hard delete), games, and tournaments from the Teams page, Games page, Game Setup tournament picker, and a centralized Data Management section in Settings (Admin). All deletes show a confirmation dialog. Cascading deletes handled by Supabase FK constraints (`ON DELETE CASCADE`).*
-6. **Score totals in game list** — *Implemented for final and in-progress Cloud Games cards via F4; scheduled 0-0 games hide the score.*
-7. **Optional stat descriptions** — Toggle to display full stat names (e.g., "Free Throw") instead of abbreviated labels (e.g., "FT"); or optionally show stat descriptions.
-8. **Games tied to season** — Determine how games are tied to an individual season (e.g., team has season field; games inherit or reference it; season filter in leaderboard). *Implemented: `seasons` table as top-level entity (migration 018); teams belong to a season via `season_id` FK; games inherit season through their team; season filter in Game Setup; season CRUD in Settings. Design: [DESIGN_SEASONS_DATA_MODEL.md](docs/completed/DESIGN_SEASONS_DATA_MODEL.md).*
-9. **Clean up existing games** — A way to clean up existing games (delete, archive, or bulk actions). *Partially addressed by enhancement #5 (delete games individually from Games page and Data Management in Settings). Bulk actions and archive not yet implemented.*
-10. **Data integrity & creation order** — Migration **`019` applied** on the database (sport CHECK, unique team per season, active jersey uniqueness, `games.season_id` + triggers, tournament/team validation). App aligns `cloudSync` and Game Setup / Teams. Full plan and checklist: [docs/completed/DATA_INTEGRITY_AND_CREATION_PLAN.md](docs/completed/DATA_INTEGRITY_AND_CREATION_PLAN.md). Regression: [docs/REGRESSION_TESTING.md](docs/REGRESSION_TESTING.md) §13.
-11. *(Add more as we go)*
+### Shipped history (formerly Future Enhancements)
 
+Earlier backlog items that are already done (see What’s Done above for detail): home score adjustment (015), editable names/tournaments (016), minutes/notes/missed shots (017), entity deletes, in-progress/final scores on resume UI (F4), seasons on games (018), data-integrity migration **019**.
 ### Known Issues
 
 1. **Verify historical duplicate final/in-progress listing** — Older docs noted that a completed cloud game could appear as both final and in progress after finalization. Re-test this against the current Cloud Games flow before treating it as an active bug; if it still reproduces, fix the finalization/list filtering path.

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 ### Shipped history (formerly Future Enhancements)
 
 Earlier backlog items that are already done (see What’s Done above for detail): home score adjustment (015), editable names/tournaments (016), minutes/notes/missed shots (017), entity deletes, in-progress/final scores on resume UI (F4), seasons on games (018), data-integrity migration **019**.
+
 ### Known Issues
 
 1. **Verify historical duplicate final/in-progress listing** — Older docs noted that a completed cloud game could appear as both final and in progress after finalization. Re-test this against the current Cloud Games flow before treating it as an active bug; if it still reproduces, fix the finalization/list filtering path.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Supabase credentials (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`) must be set
 
 ```bash
 pnpm build      # TypeScript check + production build
+pnpm test       # Vitest unit tests
 pnpm preview    # Serve the production build locally (port 4173)
 pnpm lint       # Run ESLint
 ```
@@ -177,12 +178,17 @@ src/
 │   ├── GameSetup.tsx      # Enter game info (teams, tournament, date)
 │   ├── PlayerSetup.tsx    # Add/remove players
 │   ├── GameCheckout.tsx   # Pre-game player checkout (cloud teams)
-│   ├── GameTracker.tsx    # Live stat tracking interface
+│   ├── GameTracker.tsx    # Live stat tracking interface (basketball: inline court)
 │   ├── GameSummary.tsx    # Post-game stat tables (resolved stats + admin corrections)
 │   ├── Games.tsx          # Cloud game history, resume/final flows, delete games
-│   ├── Teams.tsx          # Cloud team + roster management + invites + delete
+│   ├── Teams.tsx          # Cloud team list/create + /team/manage roster/members/merge
+│   ├── TeamInfo.tsx       # Team hub (/team) — overview, Start Game, stats links
+│   ├── TeamRoster.tsx     # Read-only roster drill-down (/team/roster)
+│   ├── TeamSchedule.tsx   # Team schedule drill-down (/team/schedule)
+│   ├── SeasonInfo.tsx     # Season detail (/team/season)
+│   ├── GameInfo.tsx       # Single cloud game detail (/game-info)
 │   ├── Leaderboard.tsx    # Season leaderboard (season + team scope, sortable)
-│   ├── PlayerProfile.tsx  # Player season totals, game log with inline stats, career link
+│   ├── PlayerProfile.tsx  # /player and /player-info shared profile
 │   ├── CareerStats.tsx    # Career stats (/career)
 │   ├── TeamStats.tsx      # Team season summary (/team-stats)
 │   ├── TournamentStats.tsx # Tournament stats (/tournament-stats)
@@ -192,6 +198,8 @@ src/
 │   ├── Scoreboard.tsx     # Live score display
 │   ├── StatButton.tsx     # Reusable stat increment/decrement button
 │   ├── SeasonTeamStatsEditor.tsx  # Admin: season team-stat rules (basketball)
+│   ├── shot-chart/        # Half-court SVG, CourtEventPopup, ShotChartPanel
+│   ├── team-info/         # TeamHero, overview cards, GameCard, PlayerRow
 │   └── team-stats/        # PeriodToggle, BasketballBonusIndicator, TeamStatSummary
 ├── types.ts               # TypeScript interfaces
 ├── App.tsx                # Router + providers + auth gate
@@ -239,23 +247,25 @@ supabase/scripts/
 └── normalize_exhibition_games.sql   # Identify/link/clear legacy exhibition tournament_name rows
 
 docs/
+├── AGENT_CODEBASE_OVERVIEW.md # Agent/contributor entry: routes, sync, doc workflow
 ├── INTEGRATION_PLAN.md    # Supabase architecture & phases (§1 schema summary = post-018; see migrations)
 ├── DESIGN_STAT_TRACKING_UI.md    # Design: Career/season/game views (living doc; progress table)
-├── DESIGN_TEAM_INFO_PAGE.md # Team hub / drill-down (implementation plan; not built)
+├── DESIGN_TEAM_INFO_PAGE.md # Team hub / drill-down (shipped V1 design reference)
+├── DESIGN_SHOT_TRACKER_UI_REVAMP.md # Court-capture program status (F1–F13)
+├── PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md # F5–F13 roadmap; F11/F13 held
+├── PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md # Held draft: shot detail / edit
 ├── PLAN_MULTI_GAME_PARKING.md # Roadmap: multiple parked games + sync queue (not shipped)
 ├── REGRESSION_TESTING.md  # High-level test scripts for all features
 ├── completed/             # Shipped features — design & implementation references
+│   ├── PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md
+│   ├── PLAN_F1…F9, PLAN_F12  # Court-capture feature plans (implemented)
 │   ├── DESIGN_SEASONS_DATA_MODEL.md
 │   ├── STAT_TRACKING_UI_PROGRESS.md
 │   ├── DESIGN_PHASE3_GAME_SUMMARY_ADMIN.md
 │   ├── DESIGN_TOURNAMENTS.md
 │   ├── DATA_INTEGRITY_AND_CREATION_PLAN.md
 │   ├── DESIGN_PLAYER_MERGE.md
-│   ├── DESIGN_TEAM_STATS_TRACKING.md
-│   ├── DESIGN_TEAM_STATS_BASKETBALL.md
-│   ├── DESIGN_TEAM_STATS_SEASON_CONFIG.md
-│   ├── DESIGN_TEAM_STATS_DATA_MODEL.md
-│   ├── DESIGN_TEAM_STATS_IMPLEMENTATION.md
+│   ├── DESIGN_TEAM_STATS_*.md
 │   ├── DESIGN_SHOT_CHART.md
 │   └── DESIGN_SHOT_CHART_IMPLEMENTATION.md
 └── archived/              # Future / placeholder / not-built specs
@@ -263,6 +273,8 @@ docs/
     ├── DESIGN_MULTI_PARENT_INVITE_LINKS.md
     └── DESIGN_USER_PERMISSIONS_AND_ROLES.md
 ```
+
+> Full route table and file map: [`docs/AGENT_CODEBASE_OVERVIEW.md`](docs/AGENT_CODEBASE_OVERVIEW.md).
 
 ### Testing
 
@@ -323,15 +335,16 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 - [x] **Team-level stat tracking (basketball)** — pseudo-players `__team_home__` / `__team_opp__`, `teamCategories` in `sports.ts`, period-scoped stat ids (`team_foul_p1`, …), bonus UI, season rules in `seasons.team_stats_config` (Admin → Seasons), cloud placeholder players + `get_game_team_stats`, checkout + Game Summary **Team stats** tab (design: [DESIGN_TEAM_STATS_TRACKING.md](docs/completed/DESIGN_TEAM_STATS_TRACKING.md))
 
 - [x] **Team Info hub + drill-downs** — canonical `/team?teamId=` route with overview, roster, schedule, player/game/season drill-downs, Start Game preselect, and `/team/manage?teamId=` management migration ([plan](docs/completed/PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md))
+- [x] **Court capture enhancements (F5–F9, F12)** — shot-value override, in-popup player switch, assist-linking, popup stat line, rebound-after-miss prompt, recent-events undo ([roadmap](docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md))
 
 ### What's Next
 
-- [ ] **Court capture polish** — F5 shot-value override, F6 in-popup player switching, F12 recent-events undo, F7 assist-linking, F8 popup stat line, and F9 rebound-after-miss prompt are implemented; F10 visible numbering is superseded by F13, and both F11 quick buttons and F13 shot detail/editing are held pending further user feedback ([roadmap](docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md), [F13 plan](docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md))
+- [ ] **Court capture held items** — F10 visible numbering is superseded by F13; F11 quick buttons and F13 shot detail/editing are held pending further user feedback ([roadmap](docs/PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md), [F13 plan](docs/PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md))
 - [ ] **Multi-game parking + sync queue** — multiple in-progress/paused games per device, offline-safe snapshots, ordered cloud sync ([plan](docs/PLAN_MULTI_GAME_PARKING.md))
 - [ ] **Stat view follow-ups** — the major career/season/team/tournament stat views are shipped; use [DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md) and [completed/STAT_TRACKING_UI_PROGRESS.md](docs/completed/STAT_TRACKING_UI_PROGRESS.md) as references for smaller refinements
 - [ ] Team collaboration invites: multi-parent workflows, invite links (design: [DESIGN_MULTI_PARENT_INVITE_LINKS.md](docs/archived/DESIGN_MULTI_PARENT_INVITE_LINKS.md))
 - [ ] Per-sport stat refinements and additional stats (minutes for hockey/soccer/football, missed shots for hockey)
-- [ ] Player transfer UI: search/autocomplete for adding existing players to new teams
+- [ ] Player transfer UI: search/autocomplete for adding existing players to new teams (player pool / Add Existing already ships; this is UX polish)
 
 ### Future Enhancements
 

--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -211,15 +211,20 @@ flowchart LR
 
 | Doc | Topic |
 |-----|-------|
+| [`PLAN_MULTI_GAME_PARKING.md`](PLAN_MULTI_GAME_PARKING.md) | Multiple parked games + sync queue (primary next roadmap item) |
+
+### Held / waiting for feedback
+
+| Doc | Topic |
+|-----|-------|
 | [`DESIGN_SHOT_TRACKER_UI_REVAMP.md`](DESIGN_SHOT_TRACKER_UI_REVAMP.md) | Court-capture program status (F1–F13) |
 | [`PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md`](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | Court-capture roadmap; F10 superseded by F13 |
-| [`PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md`](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md) | Held draft plan for shot detail, linked metadata, and editing |
-| [`PLAN_MULTI_GAME_PARKING.md`](PLAN_MULTI_GAME_PARKING.md) | Multiple parked games + sync queue |
+| [`PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md`](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md) | Held draft: shot detail, linked metadata, and editing |
 
 **Court program status:** F1-F9 and F12 are implemented; manual Supabase-heavy QA remains in
 [`REGRESSION_TESTING.md`](REGRESSION_TESTING.md). F10 standalone marker numbering is no
-longer needed and is superseded by F13 shot detail/edit planning. F11 and F13 are both
-held pending further user feedback. See also [`DESIGN_SHOT_TRACKER_UI_REVAMP.md`](DESIGN_SHOT_TRACKER_UI_REVAMP.md).
+longer needed and is superseded by F13. F11 and F13 are held pending further user feedback —
+do not start them without explicit go-ahead.
 
 ### Verification norms
 

--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -211,6 +211,7 @@ flowchart LR
 
 | Doc | Topic |
 |-----|-------|
+| [`DESIGN_SHOT_TRACKER_UI_REVAMP.md`](DESIGN_SHOT_TRACKER_UI_REVAMP.md) | Court-capture program status (F1–F13) |
 | [`PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md`](PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md) | Court-capture roadmap; F10 superseded by F13 |
 | [`PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md`](PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md) | Held draft plan for shot detail, linked metadata, and editing |
 | [`PLAN_MULTI_GAME_PARKING.md`](PLAN_MULTI_GAME_PARKING.md) | Multiple parked games + sync queue |
@@ -218,7 +219,7 @@ flowchart LR
 **Court program status:** F1-F9 and F12 are implemented; manual Supabase-heavy QA remains in
 [`REGRESSION_TESTING.md`](REGRESSION_TESTING.md). F10 standalone marker numbering is no
 longer needed and is superseded by F13 shot detail/edit planning. F11 and F13 are both
-held pending further user feedback.
+held pending further user feedback. See also [`DESIGN_SHOT_TRACKER_UI_REVAMP.md`](DESIGN_SHOT_TRACKER_UI_REVAMP.md).
 
 ### Verification norms
 

--- a/docs/DESIGN_STAT_TRACKING_UI.md
+++ b/docs/DESIGN_STAT_TRACKING_UI.md
@@ -19,9 +19,13 @@ Detailed checklist: [completed/STAT_TRACKING_UI_PROGRESS.md](completed/STAT_TRAC
 
 ---
 
-## 1. Current State
+## 1. Historical baseline (pre-ship)
 
-### 1.1 Existing Pages
+> The tables below describe the app **before** the career/season/team/tournament views
+> shipped. All items in the Progress table above are **Done**. Use this section only as
+> context for why the redesign existed — do not treat §1.2 gaps as current backlog.
+
+### 1.1 Existing pages (at design time)
 
 | Page | Route | What it shows | Data source |
 |------|-------|---------------|-------------|
@@ -29,13 +33,13 @@ Detailed checklist: [completed/STAT_TRACKING_UI_PROGRESS.md](completed/STAT_TRAC
 | **Leaderboard** | `/leaderboard` | Team-scoped season totals; ranked by score or any stat; click → Player Profile | `get_season_stats_resolved` RPC |
 | **Player Profile** | `/player?teamId=&playerId=` | One player's season totals (grid of stat cards) + game log (list of games with "View" button) | `get_season_stats_resolved` RPC filtered to one player; `game_stats` for game log |
 
-### 1.2 Gaps
+### 1.2 Gaps (at design time — now closed)
 
-- **No career view.** A player who played on multiple teams across seasons has no way to see lifetime totals or a per-season breakdown.
-- **No season scoping.** Leaderboard and Player Profile are scoped to a team, which currently IS a season. After the seasons redesign, we need explicit season selectors.
-- **Game Summary is combined.** Player stats and team totals are in the same table. No dedicated team stats view or standalone per-player game stat line.
-- **No per-game stat detail on Player Profile.** The game log shows the game list but no inline stat lines — you have to click "View" to load the full Game Summary.
-- **No team summary page.** No single page showing aggregated team stats across a season (total points scored, total rebounds, etc. as a team).
+- **No career view.** A player who played on multiple teams across seasons has no way to see lifetime totals or a per-season breakdown. → **Shipped:** `/career`
+- **No season scoping.** Leaderboard and Player Profile are scoped to a team, which currently IS a season. After the seasons redesign, we need explicit season selectors. → **Shipped:** season selector + `seasonId` URL
+- **Game Summary is combined.** Player stats and team totals are in the same table. No dedicated team stats view or standalone per-player game stat line. → **Shipped:** Players / Team tab; team season summary
+- **No per-game stat detail on Player Profile.** The game log shows the game list but no inline stat lines — you have to click "View" to load the full Game Summary. → **Shipped:** inline game log via RPC
+- **No team summary page.** No single page showing aggregated team stats across a season (total points scored, total rebounds, etc. as a team). → **Shipped:** `/team-stats`
 
 ---
 

--- a/docs/INTEGRATION_PLAN.md
+++ b/docs/INTEGRATION_PLAN.md
@@ -429,11 +429,11 @@ CREATE POLICY "corrections_admin_update" ON stat_corrections
 7. Corrections flow through to future season/leaderboard views when those UIs call get_game_stats_resolved / get_season_stats_resolved.
 ```
 
-**Future enhancements:** Full side-by-side comparison of all parent submissions per player, explicit review queue for averaged/conflicting stats, and reassign-primary-checkout UI are still on the roadmap; the current implementation provides inline per-stat corrections from the existing summary table.
+**Shipped on Game Summary:** Primary vs All Submissions toggle, conflict indicators, "Stats needing review," reassign primary recorder (`set_primary_recorder`), and inline per-stat corrections. A dedicated full-page side-by-side review UI (beyond the All Submissions toggle) remains optional polish, not required for Phase 3.
 
 ### 3.6 UI Flow
 
-**Implemented screens:** Checkout screen → `GameCheckout.tsx` (route `/checkout`). Game Tracker → `GameTracker.tsx`. Game Summary and admin review → `GameSummary.tsx` (review mode with per-stat corrections). Full "All submissions" comparison view is still on the roadmap.
+**Implemented screens:** Checkout screen → `GameCheckout.tsx` (route `/checkout`). Game Tracker → `GameTracker.tsx`. Game Summary and admin review → `GameSummary.tsx` (Primary/All toggle, review mode with per-stat corrections, primary-recorder reassignment).
 
 **Before the game — Checkout Screen:**
 ```
@@ -462,7 +462,7 @@ CREATE POLICY "corrections_admin_update" ON stat_corrections
 **After the game — Game Summary:**
 - Shows resolved stats (primary recorder per player, or admin correction if present) for finalized cloud games via `get_game_stats_resolved`.
 - Team owner/admin can tap "Review / Correct stats" to enter review mode; pencil icon on each stat opens a correction modal (new value + optional reason).
-- "All submissions" toggle and full side-by-side comparison are planned future enhancements.
+- **Primary View** vs **All Submissions** toggle is shipped on Game Summary for finalized cloud games; a separate full-page side-by-side review remains optional polish.
 
 ### 3.7 Season Stats with Checkout + Corrections
 
@@ -504,7 +504,7 @@ This means:
 - If a primary checkout is reassigned, season totals recalculate from the new primary
 - No separate "recalculate season" step is ever needed — it's always derived
 
-**Current UI:** Season stats UI (player profiles, team leaderboards) is planned to consume `get_season_stats_resolved`; the current implementation focuses on per-game resolution in Game Summary.
+**Current UI:** Season stats UIs **shipped** and consume `get_season_stats_resolved` (and related RPCs): Leaderboard, Player Profile, Career (`get_career_stats_resolved`), Team Stats, Tournament Stats. See [DESIGN_STAT_TRACKING_UI.md](DESIGN_STAT_TRACKING_UI.md). Per-game resolution remains on Game Summary via `get_game_stats_resolved`.
 
 ### 3.8 Edge Cases
 
@@ -623,14 +623,15 @@ To enable cross-device deterministic active-game preference, apply `007_games_la
 - [x] Team invite system — invite by email (owner/admin), accept/decline, roles, member list (migration 011)
 - [x] Game Summary: "Primary View" vs "All Submissions" toggle (design: [completed/DESIGN_PHASE3_GAME_SUMMARY_ADMIN.md](completed/DESIGN_PHASE3_GAME_SUMMARY_ADMIN.md))
 - [x] Admin: reassign primary checkout after a game (Game Summary "Primary recorder" section; RPC `set_primary_recorder`, migration 014)
-- [ ] Admin: stat review page with side-by-side parent submissions
+- [ ] Admin: dedicated full-page side-by-side parent submissions (optional; All Submissions toggle + review queue already on Game Summary)
 - [x] Admin: correct individual stats with reason (audit trail) — inline in Game Summary review mode
 - [x] Admin: review queue for unresolved discrepancies (averaged stats) — "Stats needing review" section on Game Summary with Correct / Set primary recorder links
 - [x] Player profile page with season totals and game log
 - [x] Team leaderboard page (uses resolved totals)
 - [x] Conflict indicator when multiple parents tracked same player without checkout
-- [x] **Basketball shot chart** — `/shot-chart`, migration **032**, sync in `cloudSync.ts`
+- [x] **Basketball court capture / shot chart** — inline on Game Tracker (`#/game`); legacy `#/shot-chart` redirects; migration **032**; sync in `cloudSync.ts`
 - [x] **Basketball team stats** — pseudo-players, `seasons.team_stats_config`, migrations **027–031**, Game Summary team tab
+- [x] **Team Info hub** — `/team?teamId=` plus roster/schedule/season/game/player drill-downs and `/team/manage` ([DESIGN_TEAM_INFO_PAGE.md](DESIGN_TEAM_INFO_PAGE.md))
 - [x] **Sync diagnostics** — `client_sync_errors` (**033**), `logClientSyncError.ts`, UUID validation for `playerIdMap` (`uuidValidation.ts`)
 - [ ] Invite links: shareable URL to join team (design: [archived/DESIGN_MULTI_PARENT_INVITE_LINKS.md](archived/DESIGN_MULTI_PARENT_INVITE_LINKS.md))
 
@@ -687,11 +688,12 @@ The `VITE_` prefix is required by Vite to expose variables to the browser. The p
 
 > **Note:** Many items that historically lived in this backlog are **already shipped** (home score adjustment, tournaments table, minutes, notes, missed shots, deletes, seasons on games, etc.). Treat the **README** “Features / What’s Done” sections as the live checklist. What follows is a **short residual backlog**; older numbered items were archived into README where implemented.
 
-1. **Score totals in game list** — Games history list could show home vs opponent score on each card (partially improved; refine as needed).
-2. **Optional stat descriptions** — Toggle for full stat names vs abbreviations.
-3. **Bulk / archive games** — Beyond per-row delete in Games and Settings Data Management.
-4. **Multi-game parking + sync queue** — Multiple in-progress sessions per device, offline-safe; see [PLAN_MULTI_GAME_PARKING.md](PLAN_MULTI_GAME_PARKING.md).
-5. *(Add more as we go)*
+1. **Optional stat descriptions** — Toggle for full stat names vs abbreviations.
+2. **Bulk / archive games** — Beyond per-row delete in Games and Settings Data Management.
+3. **Multi-game parking + sync queue** — Multiple in-progress sessions per device, offline-safe; see [PLAN_MULTI_GAME_PARKING.md](PLAN_MULTI_GAME_PARKING.md).
+4. *(Add more as we go)*
+
+> **Shipped (removed from residual backlog):** in-progress and final scores on Cloud Games / home resume cards (F4); Team Info hub ([DESIGN_TEAM_INFO_PAGE.md](DESIGN_TEAM_INFO_PAGE.md)).
 
 ---
 
@@ -726,12 +728,14 @@ src/
 │   ├── AuthContext.tsx, GameContext.tsx, SettingsContext.tsx
 ├── pages/
 │   ├── Auth, SportSelect, GameSetup, PlayerSetup, GameCheckout, GameTracker
-│   ├── GameSummary, Games, Teams, Admin, Leaderboard, PlayerProfile
+│   ├── GameSummary, Games, Teams (/teams + /team/manage), Admin
+│   ├── TeamInfo, TeamRoster, TeamSchedule, SeasonInfo, GameInfo
+│   ├── Leaderboard, PlayerProfile (/player + /player-info)
 │   ├── CareerStats (/career), TeamStats (/team-stats), TournamentStats (/tournament-stats)
-│   ├── ShotChart (/shot-chart), ShotChartPreview (dev: /dev/shot-chart)
+│   ├── ShotChart (legacy redirect → /game), ShotChartPreview (dev: /dev/shot-chart)
 ├── App.tsx                  # HashRouter routes
 supabase/migrations/
 │   └── 001 … 033 (see README for full names: through client_sync_errors)
 ```
 
-Admin review and stat corrections live in **Game Summary**, not a separate `AdminReview` page.
+Admin review and stat corrections live in **Game Summary**, not a separate `AdminReview` page. Court capture is **inline on Game Tracker**; see [AGENT_CODEBASE_OVERVIEW.md](AGENT_CODEBASE_OVERVIEW.md) for the full route table and [DESIGN_TEAM_INFO_PAGE.md](DESIGN_TEAM_INFO_PAGE.md) for the Team Info hierarchy.

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -54,6 +54,8 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 
 **Precondition:** Signed in; migrations 002, 004–006, 011 applied.
 
+> Team Info hub smoke (overview, drill-downs, Start Game, `from=team`) is consolidated in **§4h**.
+
 | Step | Action | Expected |
 |------|--------|----------|
 | 4.1 | Home → Teams | Cloud Teams page; Create Team form |
@@ -420,7 +422,7 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 - **HashRouter:** In-app links use hash routes (e.g. `/#/game`, `/#/teams`).  
 - **Shot chart SVG (dev QA):** `/#/dev/shot-chart` — see **§4d** above (`ShotChartPreview.tsx` + optional auth bypass in `App.tsx` only in dev). End-user court capture is inline on `/#/game` — see **§4e**; legacy `/#/shot-chart` redirects there.
 - **localStorage:** Game and settings key `statkeeper_game`; clear to reset local state.  
-- **Migrations:** If a script fails on cloud features, confirm migrations through **019** are applied in Supabase SQL Editor when using seasons, `team_players`, and data-integrity constraints (`019_data_integrity_constraints.sql`). Run `supabase/scripts/audit_data_integrity_pre_019.sql` before `019` if upgrading an existing project. For **player merge** (Teams → Merge players), apply **`024_player_merge_rpcs.sql`** ([completed/DESIGN_PLAYER_MERGE.md](completed/DESIGN_PLAYER_MERGE.md)).
+- **Migrations:** If a script fails on cloud features, confirm the migrations listed in [README.md](../README.md) (through **`033_client_sync_errors.sql`**) are applied in the Supabase SQL Editor. Seasons / `team_players` / integrity need **019** (run `supabase/scripts/audit_data_integrity_pre_019.sql` before **019** on legacy DBs). Player merge needs **024**/**025**. Team stats need **028–031**. Shot chart needs **032**. Sync diagnostics need **033**.
 
 ---
 

--- a/docs/completed/DATA_INTEGRITY_AND_CREATION_PLAN.md
+++ b/docs/completed/DATA_INTEGRITY_AND_CREATION_PLAN.md
@@ -2,7 +2,7 @@
 
 This document captures a planned set of database and application changes to reduce drift after schema evolution (especially migration 018: seasons, `team_players`, `players.created_by`), align team/season creation across UI paths, and enforce clearer rules for required fields and insert order.
 
-**Status:** Database Phase A audit and migration **`019` are applied** on the production-ready database. App changes (`cloudSync`, Game Setup, Teams) are in the codebase. **Next:** run a full app regression (see checklist §5 and [`REGRESSION_TESTING.md`](../REGRESSION_TESTING.md), including §13).
+**Status:** Database Phase A audit and migration **`019` are applied** on the production-ready database. App changes (`cloudSync`, Game Setup, Teams) are in the codebase. **Maintenance:** after applying **019** (or importing legacy data), re-run the integrity checklist in §5 and [`REGRESSION_TESTING.md`](../REGRESSION_TESTING.md) §13 as an on-upgrade sanity check — not open feature work.
 
 For **new** environments or clones, still run `supabase/scripts/audit_data_integrity_pre_019.sql` before `019` if you are importing legacy data that might violate constraints.
 

--- a/docs/completed/DESIGN_PLAYER_MERGE.md
+++ b/docs/completed/DESIGN_PLAYER_MERGE.md
@@ -2,7 +2,7 @@
 
 Merge two `players` rows when one was created by mistake: **reattach** all dependent data to the **survivor**, resolve uniqueness conflicts (with **user choices** where needed), then **delete** the duplicate row.
 
-**Status:** Product decisions locked (§5). Ready for implementation.
+**Status:** **Implemented.** Merge wizard ships on `/team/manage` (and Admin) via `MergePlayerWizard`; RPCs and audit table are migrations **024** / **025**.
 
 **Related:** [DATA_INTEGRITY_AND_CREATION_PLAN.md](DATA_INTEGRITY_AND_CREATION_PLAN.md), [DESIGN_SEASONS_DATA_MODEL.md](DESIGN_SEASONS_DATA_MODEL.md).
 

--- a/docs/completed/DESIGN_TEAM_STATS_TRACKING.md
+++ b/docs/completed/DESIGN_TEAM_STATS_TRACKING.md
@@ -280,6 +280,8 @@ This keeps the door open for radically different UIs per sport without over-engi
 
 ### Phase Ordering Recommendation
 
+> **Historical implementation order** (basketball V1 is shipped). Do not re-run Phases 1–9 as new work; Phase 10 (additional sports) remains optional follow-on.
+
 Start with **Phases 1–3** (types, injection, category switching) to get the core flow working locally. Then **Phase 6** (season config) so the bonus thresholds are configurable before building **Phase 4** (bonus indicators). **Phase 5** (summary) and **Phase 7** (cloud sync) can proceed in parallel. **Phase 8–9** are low-effort cleanup. **Phase 10** is ongoing as each sport is designed.
 
 ---

--- a/docs/completed/PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md
+++ b/docs/completed/PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md
@@ -1,5 +1,7 @@
 # Feature 1 Plan: Single-Page Game Tracker + Court Event Capture (Option A)
 
+> **Status:** Implemented.
+>
 > **For agentic workers:** Design + implementation plan. Steps use checkbox (`- [ ]`)
 > syntax. See the umbrella [DESIGN_SHOT_TRACKER_UI_REVAMP.md](../DESIGN_SHOT_TRACKER_UI_REVAMP.md)
 > for shared context. Follow-on enhancements live in

--- a/docs/completed/PLAN_F2_PER_PLAYER_AND_TEAM_SHOT_VIEWS.md
+++ b/docs/completed/PLAN_F2_PER_PLAYER_AND_TEAM_SHOT_VIEWS.md
@@ -1,5 +1,7 @@
 # Feature 2 Plan: Per-Player Shot Tracker + Team Views
 
+> **Status:** Implemented.
+>
 > **For agentic workers:** Design + implementation plan. Steps use checkbox (`- [ ]`)
 > syntax. See [DESIGN_SHOT_TRACKER_UI_REVAMP.md](../DESIGN_SHOT_TRACKER_UI_REVAMP.md) for
 > shared context. Depends on **F1** ([PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md](PLAN_F1_GAME_TRACKER_COURT_CAPTURE.md))

--- a/docs/completed/PLAN_F3_CLOUD_GAME_SHOT_CHARTS.md
+++ b/docs/completed/PLAN_F3_CLOUD_GAME_SHOT_CHARTS.md
@@ -1,5 +1,7 @@
 # Feature 3 Plan: Shot Trackers Viewable on Cloud-Saved Games
 
+> **Status:** Implemented (two-user cloud QA still recommended in REGRESSION_TESTING).
+>
 > **For agentic workers:** Design + implementation plan. Steps use checkbox (`- [ ]`)
 > syntax. See [DESIGN_SHOT_TRACKER_UI_REVAMP.md](../DESIGN_SHOT_TRACKER_UI_REVAMP.md) for
 > shared context. Builds on **F1** (inline court, `ShotChartPanel`) and **F2**

--- a/docs/completed/PLAN_F4_IN_PROGRESS_SCORES_ON_RESUME_UI.md
+++ b/docs/completed/PLAN_F4_IN_PROGRESS_SCORES_ON_RESUME_UI.md
@@ -1,5 +1,7 @@
 # Feature 4 Plan: In-Progress Scores on the Resume Game UI
 
+> **Status:** Implemented.
+>
 > **For agentic workers:** Design + implementation plan. Steps use checkbox (`- [ ]`)
 > syntax. See [DESIGN_SHOT_TRACKER_UI_REVAMP.md](../DESIGN_SHOT_TRACKER_UI_REVAMP.md) for
 > shared context. **Independent** of F1–F3 — can land in any order.

--- a/docs/completed/PLAN_F5_AUTO_2_3_OVERRIDE.md
+++ b/docs/completed/PLAN_F5_AUTO_2_3_OVERRIDE.md
@@ -1,5 +1,7 @@
 # Feature 5 Plan: Auto 2/3 with Manual Override Chip
 
+> **Status:** Implemented.
+>
 > **For agentic workers:** Design + implementation plan. Steps use checkbox (`- [ ]`)
 > syntax. See [DESIGN_SHOT_TRACKER_UI_REVAMP.md](../DESIGN_SHOT_TRACKER_UI_REVAMP.md) and the
 > [enhancements roadmap](../PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md). **Depends on F1**

--- a/docs/completed/PLAN_F6_IN_POPUP_PLAYER_SWITCH.md
+++ b/docs/completed/PLAN_F6_IN_POPUP_PLAYER_SWITCH.md
@@ -1,5 +1,7 @@
 # Feature 6 Plan: In-Popup Player Confirm / Switch
 
+> **Status:** Implemented.
+>
 > **For agentic workers:** Design + implementation plan. Steps use checkbox (`- [ ]`)
 > syntax. See [DESIGN_SHOT_TRACKER_UI_REVAMP.md](../DESIGN_SHOT_TRACKER_UI_REVAMP.md) and the
 > [enhancements roadmap](../PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md). **Depends on F1**

--- a/docs/completed/PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md
+++ b/docs/completed/PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md
@@ -1,16 +1,16 @@
 # Team Info Drill-Down Implementation Plan
 
-> **For agentic workers:** Use `docs/DESIGN_TEAM_INFO_PAGE.md` as the product spec and this file as the execution guide. Work through the sections in order; each section is intended to be independently reviewable and testable.
+> **Historical — do not execute.** This plan is **shipped through TI-9**. Use
+> [`docs/DESIGN_TEAM_INFO_PAGE.md`](../DESIGN_TEAM_INFO_PAGE.md) as the living V1
+> design reference when extending Team Info. Do not re-run TI-1…TI-9 as new work.
 
-**Goal:** Build the Team Info drill-down hierarchy around a new team hub, then migrate roster, schedule, player, game, season, and stats entry points into that hierarchy without changing the current Supabase schema.
+**Goal (achieved):** Build the Team Info drill-down hierarchy around a team hub, then migrate roster, schedule, player, game, season, and stats entry points into that hierarchy without changing the Supabase schema.
 
-**Architecture:** Add a `/team?teamId=` hub route first, backed by existing Supabase tables, existing resolved-stat RPCs, and shared display helpers. Keep current stat pages (`/leaderboard`, `/player`, `/career`, `/team-stats`, `/tournament-stats`, `/summary`) working while the new drill-down pages are introduced in small slices.
+**Architecture:** `/team?teamId=` hub backed by existing Supabase tables, resolved-stat RPCs, and shared display helpers. Stat pages (`/leaderboard`, `/player`, `/career`, `/team-stats`, `/tournament-stats`, `/summary`) remain compatible.
 
 **Tech Stack:** React 18, TypeScript, Vite, Tailwind CSS, React Router `HashRouter`, Supabase client queries/RPCs, Vitest for pure helper tests, manual browser regression for route and mobile UI behavior.
 
-**Status:** Implemented through **TI-9**. TI-9 completes the final docs/regression polish slice.
-The shipped hierarchy is `/team?teamId=` plus `/team/roster`, `/team/schedule`,
-`/team/season`, `/game-info`, `/player-info`, `/team/manage`, and `/setup?teamId=`.
+**Status:** Implemented through **TI-9**. The shipped hierarchy is `/team?teamId=` plus `/team/roster`, `/team/schedule`, `/team/season`, `/game-info`, `/player-info`, `/team/manage`, and `/setup?teamId=`.
 
 ---
 
@@ -18,13 +18,13 @@ The shipped hierarchy is `/team?teamId=` plus `/team/roster`, `/team/schedule`,
 
 | Plan | Current relevance | Decision |
 |---|---|---|
-| `docs/DESIGN_TEAM_INFO_PAGE.md` | Primary feature spec for the team hub and drill-down hierarchy. | Focus here first. It is the most direct next feature and can reuse shipped stats work. |
-| `docs/DESIGN_STAT_TRACKING_UI.md` | Most prerequisite stats pages are shipped: leaderboard, player profile, career, team stats, tournament stats, compact stat helpers. | Treat as foundation. Link into these pages instead of rebuilding their data views. |
-| `docs/completed/DESIGN_SEASONS_DATA_MODEL.md` | Seasons, `team_players`, player guardians, and team-scoped games are already the current model. | Use as schema source of truth. Do not add tables for this feature. |
-| `docs/completed/DESIGN_TOURNAMENTS.md` | Tournaments are team-scoped and already feed tournament stats and game setup. | Reuse for team overview cards and schedule grouping. |
-| `docs/archived/DESIGN_NAVIGATION_SEASONS_TOURNAMENTS.md` | Broader Sport -> Season -> Team -> Tournament navigation concept. | Defer broad navigation replacement until the team hub exists. The hub becomes the team-level destination inside that larger hierarchy. |
+| `docs/DESIGN_TEAM_INFO_PAGE.md` | Shipped V1 design reference for the team hub and drill-downs. | **Reference / extend only** — do not treat as a greenfield build. |
+| `docs/DESIGN_STAT_TRACKING_UI.md` | Prerequisite stats pages are shipped: leaderboard, player profile, career, team stats, tournament stats, compact stat helpers. | Treat as foundation. Link into these pages instead of rebuilding their data views. |
+| `docs/completed/DESIGN_SEASONS_DATA_MODEL.md` | Seasons, `team_players`, player guardians, and team-scoped games are the current model. | Use as schema source of truth. Do not add tables for Team Info extensions unless required. |
+| `docs/completed/DESIGN_TOURNAMENTS.md` | Tournaments are team-scoped and feed tournament stats and game setup. | Reuse for team overview cards and schedule grouping. |
+| `docs/archived/DESIGN_NAVIGATION_SEASONS_TOURNAMENTS.md` | Broader Sport -> Season -> Team -> Tournament navigation concept. | Still deferred; Team Info is the team-level destination inside that larger hierarchy. |
 | `docs/INTEGRATION_PLAN.md` | Live integration status and regression surface for Supabase teams, games, invites, stats, shot chart, and team stats. | Use for constraints and regression coverage. |
-| `docs/REGRESSION_TESTING.md` | Manual scripts for cloud teams, games, season stats, tournaments, invites, and smoke tests. | Extend after each section that changes navigation. |
+| `docs/REGRESSION_TESTING.md` | Manual scripts including Team Info §4 / §4h smoke. | Extend when navigation or hub behavior changes. |
 
 ---
 
@@ -38,11 +38,11 @@ The feature shipped as the planned series of small PRs:
 - **TI-8:** Team Info Start Game uses `/setup?teamId=`, Game Setup preselects cloud teams, and team-context back links return to Team Info without breaking global home shortcuts.
 - **TI-9:** Final regression/docs polish and full validation.
 
-The original implementation guidance below is kept as historical execution context.
-
 ---
 
-## 2a. Original recommended focus
+## 2a. Original recommended focus (historical)
+
+> The sections below (TI-0…TI-9 task detail) are **historical execution context**. Do not treat unchecked boxes or “start with TI-1” language as current backlog.
 
 Start with **TI-1: Team Info hub MVP + minimal navigation shell**.
 


### PR DESCRIPTION
## Summary
- Align README What’s Done/Next and project structure with shipped Team Info and court-capture (F5–F9/F12 done; F11/F13 held)
- Mark completed plans as historical/implemented (Team Info, Player Merge, Data Integrity, Team Stats, F1–F6 status lines)
- Reframe DESIGN_STAT_TRACKING_UI §1 as pre-ship baseline; update INTEGRATION_PLAN season stats / All toggle / shot chart / Team Info; regression migrations footer through 033

## Test plan
- [ ] Grep for `not built`, `Ready for implementation`, `Focus here first`, `planned to consume` in active docs
- [ ] Spot-check README What’s Done vs What’s Next for Team Info + court capture
- [ ] Confirm `docs/completed/PLAN_TEAM_INFO_*` banner says do not execute
- [ ] Confirm AGENT overview Active table lists DESIGN_SHOT_TRACKER_UI_REVAMP