### PR TITLE
fix: Team Info path helper adoption

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -84,7 +84,7 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.19 | Game Info → View full summary on a finalized game | Hydrates the cloud game through the existing flow and opens `/summary`; pending local sync still blocks hydration |
 | 4.20 | Team Roster → tap a player | Opens `/player-info?playerId=<id>&teamId=<id>` with **Player Info**, season totals, game log, career link, and **Back to Team** returning to `/team?teamId=<id>` |
 | 4.21 | Team Info → Season Stats → back arrow | Opens Leaderboard with that team selected; back arrow returns to `/team?teamId=<id>` |
-| 4.21b | Leaderboard → tap a player row | Existing `/player?teamId=<id>&playerId=<id>&seasonId=<id>` route still opens **Player Profile** and backs to Leaderboard |
+| 4.21b | Global Leaderboard (not from team) → tap a player row | Existing `/player?teamId=<id>&playerId=<id>&seasonId=<id>` route still opens **Player Profile** and backs to Leaderboard (team-origin rows use `/player-info` — see **4h.8b**) |
 | 4.22 | Team Info hero → season name | Opens `/team/season?seasonId=<id>` with season name, sport, team count, and teams in that season |
 | 4.23 | Season Info → tap a team name / Season Stats | Team name opens `/team?teamId=<id>`; Season Stats opens `/leaderboard?teamId=<id>&seasonId=<id>&from=team`; back arrow returns to Team Info |
 | 4.24 | Team Info → Start Game | Opens `/setup?teamId=<id>` with the team's sport and existing team preselected |

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -66,7 +66,7 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.5 | Edit player (pencil) → change first name, last name, jersey number → Save | Player row updates with new values; reflected in cloud roster |
 | 4.5b | Edit player nickname | Display name updates; primary name shown in parentheses if nickname set |
 | 4.6 | Remove player | Player removed from roster (soft deactivate) |
-| 4.7 | Team Manage → Season Stats link | Navigate to Leaderboard with that team pre-selected |
+| 4.7 | Team Manage → Season Stats link | Opens `/leaderboard?teamId=<id>&seasonId=<id>&from=team`; back arrow returns to Team Info |
 | 4.8 | Reload → Teams | Same teams and roster (from Supabase) |
 | 4.9 | Teams → tap a team card's primary name area | Opens `/team?teamId=<id>`; Team Info shows display name, season, sport, record, roster count, game count, and links back to Season Stats, Team Stats, and Manage Team |
 | 4.10 | Teams → tap **Manage** on a team card | Opens `/team/manage?teamId=<id>` with roster and member management for that team |
@@ -86,7 +86,7 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.21 | Team Info → Season Stats → back arrow | Opens Leaderboard with that team selected; back arrow returns to `/team?teamId=<id>` |
 | 4.21b | Leaderboard → tap a player row | Existing `/player?teamId=<id>&playerId=<id>&seasonId=<id>` route still opens **Player Profile** and backs to Leaderboard |
 | 4.22 | Team Info hero → season name | Opens `/team/season?seasonId=<id>` with season name, sport, team count, and teams in that season |
-| 4.23 | Season Info → tap a team name / Season Stats | Team name opens `/team?teamId=<id>`; Season Stats opens Leaderboard with `seasonId` and `teamId` set |
+| 4.23 | Season Info → tap a team name / Season Stats | Team name opens `/team?teamId=<id>`; Season Stats opens `/leaderboard?teamId=<id>&seasonId=<id>&from=team`; back arrow returns to Team Info |
 | 4.24 | Team Info → Start Game | Opens `/setup?teamId=<id>` with the team's sport and existing team preselected |
 | 4.25 | Open `/setup?teamId=<id>` directly | Loads the team sport when possible and preselects the team; invalid/inaccessible team shows Team unavailable and does not auto-select another team |
 | 4.26 | Team Stats / Tournament Stats / Game Info / Player Info → back action | Returns to `/team?teamId=<id>` when opened with team context |
@@ -254,6 +254,7 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4h.6 | Roster → player row | Opens `/player-info?playerId=<id>&teamId=<id>`; Back to Team returns to Team Info; Career link still opens `/career` |
 | 4h.7 | Hero season link | Opens `/team/season?seasonId=<id>&teamId=<id>`; Back to Team returns to Team Info; team rows link back into Team Info |
 | 4h.8 | Overview → Season Stats | Opens `/leaderboard?teamId=<id>&seasonId=<id>&from=team`; back arrow returns to Team Info |
+| 4h.8b | Leaderboard (from team) → tap a player row | Opens `/player-info?playerId=<id>&teamId=<id>&seasonId=<id>`; **Back to Team** returns to Team Info |
 | 4h.9 | Home → Season Stats | Opens global Leaderboard; back arrow returns home, even after the URL auto-fills `teamId` |
 | 4h.10 | Team Info → Start Game | Opens `/setup?teamId=<id>` with the team's sport and existing team preselected; continuing loads the team's active roster |
 | 4h.11 | Open `/setup?teamId=<id>` while another active game exists | If the requested team has a different sport than the active game, confirmation appears; cancel returns home and preserves the active game. Same-sport team links continue into setup without that reset prompt. |

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -4,7 +4,7 @@ import { sports, computePlayerScore } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName, playerDisplayName } from '../lib/display'
-import { teamInfoPath } from '../lib/teamInfo'
+import { playerInfoPath, teamInfoPath } from '../lib/teamInfo'
 
 interface TeamRow {
   id: string
@@ -413,7 +413,9 @@ export default function Leaderboard() {
                       type="button"
                       onClick={() =>
                         navigate(
-                          `/player?teamId=${selectedTeamId}&playerId=${row.player.id}&seasonId=${selectedSeasonId}`
+                          isTeamOrigin
+                            ? playerInfoPath(row.player.id, selectedTeamId, selectedSeasonId)
+                            : `/player?teamId=${selectedTeamId}&playerId=${row.player.id}&seasonId=${selectedSeasonId}`
                         )
                       }
                       className="flex-1 text-left px-3 py-2 hover:bg-blue-50/50 active:scale-[0.99] min-w-0"

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -12,7 +12,7 @@ import { playerDisplayName, teamDisplayName } from '../lib/display'
 import { formatCompactGameStatLine } from '../lib/statDisplay'
 import PlayerStatSummaryTables, { type StatHighGameMap } from '../components/PlayerStatSummaryTables'
 import { buildResolvedByGameForPlayer } from '../lib/playerStatSummaryTables'
-import { teamInfoPath } from '../lib/teamInfo'
+import { teamInfoPath, teamLeaderboardPath } from '../lib/teamInfo'
 
 interface TeamRow {
   id: string
@@ -313,7 +313,7 @@ export default function PlayerProfile() {
   }
 
   const leaderboardHref = team
-    ? `/leaderboard?teamId=${team.id}&seasonId=${team.season_id}`
+    ? teamLeaderboardPath(team.id, team.season_id)
     : '/leaderboard'
   const isPlayerInfoRoute = location.pathname === '/player-info'
   const backHref = isPlayerInfoRoute && team ? teamInfoPath(team.id) : leaderboardHref

--- a/src/pages/SeasonInfo.tsx
+++ b/src/pages/SeasonInfo.tsx
@@ -188,7 +188,7 @@ export default function SeasonInfo() {
                           {teamDisplayName(team)}
                         </Link>
                         <Link
-                          to={teamLeaderboardPath(team.id, season.id)}
+                          to={teamLeaderboardPath(team.id, season.id, true)}
                           className="shrink-0 text-xs font-semibold text-blue-600"
                         >
                           Season Stats

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName, playerDisplayName, playerRosterSelectLabel } from '../lib/display'
-import { teamInfoPath, teamManagementPath } from '../lib/teamInfo'
+import { teamInfoPath, teamLeaderboardPath, teamManagementPath } from '../lib/teamInfo'
 import ConfirmDialog from '../components/ConfirmDialog'
 import MergePlayerWizard, { type MergePlayerOption } from '../components/MergePlayerWizard'
 import { fetchMergePlayerScope } from '../lib/mergePlayerScope'
@@ -1153,7 +1153,9 @@ export default function Teams() {
                 <>
                   <button
                     type="button"
-                    onClick={() => navigate(`/leaderboard?teamId=${selectedTeam.id}`)}
+                    onClick={() =>
+                      navigate(teamLeaderboardPath(selectedTeam.id, selectedTeam.season_id, true))
+                    }
                     className="text-xs text-blue-600 font-medium hover:underline"
                   >
                     Season Stats

--- a/src/pages/TournamentStats.tsx
+++ b/src/pages/TournamentStats.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName, playerDisplayName } from '../lib/display'
 import { formatCompactGameStatLine } from '../lib/statDisplay'
-import { teamInfoPath, teamStatsPath } from '../lib/teamInfo'
+import { playerInfoPath, teamInfoPath, teamStatsPath } from '../lib/teamInfo'
 
 interface TeamRow {
   id: string
@@ -536,9 +536,7 @@ export default function TournamentStats() {
                   <button
                     type="button"
                     onClick={() =>
-                      navigate(
-                        `/player?teamId=${teamId}&playerId=${row.player.id}&seasonId=${team.season_id}`
-                      )
+                      navigate(playerInfoPath(row.player.id, teamId, team.season_id))
                     }
                     className="flex-1 text-left px-3 py-2 hover:bg-blue-50/40 min-w-0"
                   >


### PR DESCRIPTION
## Summary
- Season Info and Team Manage Season Stats use `teamLeaderboardPath(..., true)` so Leaderboard ← returns to Team Info
- Leaderboard (when `from=team`) and Tournament Stats open players via `playerInfoPath` (`/player-info`) for Back to Team
- Player Profile leaderboard back-link uses the path helper; regression docs updated (4.7, 4.23, 4h.8b)

## Test plan
- [ ] Team Info → Season Stats → ← returns to Team Info
- [ ] Season Info → Season Stats → ← returns to Team Info
- [ ] Team Manage → Season Stats → ← returns to Team Info
- [ ] From team-origin Leaderboard, tap player → Back to Team
- [ ] Home → Season Stats → tap player → still backs to Leaderboard (legacy `/player`)
- [ ] `pnpm test -- src/lib/teamInfo.test.ts`; `pnpm lint`; `pnpm build`