### PR TITLE
chore: unused surface cleanup (knip + legacy redirects)

### DIFF
--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -98,6 +98,14 @@ Uses **HashRouter** — URLs look like `http://localhost:5173/#/game`, not `/gam
 | `/tournament-stats` | TournamentStats | Tournament-scoped stats |
 | `/dev/shot-chart` | ShotChartPreview | **Dev only** — no auth, sample data |
 
+**Intentional legacy routes (keep; do not remove in unused-route sweeps):**
+
+| Legacy / dual route | Behavior | Prefer going forward |
+|---------------------|----------|----------------------|
+| `/shot-chart` | Redirects to `/game` (basketball guard) | Inline court on `/game` |
+| `/teams?teamId=` | Redirects to `/team/manage?teamId=` | `/team/manage` or Team Info → Manage |
+| `/player` + `/player-info` | Same `PlayerProfile` page; `/player-info` adds Back to Team | `playerInfoPath` / `teamInfo` helpers for team context |
+
 **Primary live-game path:** `/` → `/setup` → `/players` → `/checkout?` → `/game` → `/summary`
 
 ---

--- a/src/components/shot-chart/CourtEventPopup.tsx
+++ b/src/components/shot-chart/CourtEventPopup.tsx
@@ -16,7 +16,7 @@ import { isTeamPseudoPlayer, sortTeamPlayersFirst } from '../../lib/teamPlayers'
 const ARMING_DELAY_MS = 300
 
 /** Stat-only events the popup can record (no court location stored). */
-export const COURT_STAT_EVENTS = [
+const COURT_STAT_EVENTS = [
   { statId: 'oreb', label: 'Off Reb' },
   { statId: 'dreb', label: 'Def Reb' },
   { statId: 'stl', label: 'Steal' },
@@ -24,7 +24,7 @@ export const COURT_STAT_EVENTS = [
   { statId: 'ast', label: 'Assist' },
 ] as const
 
-export type CourtStatEventId = (typeof COURT_STAT_EVENTS)[number]['statId']
+type CourtStatEventId = (typeof COURT_STAT_EVENTS)[number]['statId']
 
 function playerPickerLabel(player: Player): string {
   if (isTeamPseudoPlayer(player)) return `${player.number || '*'} ${player.name}`

--- a/src/components/shot-chart/courtGeometry.ts
+++ b/src/components/shot-chart/courtGeometry.ts
@@ -2,7 +2,7 @@ import type { ShotZone } from '../../types'
 
 // Overall half-court dimensions (feet)
 export const COURT_WIDTH = 50
-export const HALF_COURT_DEPTH = 47
+const HALF_COURT_DEPTH = 47
 
 // NBA: rim 5.25' from baseline, backboard face 4' from baseline. For the diagram we use
 // half that rim offset so the basket sits halfway between the old position and the
@@ -27,12 +27,12 @@ export const BASKET_RADIUS = 0.75
 
 // Paint / lane: 16' wide (NBA), 19' deep from baseline to free-throw line
 export const PAINT_WIDTH = 16
-export const PAINT_DEPTH_FROM_BASELINE = 19
+const PAINT_DEPTH_FROM_BASELINE = 19
 export const FT_LINE_Y = PAINT_DEPTH_FROM_BASELINE - BASKET_CENTER_Y
 
 export const FT_CIRCLE_RADIUS = 6
 
-export const RESTRICTED_RADIUS = 4
+const RESTRICTED_RADIUS = 4
 
 export const THREE_POINT_RADIUS = 23.75
 export const CORNER_THREE_X = 22

--- a/src/config/sports.ts
+++ b/src/config/sports.ts
@@ -358,12 +358,3 @@ export function computePlayerScore(sport: SportConfig, stats: Record<string, num
 export function computeCategoryTotal(category: { actions: { id: string }[] }, stats: Record<string, number>): number {
   return category.actions.reduce((sum, action) => sum + (stats[action.id] || 0), 0)
 }
-
-export function computeHockeyPoints(stats: Record<string, number>): number {
-  return (stats['goal'] || 0) + (stats['h_ast'] || 0)
-}
-
-/** Ids persisted on `seasons.sport`; must match supabase migration 019 CHECK. */
-export type SportId = (typeof sports)[number]['id']
-
-export const KNOWN_SPORT_IDS: readonly SportId[] = sports.map(s => s.id)

--- a/src/lib/clearShotChart.test.ts
+++ b/src/lib/clearShotChart.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import type { ActionLogEntry, GameState, ShotRecord } from '../types'
 import {
   clearEntireShotChart,
-  linkedCourtAssistEntryIds,
   linkedCourtStatEntryIds,
 } from './clearShotChart'
 
@@ -78,7 +77,7 @@ describe('linkedCourtStatEntryIds', () => {
   })
 
   it('ignores legacy positional assist without linkedShotId', () => {
-    const ids = linkedCourtAssistEntryIds(
+    const ids = linkedCourtStatEntryIds(
       [
         logEntry({ id: 'shot-log', playerId: 'p1', statId: '2pt', shotId: 's1' }),
         logEntry({ id: 'ast-log', playerId: 'p2', statId: 'ast' }),

--- a/src/lib/clearShotChart.ts
+++ b/src/lib/clearShotChart.ts
@@ -34,9 +34,6 @@ export function linkedCourtStatEntryIds(
   return linked
 }
 
-/** @deprecated Use linkedCourtStatEntryIds */
-export const linkedCourtAssistEntryIds = linkedCourtStatEntryIds
-
 /** Clear every chart shot and revert linked stats/log rows (works even when non-shot actions trail the log). */
 export function clearEntireShotChart(state: GameState): GameState {
   if (state.shotChart.length === 0) return state

--- a/src/lib/reboundPrompt.ts
+++ b/src/lib/reboundPrompt.ts
@@ -6,7 +6,7 @@ import {
 } from './teamPlayers'
 
 export type ReboundStatId = 'oreb' | 'dreb'
-export type ReboundSide = 'home' | 'opponent'
+type ReboundSide = 'home' | 'opponent'
 
 export interface ReboundPromptOptions {
   offensiveSide: ReboundSide

--- a/src/lib/teamStatsSummary.ts
+++ b/src/lib/teamStatsSummary.ts
@@ -1,7 +1,7 @@
 import type { BasketballTeamStatsConfig, SportConfig, StatAction } from '../types'
 import { buildPeriodSegmentLabels, periodScopedStatKey } from './teamStatsPeriods'
 
-export type TeamBonusEventType = 'one_and_one' | 'double_bonus' | 'bonus_nba'
+type TeamBonusEventType = 'one_and_one' | 'double_bonus' | 'bonus_nba'
 
 export interface TeamBonusEvent {
   periodIndex: number
@@ -89,7 +89,7 @@ export function deriveBonusEvents(
   return events
 }
 
-export function sumPeriodScopedStat(stats: Record<string, number>, baseId: string): number {
+function sumPeriodScopedStat(stats: Record<string, number>, baseId: string): number {
   let sum = 0
   const prefix = `${baseId}_p`
   for (const [k, v] of Object.entries(stats)) {


### PR DESCRIPTION
## Summary
- Remove deprecated `linkedCourtAssistEntryIds` alias; tests use `linkedCourtStatEntryIds`
- Unexport knip-flagged dead symbols (`computeHockeyPoints`, `KNOWN_SPORT_IDS`, etc.) while keeping intentional docs/modules (`shotChartCoordinates.ts`, icon script)
- Document kept legacy dual routes (`/shot-chart`, `/teams?teamId=`, `/player` + `/player-info`) in AGENT overview

## Test plan
- [ ] `pnpm test -- src/lib/clearShotChart.test.ts`
- [ ] `pnpm lint`; `pnpm build`
- [ ] `#/shot-chart` still redirects; `/teams?teamId=` still redirects to manage