### PR TITLE
refactor: legacy finals loader + enabled-sport gating

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -60,6 +60,7 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 |------|--------|----------|
 | 4.1 | Home → Teams | Cloud Teams page; Create Team form; no team row is pre-selected/highlighted |
 | 4.1b | Stay on Cloud Teams list (do not open Manage) | Network: no `team_players` / `get_team_members_with_profiles` for a default first team |
+| 4.1c | Settings → disable a sport → Teams Create Team / Settings → Seasons New Season | Sport dropdown lists only enabled sports (same filter as Home SportSelect) |
 | 4.2 | Create team (name, sport, season) | Opens `/team/manage?teamId=<id>` for the created team |
 | 4.3 | Team Manage → add players (number, first, last) | Players appear in Roster |
 | 4.4 | Edit team name (pencil) → change primary name → Save | Team name updates in list; reflected in Game Setup dropdown and Games page |

--- a/src/lib/legacyFinalStats.test.ts
+++ b/src/lib/legacyFinalStats.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadLegacyFinalStatsTotals } from './legacyFinalStats'
+
+function mockClient(
+  responses: Record<string, { data?: { stat_id: string; value: number }[]; error?: { message: string } }>
+) {
+  return {
+    rpc: vi.fn(async (_name: string, args: { p_game_id: string }) => {
+      return responses[args.p_game_id] ?? { data: [], error: null }
+    }),
+  }
+}
+
+describe('loadLegacyFinalStatsTotals', () => {
+  it('returns empty when no legacy finals need resolution', async () => {
+    const client = mockClient({})
+    const totals = await loadLegacyFinalStatsTotals(client as never, [
+      { id: 'g1', status: 'final', home_team_score: 72 },
+      { id: 'g2', status: 'in_progress', home_team_score: null },
+    ])
+    expect(totals).toEqual({})
+    expect(client.rpc).not.toHaveBeenCalled()
+  })
+
+  it('sums resolved stats per legacy final game', async () => {
+    const client = mockClient({
+      g1: {
+        data: [
+          { stat_id: '2pt', value: 10 },
+          { stat_id: '2pt', value: 4 },
+          { stat_id: '3pt', value: 3 },
+        ],
+      },
+      g2: {
+        data: [{ stat_id: 'ft', value: 5 }],
+      },
+    })
+    const totals = await loadLegacyFinalStatsTotals(client as never, [
+      { id: 'g1', status: 'final', home_team_score: null },
+      { id: 'g2', status: 'final', home_team_score: null },
+      { id: 'g3', status: 'final', home_team_score: 80 },
+    ])
+    expect(totals).toEqual({
+      g1: { '2pt': 14, '3pt': 3 },
+      g2: { ft: 5 },
+    })
+    expect(client.rpc).toHaveBeenCalledTimes(2)
+  })
+
+  it('omits games whose RPC fails', async () => {
+    const client = mockClient({
+      g1: { error: { message: 'boom' } },
+      g2: { data: [{ stat_id: '2pt', value: 2 }] },
+    })
+    const totals = await loadLegacyFinalStatsTotals(client as never, [
+      { id: 'g1', status: 'final', home_team_score: null },
+      { id: 'g2', status: 'final', home_team_score: null },
+    ])
+    expect(totals).toEqual({ g2: { '2pt': 2 } })
+  })
+})

--- a/src/lib/legacyFinalStats.ts
+++ b/src/lib/legacyFinalStats.ts
@@ -1,0 +1,38 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type LegacyFinalGameRow = {
+  id: string
+  status: string
+  home_team_score?: number | null
+}
+
+/**
+ * For finalized games that predate stored `home_team_score`, batch-load
+ * `get_game_stats_resolved` and sum values by `stat_id` per game.
+ * Games that error are omitted from the result (callers keep null home scores).
+ */
+export async function loadLegacyFinalStatsTotals(
+  supabase: SupabaseClient,
+  games: LegacyFinalGameRow[]
+): Promise<Record<string, Record<string, number>>> {
+  const legacyFinals = games.filter(
+    game => game.status === 'final' && game.home_team_score == null
+  )
+  if (legacyFinals.length === 0) return {}
+
+  const totals: Record<string, Record<string, number>> = {}
+  await Promise.all(
+    legacyFinals.map(async game => {
+      const { data, error: statsError } = await supabase.rpc('get_game_stats_resolved', {
+        p_game_id: game.id,
+      })
+      if (statsError) return
+      totals[game.id] = {}
+      for (const row of (data ?? []) as { stat_id: string; value: number }[]) {
+        totals[game.id][row.stat_id] =
+          (totals[game.id][row.stat_id] ?? 0) + Number(row.value)
+      }
+    })
+  )
+  return totals
+}

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { sports } from '../config/sports'
 import type { BasketballTeamStatsConfig } from '../types'
@@ -83,7 +83,8 @@ export default function Admin() {
   const supabaseClient = supabase
   const userId = user?.id ?? null
 
-  const enabledCount = sports.filter(s => isSportEnabled(s.id)).length
+  const enabledSports = useMemo(() => sports.filter(s => isSportEnabled(s.id)), [isSportEnabled])
+  const enabledCount = enabledSports.length
 
   const [adminTeams, setAdminTeams] = useState<AdminTeamRow[]>([])
   const [adminGames, setAdminGames] = useState<AdminGameRow[]>([])
@@ -105,10 +106,19 @@ export default function Admin() {
   const [loadingSeasons, setLoadingSeasons] = useState(false)
   const [seasonsError, setSeasonsError] = useState<string | null>(null)
   const [newSeasonName, setNewSeasonName] = useState('')
-  const [newSeasonSport, setNewSeasonSport] = useState(sports[0]?.id ?? '')
+  const [newSeasonSport, setNewSeasonSport] = useState(
+    () => sports.find(s => isSportEnabled(s.id))?.id ?? sports[0]?.id ?? ''
+  )
   const [newSeasonStartDate, setNewSeasonStartDate] = useState('')
   const [newSeasonEndDate, setNewSeasonEndDate] = useState('')
   const [creatingSeason, setCreatingSeason] = useState(false)
+
+  useEffect(() => {
+    if (enabledSports.length === 0) return
+    if (!enabledSports.some(s => s.id === newSeasonSport)) {
+      setNewSeasonSport(enabledSports[0]!.id)
+    }
+  }, [enabledSports, newSeasonSport])
   const [editingSeasonId, setEditingSeasonId] = useState<string | null>(null)
   const [editSeasonName, setEditSeasonName] = useState('')
   const [editSeasonStartDate, setEditSeasonStartDate] = useState('')
@@ -581,7 +591,7 @@ export default function Admin() {
                     onChange={e => setNewSeasonSport(e.target.value)}
                     className="input-field"
                   >
-                    {sports.map(s => (
+                    {enabledSports.map(s => (
                       <option key={s.id} value={s.id}>{s.icon} {s.name}</option>
                     ))}
                   </select>
@@ -608,7 +618,7 @@ export default function Admin() {
                   <button
                     type="button"
                     onClick={() => void handleCreateSeason()}
-                    disabled={!newSeasonName.trim() || creatingSeason}
+                    disabled={!newSeasonName.trim() || creatingSeason || enabledSports.length === 0}
                     className="btn-primary w-full"
                   >
                     {creatingSeason ? 'Creating…' : 'Create Season'}

--- a/src/pages/TeamInfo.tsx
+++ b/src/pages/TeamInfo.tsx
@@ -12,6 +12,7 @@ import { sports } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
 import { teamDisplayName } from '../lib/display'
+import { loadLegacyFinalStatsTotals } from '../lib/legacyFinalStats'
 import { supabase } from '../lib/supabase'
 import {
   computeTeamRecord,
@@ -239,25 +240,9 @@ export default function TeamInfo() {
         setTeamMembers(rows)
       }
 
-      const legacyFinals = loadedGames.filter(
-        game => game.status === 'final' && game.home_team_score == null
-      )
-      if (legacyFinals.length > 0) {
-        const totals: Record<string, Record<string, number>> = {}
-        await Promise.all(
-          legacyFinals.map(async game => {
-            const { data, error: statsError } = await supabaseClient.rpc('get_game_stats_resolved', {
-              p_game_id: game.id,
-            })
-            if (statsError) return
-            totals[game.id] = {}
-            for (const row of (data ?? []) as { stat_id: string; value: number }[]) {
-              totals[game.id][row.stat_id] =
-                (totals[game.id][row.stat_id] ?? 0) + Number(row.value)
-            }
-          })
-        )
-        if (!cancelled) setStatsTotalsByGameId(totals)
+      const totals = await loadLegacyFinalStatsTotals(supabaseClient, loadedGames)
+      if (!cancelled && Object.keys(totals).length > 0) {
+        setStatsTotalsByGameId(totals)
       }
 
       if (!cancelled) setLoading(false)

--- a/src/pages/TeamSchedule.tsx
+++ b/src/pages/TeamSchedule.tsx
@@ -4,6 +4,7 @@ import GameCard, { type TeamInfoGameCardGame } from '../components/team-info/Gam
 import { sports } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { teamDisplayName } from '../lib/display'
+import { loadLegacyFinalStatsTotals } from '../lib/legacyFinalStats'
 import { supabase } from '../lib/supabase'
 import {
   resolveTeamInfoHomeScore,
@@ -125,25 +126,9 @@ export default function TeamSchedule() {
       setTeam(teamRes.data as unknown as TeamScheduleTeamRow)
       setGames(loadedGames)
 
-      const legacyFinals = loadedGames.filter(
-        game => game.status === 'final' && game.home_team_score == null
-      )
-      if (legacyFinals.length > 0) {
-        const totals: Record<string, Record<string, number>> = {}
-        await Promise.all(
-          legacyFinals.map(async game => {
-            const { data, error: statsError } = await supabaseClient.rpc('get_game_stats_resolved', {
-              p_game_id: game.id,
-            })
-            if (statsError) return
-            totals[game.id] = {}
-            for (const row of (data ?? []) as { stat_id: string; value: number }[]) {
-              totals[game.id][row.stat_id] =
-                (totals[game.id][row.stat_id] ?? 0) + Number(row.value)
-            }
-          })
-        )
-        if (!cancelled) setStatsTotalsByGameId(totals)
+      const totals = await loadLegacyFinalStatsTotals(supabaseClient, loadedGames)
+      if (!cancelled && Object.keys(totals).length > 0) {
+        setStatsTotalsByGameId(totals)
       }
 
       if (!cancelled) setLoading(false)

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { sports } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
+import { useSettings } from '../context/SettingsContext'
 import { supabase } from '../lib/supabase'
 import { teamDisplayName, playerDisplayName, playerRosterSelectLabel } from '../lib/display'
 import { teamInfoPath, teamLeaderboardPath, teamManagementPath } from '../lib/teamInfo'
@@ -59,10 +60,12 @@ export default function Teams() {
   const [searchParams] = useSearchParams()
   const { user, isConfigured } = useAuth()
   const { state: gameState, dispatch: gameDispatch } = useGame()
+  const { isSportEnabled } = useSettings()
   const userId = user?.id ?? null
   const requestedTeamId = searchParams.get('teamId')
   const isManagementRoute = location.pathname === '/team/manage'
   const supabaseClient = supabase
+  const enabledSports = useMemo(() => sports.filter(s => isSportEnabled(s.id)), [isSportEnabled])
 
   const [teams, setTeams] = useState<TeamRow[]>([])
   const [selectedTeamId, setSelectedTeamId] = useState<string>('')
@@ -82,6 +85,13 @@ export default function Teams() {
   const [newTeamName, setNewTeamName] = useState('')
   const [newTeamSport, setNewTeamSport] = useState('basketball')
   const [newTeamSeason, setNewTeamSeason] = useState(new Date().getFullYear().toString())
+
+  useEffect(() => {
+    if (enabledSports.length === 0) return
+    if (!enabledSports.some(s => s.id === newTeamSport)) {
+      setNewTeamSport(enabledSports[0]!.id)
+    }
+  }, [enabledSports, newTeamSport])
 
   const [newPlayerFirst, setNewPlayerFirst] = useState('')
   const [newPlayerLast, setNewPlayerLast] = useState('')
@@ -984,7 +994,7 @@ export default function Teams() {
                     onChange={e => setNewTeamSport(e.target.value)}
                     className="input-field"
                   >
-                    {sports.map(sport => (
+                    {enabledSports.map(sport => (
                       <option key={sport.id} value={sport.id}>
                         {sport.icon} {sport.name}
                       </option>
@@ -1006,6 +1016,7 @@ export default function Teams() {
                 disabled={
                   !newTeamName.trim()
                   || creatingTeam
+                  || enabledSports.length === 0
                   || (seasonMode === 'existing' && !selectedSeasonId)
                   || (seasonMode === 'new' && !newTeamSeason.trim())
                 }


### PR DESCRIPTION
## Summary
- Shared `loadLegacyFinalStatsTotals` used by Team Info and Team Schedule (unit tested)
- Create Team and Settings → New Season sport dropdowns only list enabled sports
- Regression note 4.1c

## Test plan
- [ ] Team Info / Schedule still show W-L for legacy finals (null `home_team_score`)
- [ ] Disable hockey → Teams Create Team and Admin New Season omit hockey
- [ ] `pnpm test -- src/lib/legacyFinalStats.test.ts`; `pnpm lint`; `pnpm build`