### PR TITLE
refactor: Layer 5 Teams split + GameSummary extraction

### DIFF
--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -82,9 +82,9 @@ Uses **HashRouter** — URLs look like `http://localhost:5173/#/game`, not `/gam
 | `/shot-chart` | ShotChart | **Legacy** — redirects to `/game` (court is inline now) |
 | `/summary` | GameSummary | Post-game review, finalize, sync |
 | `/admin` | Admin | Seasons, sport toggles, data management |
-| `/teams` | Teams | Cloud team list/create entry, pending invites |
+| `/teams` | TeamsList | Cloud team list/create entry, pending invites |
 | `/team` | TeamInfo | Team hub with overview, roster, schedule, stats links, Start Game |
-| `/team/manage` | Teams | Team roster/member management for one team |
+| `/team/manage` | TeamManage | Team roster/member management for one team |
 | `/team/roster` | TeamRoster | Read-only full roster drill-down |
 | `/team/schedule` | TeamSchedule | Team-scoped game schedule drill-down |
 | `/team/season` | SeasonInfo | Season detail and team list |

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -71,7 +71,7 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 | 4.7 | Team Manage → Season Stats link | Opens `/leaderboard?teamId=<id>&seasonId=<id>&from=team`; back arrow returns to Team Info |
 | 4.8 | Reload → Teams | Same teams and roster (from Supabase) |
 | 4.9 | Teams → tap a team card's primary name area | Opens `/team?teamId=<id>`; Team Info shows display name, season, sport, record, roster count, game count, and links back to Season Stats, Team Stats, and Manage Team |
-| 4.10 | Teams → tap **Manage** on a team card | Opens `/team/manage?teamId=<id>` with roster and member management for that team |
+| 4.10 | Teams → tap **Manage** on a team card | Opens `/team/manage?teamId=<id>` (`TeamManage` page) with roster and member management for that team |
 | 4.10b | Open legacy `/teams?teamId=<id>` link | Redirects to `/team/manage?teamId=<id>` |
 | 4.10c | Open `/team/manage` without a team id or with an invalid id | Shows Team unavailable state; does not auto-select or manage another team |
 | 4.11 | Team Info → switch **Overview / Roster / Schedule** segments | Segment content changes in place; URL stays `/team?teamId=<id>`; Manage links open `/team/manage?teamId=<id>` |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,8 @@ import GameTracker from './pages/GameTracker'
 import GameCheckout from './pages/GameCheckout'
 import GameSummary from './pages/GameSummary'
 import Admin from './pages/Admin'
-import Teams from './pages/Teams'
+import TeamsList from './pages/TeamsList'
+import TeamManage from './pages/TeamManage'
 import TeamInfo from './pages/TeamInfo'
 import TeamRoster from './pages/TeamRoster'
 import TeamSchedule from './pages/TeamSchedule'
@@ -63,9 +64,9 @@ function AppRoutes() {
           <Route path="/shot-chart" element={<ShotChart />} />
           <Route path="/summary" element={<GameSummary />} />
           <Route path="/admin" element={<Admin />} />
-          <Route path="/teams" element={<Teams />} />
+          <Route path="/teams" element={<TeamsList />} />
           <Route path="/team" element={<TeamInfo />} />
-          <Route path="/team/manage" element={<Teams />} />
+          <Route path="/team/manage" element={<TeamManage />} />
           <Route path="/team/roster" element={<TeamRoster />} />
           <Route path="/team/schedule" element={<TeamSchedule />} />
           <Route path="/team/season" element={<SeasonInfo />} />

--- a/src/hooks/useFinalizeGame.ts
+++ b/src/hooks/useFinalizeGame.ts
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
+import { useGame, GAME_STORAGE_KEY } from '../context/GameContext'
+import { supabase } from '../lib/supabase'
+
+/**
+ * Finalize an in-progress cloud game: flush sync → mark final → clear local → reset.
+ * Order is intentional — do not reorder (avoids final + in-progress duplicates).
+ */
+export function useFinalizeGame() {
+  const navigate = useNavigate()
+  const { state, dispatch, flushCloudSync } = useGame()
+  const { user, isConfigured } = useAuth()
+  const [finalizing, setFinalizing] = useState(false)
+  const [finalizeError, setFinalizeError] = useState<string | null>(null)
+
+  const isFinalCloudGame = state.cloudSync.gameStatus === 'final'
+  const canFinalizeCloudGame = Boolean(
+    isConfigured && user && supabase && state.cloudSync.gameId && !isFinalCloudGame
+  )
+
+  const handleFinalizeCloudGame = async () => {
+    if (!canFinalizeCloudGame || !state.cloudSync.gameId) return
+    setFinalizeError(null)
+    setFinalizing(true)
+
+    const syncResult = await flushCloudSync()
+    if (!syncResult.ok) {
+      setFinalizing(false)
+      setFinalizeError(syncResult.reason)
+      return
+    }
+
+    const { opponentScore, homeTeamScore, homeScoreAdjustment } = state
+
+    const initial = await supabase!
+      .from('games')
+      .update({
+        status: 'final',
+        opponent_score: opponentScore,
+        home_team_score: homeTeamScore,
+        home_score_adjustment: homeScoreAdjustment,
+      })
+      .eq('id', state.cloudSync.gameId)
+
+    let updateError = initial.error
+    if (
+      updateError &&
+      updateError.message?.includes('home_team_score') &&
+      updateError.message?.includes('column')
+    ) {
+      const retry = await supabase!
+        .from('games')
+        .update({
+          status: 'final',
+          opponent_score: opponentScore,
+          home_score_adjustment: homeScoreAdjustment,
+        })
+        .eq('id', state.cloudSync.gameId)
+      updateError = retry.error ?? null
+    }
+    if (
+      updateError &&
+      updateError.message?.includes('home_score_adjustment') &&
+      updateError.message?.includes('column')
+    ) {
+      const retry = await supabase!
+        .from('games')
+        .update({
+          status: 'final',
+          opponent_score: opponentScore,
+        })
+        .eq('id', state.cloudSync.gameId)
+      updateError = retry.error ?? null
+    }
+
+    setFinalizing(false)
+    if (updateError) {
+      setFinalizeError(updateError.message ?? 'Failed to finalize game')
+      return
+    }
+
+    try {
+      localStorage.removeItem(GAME_STORAGE_KEY)
+    } catch {
+      // ignore
+    }
+    dispatch({ type: 'RESET_GAME' })
+    navigate('/games')
+  }
+
+  return {
+    finalizing,
+    finalizeError,
+    canFinalizeCloudGame,
+    handleFinalizeCloudGame,
+  }
+}

--- a/src/hooks/useReviewShotChart.ts
+++ b/src/hooks/useReviewShotChart.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+import type { ShotRecord } from '../types'
+import { useAuth } from '../context/AuthContext'
+import { loadGameShotChartForReview } from '../lib/cloudSync'
+import { mergeReviewAndLocalShots } from '../lib/shotChartReview'
+import { supabase } from '../lib/supabase'
+import type { ShotChartSelection } from '../lib/shotChartViews'
+
+/**
+ * Display-only review shot chart for Game Summary (F3).
+ * NEVER dispatch review rows into GameState.shotChart.
+ */
+export function useReviewShotChart(options: {
+  gameId: string | null
+  sportId: string | undefined
+  playerIdMap: Record<string, string>
+  localShotChart: ShotRecord[]
+  resolvedKey: number
+}) {
+  const { isConfigured } = useAuth()
+  const { gameId, sportId, playerIdMap, localShotChart, resolvedKey } = options
+  const [reviewShotChart, setReviewShotChart] = useState<ShotRecord[] | null>(null)
+  const [shotViewSelection, setShotViewSelection] = useState<ShotChartSelection>({ kind: 'all' })
+
+  useEffect(() => {
+    setReviewShotChart(null)
+    if (!isConfigured || !supabase || !gameId || sportId !== 'basketball') return
+
+    let cancelled = false
+    const load = async () => {
+      try {
+        const result = await loadGameShotChartForReview(gameId, playerIdMap)
+        if (!cancelled) setReviewShotChart(result.shotChart)
+      } catch {
+        // Review load is best-effort; fall back to the viewer's own hydrated shots.
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- playerIdMap is stable per gameId
+  }, [isConfigured, gameId, sportId, resolvedKey])
+
+  const summaryShotChart = mergeReviewAndLocalShots(localShotChart, reviewShotChart)
+  const isReviewShotChart = reviewShotChart !== null && reviewShotChart.length > 0
+  const showShotChartTab = Boolean(
+    sportId === 'basketball' && (localShotChart.length > 0 || summaryShotChart.length > 0)
+  )
+
+  return {
+    summaryShotChart,
+    isReviewShotChart,
+    showShotChartTab,
+    shotViewSelection,
+    setShotViewSelection,
+  }
+}

--- a/src/pages/GameSummary.tsx
+++ b/src/pages/GameSummary.tsx
@@ -1,27 +1,18 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useGame, GAME_STORAGE_KEY } from '../context/GameContext'
+import { useGame } from '../context/GameContext'
 import { computeCategoryTotal } from '../config/sports'
 import { getDisplayedHomeScore } from '../lib/gameScore'
 import { isTeamPseudoPlayer, TEAM_PLAYER_HOME_ID, TEAM_PLAYER_OPP_ID } from '../lib/teamPlayers'
 import { resolveTeamStatsConfig } from '../config/teamStatsDefaults'
 import { hasTrackedTeamSide } from '../lib/teamStatsSummary'
 import TeamStatSummary from '../components/team-stats/TeamStatSummary'
-import BasketballCourt from '../components/shot-chart/BasketballCourt'
-import ShootingSummary from '../components/shot-chart/ShootingSummary'
-import PlayerSelectorStrip from '../components/PlayerSelectorStrip'
-import {
-  shootingLine,
-  shotsForSelection,
-  shotViewEmptyCopy,
-  shotViewLabel,
-  type ShotChartSelection,
-} from '../lib/shotChartViews'
+import GameSummaryShotChartPanel from './game-summary/GameSummaryShotChartPanel'
+import StatCorrectionModal from './game-summary/StatCorrectionModal'
+import { useFinalizeGame } from '../hooks/useFinalizeGame'
+import { useReviewShotChart } from '../hooks/useReviewShotChart'
 import { useAuth } from '../context/AuthContext'
 import { supabase } from '../lib/supabase'
-import { loadGameShotChartForReview } from '../lib/cloudSync'
-import { mergeReviewAndLocalShots } from '../lib/shotChartReview'
-import type { ShotRecord } from '../types'
 
 /** Per-stat resolved value plus metadata for conflict indicator (Part 1) */
 type ResolvedEntry = { value: number; source?: string; recorder_count?: number }
@@ -43,11 +34,15 @@ type CheckoutsByPlayerMap = Record<string, CheckoutOption[]>
 
 export default function GameSummary() {
   const navigate = useNavigate()
-  const { state, dispatch, flushCloudSync } = useGame()
-  const { user, isConfigured } = useAuth()
+  const { state, dispatch } = useGame()
+  const { user } = useAuth()
   const { sport, gameInfo, players, opponentScore, homeTeamScore, homeScoreAdjustment, shotChart } = state
-  const [finalizing, setFinalizing] = useState(false)
-  const [finalizeError, setFinalizeError] = useState<string | null>(null)
+  const {
+    finalizing,
+    finalizeError,
+    canFinalizeCloudGame,
+    handleFinalizeCloudGame,
+  } = useFinalizeGame()
   const [resolvedStats, setResolvedStats] = useState<ResolvedStatsMap | null>(null)
   const [isTeamAdmin, setIsTeamAdmin] = useState(false)
   const [reviewMode, setReviewMode] = useState(false)
@@ -66,14 +61,6 @@ export default function GameSummary() {
   const [viewMode, setViewMode] = useState<'primary' | 'all'>('primary')
   /** Players vs scores vs team-level stat summary (fouls, timeouts) vs shot chart (basketball). */
   const [summaryTab, setSummaryTab] = useState<'players' | 'team' | 'team_stats' | 'shot_chart'>('players')
-  /** Shot chart tab view filter (F2); defaults to All for whole-game review (D12). Read-only — never changes `activePlayerId`. */
-  const [shotViewSelection, setShotViewSelection] = useState<ShotChartSelection>({ kind: 'all' })
-  /**
-   * All-recorder review shots for cloud games (F3). Display-only local state — NEVER
-   * dispatched into `GameState.shotChart` (D6: review shots must not sync). Null until
-   * loaded; falls back to the viewer's own hydrated `shotChart`.
-   */
-  const [reviewShotChart, setReviewShotChart] = useState<ShotRecord[] | null>(null)
   /** Final games: overlay from get_game_team_stats (resolved placeholder stats). */
   const [teamTrackedStatsByRemoteId, setTeamTrackedStatsByRemoteId] = useState<
     Record<string, Record<string, number>> | null
@@ -87,6 +74,20 @@ export default function GameSummary() {
   const gameId = state.cloudSync.gameId
   const teamId = state.cloudSync.teamId
   const playerIdMap = state.cloudSync.playerIdMap
+
+  const {
+    summaryShotChart,
+    isReviewShotChart,
+    showShotChartTab,
+    shotViewSelection,
+    setShotViewSelection,
+  } = useReviewShotChart({
+    gameId,
+    sportId: sport?.id,
+    playerIdMap,
+    localShotChart: shotChart,
+    resolvedKey,
+  })
 
   const summaryPlayers = useMemo(
     () => players.filter(p => !isTeamPseudoPlayer(p)),
@@ -151,36 +152,6 @@ export default function GameSummary() {
   const showTeamStatsTab = Boolean(
     sport?.teamCategories?.length &&
       (hasTrackedTeamSide(teamStatHomeStats, sport) || hasTrackedTeamSide(teamStatOppStats, sport))
-  )
-
-  // All-recorder review shots for any cloud game, final or in-progress (F3 D5). Keyed on
-  // gameId; resolvedKey refetches after a primary-recorder reassignment (D11).
-  useEffect(() => {
-    setReviewShotChart(null)
-    if (!isConfigured || !supabase || !gameId || sport?.id !== 'basketball') return
-
-    let cancelled = false
-    const load = async () => {
-      try {
-        const result = await loadGameShotChartForReview(gameId, playerIdMap)
-        if (!cancelled) setReviewShotChart(result.shotChart)
-      } catch {
-        // Review load is best-effort; fall back to the viewer's own hydrated shots.
-      }
-    }
-    void load()
-    return () => {
-      cancelled = true
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- playerIdMap is stable per gameId
-  }, [isConfigured, gameId, sport?.id, resolvedKey])
-
-  /** Source for the shot chart tab: review rows plus any unsynced local shots (D7). */
-  const summaryShotChart = mergeReviewAndLocalShots(shotChart, reviewShotChart)
-  const isReviewShotChart = reviewShotChart !== null && reviewShotChart.length > 0
-
-  const showShotChartTab = Boolean(
-    sport?.id === 'basketball' && (shotChart.length > 0 || summaryShotChart.length > 0)
   )
 
   useEffect(() => {
@@ -610,79 +581,6 @@ export default function GameSummary() {
     handleCloseCorrect()
   }
 
-  const canFinalizeCloudGame = Boolean(
-    isConfigured && user && supabase && state.cloudSync.gameId && !isFinalCloudGame
-  )
-  const handleFinalizeCloudGame = async () => {
-    if (!canFinalizeCloudGame || !state.cloudSync.gameId) return
-    setFinalizeError(null)
-    setFinalizing(true)
-
-    const syncResult = await flushCloudSync()
-    if (!syncResult.ok) {
-      setFinalizing(false)
-      setFinalizeError(syncResult.reason)
-      return
-    }
-
-    const initial = await supabase!
-      .from('games')
-      .update({
-        status: 'final',
-        opponent_score: opponentScore,
-        home_team_score: homeTeamScore,
-        home_score_adjustment: homeScoreAdjustment,
-      })
-      .eq('id', state.cloudSync.gameId)
-
-    let finalizeError = initial.error
-    if (
-      finalizeError &&
-      finalizeError.message?.includes('home_team_score') &&
-      finalizeError.message?.includes('column')
-    ) {
-      const retry = await supabase!
-        .from('games')
-        .update({
-          status: 'final',
-          opponent_score: opponentScore,
-          home_score_adjustment: homeScoreAdjustment,
-        })
-        .eq('id', state.cloudSync.gameId)
-      finalizeError = retry.error ?? null
-    }
-    if (
-      finalizeError &&
-      finalizeError.message?.includes('home_score_adjustment') &&
-      finalizeError.message?.includes('column')
-    ) {
-      const retry = await supabase!
-        .from('games')
-        .update({
-          status: 'final',
-          opponent_score: opponentScore,
-        })
-        .eq('id', state.cloudSync.gameId)
-      finalizeError = retry.error ?? null
-    }
-
-    setFinalizing(false)
-    if (finalizeError) {
-      setFinalizeError(finalizeError.message ?? 'Failed to finalize game')
-      return
-    }
-
-    // Clear persisted game so this game no longer appears as in progress (fixes
-    // "completed game appears as both final and in progress").
-    try {
-      localStorage.removeItem(GAME_STORAGE_KEY)
-    } catch {
-      // ignore
-    }
-    dispatch({ type: 'RESET_GAME' })
-    navigate('/games')
-  }
-
   return (
     <div className="min-h-screen flex flex-col bg-slate-50">
       <header className={`bg-gradient-to-r ${sport.theme.gradient} text-white px-4 py-6`}>
@@ -911,48 +809,16 @@ export default function GameSummary() {
 
         {teamStatsSummaryEl}
 
-        {summaryTab === 'shot_chart' && (() => {
-          const visibleShots = shotsForSelection(summaryShotChart, players, shotViewSelection)
-          return (
-            <div className="space-y-3 mb-6">
-              <PlayerSelectorStrip
-                players={players}
-                activePlayerId={
-                  shotViewSelection.kind === 'player' ? shotViewSelection.playerId : null
-                }
-                onSelectPlayer={playerId =>
-                  setShotViewSelection({ kind: 'player', playerId })
-                }
-                activeBgClass={sport?.theme.bg ?? 'bg-orange-500'}
-                onSelectAll={() => setShotViewSelection({ kind: 'all' })}
-                allActive={shotViewSelection.kind === 'all'}
-              />
-              <div className="flex items-baseline justify-between gap-2 px-1">
-                <p className="text-sm font-semibold text-slate-600 truncate">
-                  Shot chart — {shotViewLabel(shotViewSelection, players)}
-                </p>
-                <p className="text-sm font-bold text-slate-700 shrink-0">
-                  {shootingLine(visibleShots)}
-                </p>
-              </div>
-              {isReviewShotChart && (
-                <p className="text-xs text-slate-400 px-1">
-                  Combined from all recorders — each player&apos;s shots come from their
-                  primary recorder&apos;s chart.
-                </p>
-              )}
-              <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
-                <BasketballCourt shots={visibleShots} className="w-full" />
-              </div>
-              <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
-                <ShootingSummary
-                  shots={visibleShots}
-                  emptyMessage={shotViewEmptyCopy(shotViewSelection, players)}
-                />
-              </div>
-            </div>
-          )
-        })()}
+        {summaryTab === 'shot_chart' && (
+          <GameSummaryShotChartPanel
+            players={players}
+            summaryShotChart={summaryShotChart}
+            isReviewShotChart={isReviewShotChart}
+            shotViewSelection={shotViewSelection}
+            onShotViewSelectionChange={setShotViewSelection}
+            activeBgClass={sport?.theme.bg ?? 'bg-orange-500'}
+          />
+        )}
 
         {summaryTab === 'team' && (
           <div className="card mb-6 border-slate-200">
@@ -1312,63 +1178,19 @@ export default function GameSummary() {
         </div>
 
         {correcting && (
-          <div
-            className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-10"
-            onClick={handleCloseCorrect}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="correct-stat-title"
-          >
-            <div
-              className="card max-w-sm w-full"
-              onClick={e => e.stopPropagation()}
-            >
-              <h3 id="correct-stat-title" className="font-semibold text-slate-700 mb-3">
-                Correct stat
-              </h3>
-              <p className="text-sm text-slate-600 mb-2">
-                {correcting.playerName} — {correcting.statLabel}
-              </p>
-              <p className="text-xs text-slate-500 mb-3">
-                Current value: {correcting.currentValue}
-              </p>
-              {correctError && (
-                <div className="mb-3 text-sm text-red-600">{correctError}</div>
-              )}
-              <input
-                type="number"
-                min={0}
-                value={correctValue}
-                onChange={e => setCorrectValue(e.target.value)}
-                className="input-field mb-3"
-                placeholder="New value"
-              />
-              <input
-                type="text"
-                value={correctReason}
-                onChange={e => setCorrectReason(e.target.value)}
-                className="input-field mb-4"
-                placeholder="Reason (optional)"
-              />
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={handleSaveCorrection}
-                  disabled={savingCorrection}
-                  className="btn-primary flex-1"
-                >
-                  {savingCorrection ? 'Saving...' : 'Save'}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleCloseCorrect}
-                  className="btn-secondary flex-1"
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          </div>
+          <StatCorrectionModal
+            playerName={correcting.playerName}
+            statLabel={correcting.statLabel}
+            currentValue={correcting.currentValue}
+            correctValue={correctValue}
+            correctReason={correctReason}
+            correctError={correctError}
+            savingCorrection={savingCorrection}
+            onCorrectValueChange={setCorrectValue}
+            onCorrectReasonChange={setCorrectReason}
+            onSave={() => { void handleSaveCorrection() }}
+            onClose={handleCloseCorrect}
+          />
         )}
       </div>
     </div>

--- a/src/pages/TeamManage.tsx
+++ b/src/pages/TeamManage.tsx
@@ -1,0 +1,6 @@
+import TeamsPage from './Teams'
+
+/** Team roster/member management (`/team/manage`). */
+export default function TeamManage() {
+  return <TeamsPage mode="manage" />
+}

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { sports } from '../config/sports'
 import { useAuth } from '../context/AuthContext'
 import { useGame } from '../context/GameContext'
@@ -54,8 +54,9 @@ interface PoolPlayer {
   nickname: string | null
 }
 
-export default function Teams() {
-  const location = useLocation()
+export type TeamsPageMode = 'list' | 'manage'
+
+export default function TeamsPage({ mode }: { mode: TeamsPageMode }) {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const { user, isConfigured } = useAuth()
@@ -63,7 +64,7 @@ export default function Teams() {
   const { isSportEnabled } = useSettings()
   const userId = user?.id ?? null
   const requestedTeamId = searchParams.get('teamId')
-  const isManagementRoute = location.pathname === '/team/manage'
+  const isManagementRoute = mode === 'manage'
   const supabaseClient = supabase
   const enabledSports = useMemo(() => sports.filter(s => isSportEnabled(s.id)), [isSportEnabled])
 

--- a/src/pages/TeamsList.tsx
+++ b/src/pages/TeamsList.tsx
@@ -1,0 +1,6 @@
+import TeamsPage from './Teams'
+
+/** Cloud Teams list/create entry (`/teams`). */
+export default function TeamsList() {
+  return <TeamsPage mode="list" />
+}

--- a/src/pages/game-summary/GameSummaryShotChartPanel.tsx
+++ b/src/pages/game-summary/GameSummaryShotChartPanel.tsx
@@ -1,0 +1,72 @@
+import type { Player, ShotRecord } from '../../types'
+import BasketballCourt from '../../components/shot-chart/BasketballCourt'
+import ShootingSummary from '../../components/shot-chart/ShootingSummary'
+import PlayerSelectorStrip from '../../components/PlayerSelectorStrip'
+import {
+  shootingLine,
+  shotsForSelection,
+  shotViewEmptyCopy,
+  shotViewLabel,
+  type ShotChartSelection,
+} from '../../lib/shotChartViews'
+
+interface GameSummaryShotChartPanelProps {
+  players: Player[]
+  summaryShotChart: ShotRecord[]
+  isReviewShotChart: boolean
+  shotViewSelection: ShotChartSelection
+  onShotViewSelectionChange: (selection: ShotChartSelection) => void
+  activeBgClass: string
+}
+
+/** Read-only shot chart tab for Game Summary — never records or dispatches shots. */
+export default function GameSummaryShotChartPanel({
+  players,
+  summaryShotChart,
+  isReviewShotChart,
+  shotViewSelection,
+  onShotViewSelectionChange,
+  activeBgClass,
+}: GameSummaryShotChartPanelProps) {
+  const visibleShots = shotsForSelection(summaryShotChart, players, shotViewSelection)
+
+  return (
+    <div className="space-y-3 mb-6">
+      <PlayerSelectorStrip
+        players={players}
+        activePlayerId={
+          shotViewSelection.kind === 'player' ? shotViewSelection.playerId : null
+        }
+        onSelectPlayer={playerId =>
+          onShotViewSelectionChange({ kind: 'player', playerId })
+        }
+        activeBgClass={activeBgClass}
+        onSelectAll={() => onShotViewSelectionChange({ kind: 'all' })}
+        allActive={shotViewSelection.kind === 'all'}
+      />
+      <div className="flex items-baseline justify-between gap-2 px-1">
+        <p className="text-sm font-semibold text-slate-600 truncate">
+          Shot chart — {shotViewLabel(shotViewSelection, players)}
+        </p>
+        <p className="text-sm font-bold text-slate-700 shrink-0">
+          {shootingLine(visibleShots)}
+        </p>
+      </div>
+      {isReviewShotChart && (
+        <p className="text-xs text-slate-400 px-1">
+          Combined from all recorders — each player&apos;s shots come from their
+          primary recorder&apos;s chart.
+        </p>
+      )}
+      <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+        <BasketballCourt shots={visibleShots} className="w-full" />
+      </div>
+      <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+        <ShootingSummary
+          shots={visibleShots}
+          emptyMessage={shotViewEmptyCopy(shotViewSelection, players)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/pages/game-summary/StatCorrectionModal.tsx
+++ b/src/pages/game-summary/StatCorrectionModal.tsx
@@ -1,0 +1,87 @@
+interface StatCorrectionModalProps {
+  playerName: string
+  statLabel: string
+  currentValue: number
+  correctValue: string
+  correctReason: string
+  correctError: string | null
+  savingCorrection: boolean
+  onCorrectValueChange: (value: string) => void
+  onCorrectReasonChange: (value: string) => void
+  onSave: () => void
+  onClose: () => void
+}
+
+export default function StatCorrectionModal({
+  playerName,
+  statLabel,
+  currentValue,
+  correctValue,
+  correctReason,
+  correctError,
+  savingCorrection,
+  onCorrectValueChange,
+  onCorrectReasonChange,
+  onSave,
+  onClose,
+}: StatCorrectionModalProps) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-10"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="correct-stat-title"
+    >
+      <div
+        className="card max-w-sm w-full"
+        onClick={e => e.stopPropagation()}
+      >
+        <h3 id="correct-stat-title" className="font-semibold text-slate-700 mb-3">
+          Correct stat
+        </h3>
+        <p className="text-sm text-slate-600 mb-2">
+          {playerName} — {statLabel}
+        </p>
+        <p className="text-xs text-slate-500 mb-3">
+          Current value: {currentValue}
+        </p>
+        {correctError && (
+          <div className="mb-3 text-sm text-red-600">{correctError}</div>
+        )}
+        <input
+          type="number"
+          min={0}
+          value={correctValue}
+          onChange={e => onCorrectValueChange(e.target.value)}
+          className="input-field mb-3"
+          placeholder="New value"
+        />
+        <input
+          type="text"
+          value={correctReason}
+          onChange={e => onCorrectReasonChange(e.target.value)}
+          className="input-field mb-4"
+          placeholder="Reason (optional)"
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={savingCorrection}
+            className="btn-primary flex-1"
+          >
+            {savingCorrection ? 'Saving...' : 'Save'}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn-secondary flex-1"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- `/teams` → `TeamsList`, `/team/manage` → `TeamManage` (shared `TeamsPage` with `mode` prop; preserves list vs manage behavior)
- Game Summary: `useFinalizeGame`, `useReviewShotChart`, `GameSummaryShotChartPanel`, `StatCorrectionModal`
- Docs: route table + Manage regression note

## Test plan
- [ ] Cloud Teams list/create still works; Manage opens roster/members
- [ ] Legacy `/teams?teamId=` redirects to manage
- [ ] Game Summary finalize still syncs → final → clears local → `/games`
- [ ] Shot chart tab still read-only (review shots not written to GameState)
- [ ] Stat correction modal still saves
- [ ] `pnpm lint`; `pnpm build`; `pnpm test`