### PR TITLE
docs: add app foundation planning roadmap

### DIFF
--- a/docs/PLAN_APP_FOUNDATION_ROADMAP.md
+++ b/docs/PLAN_APP_FOUNDATION_ROADMAP.md
@@ -1,0 +1,326 @@
+# Plan: App foundation roadmap
+
+Living roadmap for the next foundation work before soccer implementation. This plan covers
+the shared product architecture for sport-aware navigation, focused settings/admin pages,
+Google authentication, account management, and the first soccer planning/build phases.
+
+The intent is to make the app easier to navigate for basketball today while creating a
+clean path for multiple sports in progress at the same time. Each major phase below should
+be expanded into its own execution plan before implementation.
+
+---
+
+## 1. Problem statement
+
+StatKeeper has grown from a basketball-first tracker into a multi-game, multi-sport
+foundation. The current home/admin structure still largely reflects the original app:
+
+- The post-login home is primarily a sport selector plus several direct actions.
+- Settings/admin content is concentrated into long pages, which increases scrolling and
+  mixes normal preferences with advanced/debug-style tools.
+- Authentication is email/password only today, but the desired account model should support
+  Google sign-in/sign-up and account linking.
+- Soccer is the next sport direction, and the app needs a navigation/settings model that
+  does not hard-code basketball assumptions into global workflows.
+
+The next work should establish the app shell and account/settings foundations first, then
+build soccer on top of that structure.
+
+---
+
+## 2. Target mental model
+
+```text
+Login / Auth
+  -> Sport choice
+      -> Basketball dashboard
+          -> Resume active basketball game
+          -> Parked basketball games
+          -> New basketball game
+          -> Basketball teams
+          -> Basketball cloud games
+      -> Soccer dashboard
+          -> Resume active soccer game
+          -> Parked soccer games
+          -> New soccer game
+          -> Soccer teams
+          -> Soccer cloud games
+
+Global shell
+  -> Settings
+  -> Account
+  -> Help / advanced access as needed
+```
+
+The global shell should be reachable across primary authenticated pages, likely through a
+small header/footer control. Global navigation does not belong to a specific sport.
+
+The sport dashboard is where work is scoped to a sport. Sport choice answers "which sport
+are you working in?" The sport dashboard answers "what do you want to do for this sport?"
+
+---
+
+## 3. Settled product decisions
+
+- Use **login -> sport choice -> sport dashboard** as the main post-auth hierarchy.
+- Keep sport dashboards functional first: routing/structure and light polish now; broad
+  visual reskin later once the UI is highly functional.
+- Keep Settings/Admin globally accessible from the app shell, not only from the sport choice page.
+- Split Settings/Admin into focused sections instead of one long scrolling page.
+- Put sport-specific settings under that sport. For example, the basketball rebound prompt
+  setting belongs under a Basketball settings tab, not a generic settings scroll.
+- Make Google the primary auth CTA while keeping email/password as a fallback.
+- Split auth work into two phases:
+  - AUTH-1: Google sign-in/sign-up.
+  - AUTH-2: account management and identity linking UI.
+- AUTH-1 must happen before AUTH-2, but the app shell/navigation work can happen before
+  AUTH-1.
+- Google profile data is default-only: it may prefill display name/avatar, but StatKeeper's
+  display name remains editable.
+- Account controls should live in a separate Account tab/page, not buried inside a long
+  Settings page.
+- Cloud games at the sport dashboard level should be sport-filtered first. Team-specific cloud
+  games belong naturally inside the team hub or a team filter within cloud games.
+
+---
+
+## 4. Authentication direction
+
+### AUTH-1: Google sign-in/sign-up
+
+Detailed plan: [PLAN_AUTH_1_GOOGLE_SIGN_IN.md](PLAN_AUTH_1_GOOGLE_SIGN_IN.md).
+
+Goal: add Google OAuth as the primary account creation/sign-in path without removing the
+existing email/password fallback.
+
+Expected scope:
+
+- Add a Google sign-in/sign-up CTA to the auth entry point.
+- Keep email/password available for existing users and fallback/admin/testing flows.
+- Handle OAuth redirect return cleanly with HashRouter.
+- Document required Supabase and Google Console setup.
+- Preserve optional Supabase behavior: when Supabase env vars are absent, the app should
+  continue to run in offline/local mode.
+
+> **Callout: existing account linking**
+>
+> Google linking is a hard requirement, not a nice-to-have. Existing email/password accounts
+> that use the same Gmail address should be able to sign in with Google and retain the same
+> StatKeeper account/data ownership. Supabase supports automatic identity linking for OAuth
+> identities with the same verified email address, and AUTH-1 should explicitly test this
+> same-email migration path before it is considered complete.
+
+Implementation notes to preserve:
+
+- Do not tie auth identity to a sport. One account owns teams, seasons, games, and parking
+  across all sports.
+- Google account name/avatar can seed defaults, but app-facing profile identity remains
+  editable.
+- Keep email/password UI available unless a later plan explicitly retires it.
+- Add setup documentation for redirect URLs, Google OAuth credentials, and consent screen
+  requirements.
+
+### AUTH-2: Account management
+
+Detailed plan: [PLAN_AUTH_2_ACCOUNT_MANAGEMENT.md](PLAN_AUTH_2_ACCOUNT_MANAGEMENT.md).
+
+Goal: create the user-facing account area after the app shell/settings split gives it a
+proper home.
+
+Expected scope:
+
+- Add a distinct Account tab/page.
+- Show signed-in email and current display name.
+- Let the user edit the StatKeeper display name.
+- Show connected sign-in methods.
+- Add a manual "Link Google" action for logged-in users.
+- Consider avatar display/import behavior after the display-name flow is stable.
+
+---
+
+## 5. Navigation and settings direction
+
+### NAV-1: App shell and sport dashboards
+
+Detailed plan: [PLAN_NAV_1_APP_SHELL_AND_SPORT_DASHBOARDS.md](PLAN_NAV_1_APP_SHELL_AND_SPORT_DASHBOARDS.md).
+
+Goal: introduce the sport-aware navigation structure while reusing existing features.
+
+Expected scope:
+
+- Add a global app shell with persistent access to Settings/Account.
+- Keep HashRouter behavior and existing routes working.
+- Make the post-login landing experience a sport choice screen.
+- Add sport-scoped dashboards, starting with Basketball and a future-ready path for Soccer.
+- Move existing basketball actions into the Basketball dashboard:
+  - active/resume game
+  - parked games
+  - start new game
+  - teams
+  - cloud games
+- Ensure parked games and cloud games are filtered or clearly scoped by sport where shown.
+- Keep legacy/deep links working where practical.
+
+Suggested route shape:
+
+```text
+/#/sports
+/#/sport/:sportId
+/#/sport/:sportId/setup
+/#/sport/:sportId/parked
+/#/sport/:sportId/cloud-games
+/#/teams?sport=:sportId
+/#/team?teamId=...
+/#/settings
+/#/account
+```
+
+The exact route names can change during the detailed phase plan, but the hierarchy should
+remain sport-aware.
+
+### NAV-2: Settings/Admin split
+
+Detailed plan: [PLAN_NAV_2_SETTINGS_ADMIN_SPLIT.md](PLAN_NAV_2_SETTINGS_ADMIN_SPLIT.md).
+
+Goal: reduce scrolling and make normal settings, sport settings, account controls, data
+tools, and advanced tools easier to find.
+
+Recommended sections:
+
+```text
+Settings
+  -> Account
+  -> App / General
+  -> Sports
+      -> Basketball
+          -> Game tracker
+          -> Rebound prompt after miss
+          -> Basketball team-stat/season config
+      -> Soccer
+          -> Soccer-specific settings later
+      -> Future sports
+  -> Data & Sync
+  -> Advanced
+```
+
+Expected scope:
+
+- Split the existing Admin/Settings page into focused tabs or routes.
+- Move the basketball rebound prompt into the Basketball settings area.
+- Keep data import/export, parked-game storage, and cloud sync controls under Data & Sync.
+- Keep diagnostics, merge/debug utilities, and dangerous/reset actions under Advanced.
+- Avoid a broad visual reskin in this phase; prioritize structure, discoverability, and
+  shorter pages.
+
+---
+
+## 6. Soccer direction
+
+Soccer is the next sport direction after the app foundation work. The first soccer planning
+phase should assume each sport eventually gets its own live surface and layout:
+
+- Basketball uses a basketball court.
+- Soccer should use a soccer field when built.
+- Baseball should use a diamond when built.
+- Football should use a football field when built.
+
+Do not make soccer inherit basketball-specific UI. Generic sport configuration can drive
+stat definitions, setup, teams, and summaries, but live tracking surfaces should resolve by
+sport.
+
+### SOC-0: Soccer planning
+
+Goal: define the soccer-specific product model before implementation.
+
+Questions for SOC-0:
+
+- What is the first playable soccer stat set?
+- Does soccer need a field-tap event surface in the first build, or can first-pass tracking
+  use a simpler stat grid while the field UI is designed?
+- How should soccer events differ from basketball events in the action log and summary?
+- What soccer settings belong under Settings -> Sports -> Soccer?
+- Which team/season/cloud views can reuse existing generic flows unchanged?
+
+### SOC-1: First soccer implementation
+
+Goal: ship the smallest useful soccer tracking path on top of the new sport-aware shell.
+
+Expected scope will be defined by SOC-0, but likely starting points include:
+
+- Add/enable soccer sport configuration.
+- Route soccer setup through the sport dashboard.
+- Use soccer-specific labels, stats, and summaries.
+- Add either a basic soccer tracker surface or a deliberately scoped generic fallback.
+- Ensure parked soccer games and basketball games can coexist and resume independently.
+
+---
+
+## 7. Recommended build order
+
+| Phase | Deliverable | Notes |
+|-------|-------------|-------|
+| **NAV-1** | App shell + sport choice/dashboard structure | Best first foundation slice; gives every later feature a cleaner home. |
+| **NAV-2** | Settings/Admin split | Reduces scrolling and creates Account/Sports/Data/Advanced destinations. |
+| **AUTH-1** | Google sign-in/sign-up | Must precede AUTH-2; can follow navigation because auth entry does not depend on soccer. |
+| **AUTH-2** | Account management | Uses the Account destination created by NAV-2. |
+| **SOC-0** | Soccer product/technical plan | Define soccer stat model and tracker UI approach. |
+| **SOC-1** | First soccer implementation | Build on the sport dashboard and sport-specific settings structure. |
+
+---
+
+## 8. Phase planning notes
+
+When expanding each phase into an implementation plan, include:
+
+- Target files and route changes.
+- Backward compatibility for existing HashRouter links.
+- Manual regression steps for basketball and multi-game parking.
+- Any README, AGENTS, and `docs/AGENT_CODEBASE_OVERVIEW.md` updates.
+- Whether Supabase migrations are required.
+- How the phase behaves when Supabase is not configured.
+- What should be deferred to keep the PR small.
+
+Suggested phase-plan naming:
+
+```text
+docs/PLAN_NAV_1_APP_SHELL_AND_SPORT_DASHBOARDS.md
+docs/PLAN_NAV_2_SETTINGS_ADMIN_SPLIT.md
+docs/PLAN_AUTH_1_GOOGLE_SIGN_IN.md
+docs/PLAN_AUTH_2_ACCOUNT_MANAGEMENT.md
+docs/PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md
+docs/PLAN_SOC_1_SOCCER_FIRST_PASS.md
+```
+
+---
+
+## 9. Open questions for later phase plans
+
+These do not block this high-level roadmap.
+
+- NAV-1: Should sport dashboards be new pages or a refactor of the existing `SportSelect`
+  page into separate components?
+- NAV-1: What exact global shell pattern fits mobile best: top header, bottom nav, or a
+  compact hybrid?
+- NAV-1: Should `/` redirect to `/sports`, or should `/` remain the sport choice route?
+- NAV-2: Should Settings sections be tabs within one route or separate HashRouter routes?
+- NAV-2: Which current Admin tools are advanced/debug-only versus normal user-facing data
+  tools?
+- AUTH-1: Which deployment URLs need to be configured in Supabase/Google at launch
+  (localhost, GitHub Pages, custom domain)?
+- AUTH-1: What exact user-facing copy should explain existing account linking?
+- AUTH-2: Should avatar display be read-only from Google at first, editable in StatKeeper,
+  or deferred?
+- SOC-0: What soccer stats and event flow define the first useful soccer tracker?
+- SOC-0: Should the first soccer tracker include a field UI immediately or ship a smaller
+  non-field first pass?
+
+---
+
+## 10. Research references
+
+- Supabase Google OAuth setup: `https://supabase.com/docs/guides/auth/social-login/auth-google`
+- Supabase redirect URLs: `https://supabase.com/docs/guides/auth/redirect-urls`
+- Supabase identity linking: `https://supabase.com/docs/guides/auth/auth-identity-linking`
+- Supabase JavaScript `linkIdentity`: `https://supabase.com/docs/reference/javascript/auth-linkidentity`
+- Google OAuth app verification and consent screen: `https://support.google.com/cloud/answer/13461325`
+- Google sign-in branding guidelines: `https://developers.google.com/identity/branding-guidelines`

--- a/docs/PLAN_AUTH_1_GOOGLE_SIGN_IN.md
+++ b/docs/PLAN_AUTH_1_GOOGLE_SIGN_IN.md
@@ -1,0 +1,354 @@
+# Plan: AUTH-1 Google sign-in and sign-up
+
+Execution plan for the first authentication slice from
+[PLAN_APP_FOUNDATION_ROADMAP.md](PLAN_APP_FOUNDATION_ROADMAP.md). AUTH-1 adds Google OAuth
+as the primary sign-in/sign-up path while keeping the existing email/password flow as a
+fallback.
+
+AUTH-1 can happen after NAV-1/NAV-2, but it must happen before AUTH-2 account management.
+
+---
+
+## 1. Goal
+
+Add "Continue with Google" to the auth entry point so users can create or access a
+StatKeeper account with Google.
+
+Primary requirements:
+
+- Google is the primary CTA.
+- Email/password remains available.
+- Existing accounts using the same Gmail address can link to Google and keep their existing
+  StatKeeper data.
+- Supabase-unconfigured/offline-local mode still works.
+- HashRouter and GitHub Pages deployment paths still return users to the app correctly.
+
+---
+
+## 2. Current state
+
+Current auth implementation:
+
+- `src/context/AuthContext.tsx`
+  - tracks `user`, `session`, `loading`, and `isConfigured`.
+  - exposes `signUp(email, password, displayName)`.
+  - exposes `signIn(email, password)`.
+  - exposes `signOut()`.
+  - uses `supabase.auth.getSession()` and `onAuthStateChange`.
+- `src/pages/Auth.tsx`
+  - renders email/password sign in and sign up.
+  - sign-up asks for a display name.
+  - if Supabase is not configured, shows an offline/cloud setup message.
+- `src/lib/supabase.ts`
+  - creates the Supabase client only when env vars are present.
+  - accepts `VITE_SUPABASE_PUBLISHABLE_KEY` or legacy `VITE_SUPABASE_ANON_KEY`.
+- `supabase/migrations/001_profiles.sql`
+  - creates `profiles`.
+  - `handle_new_user()` creates a profile on auth user creation.
+  - current default display name is `raw_user_meta_data.display_name` or email.
+- `vite.config.ts`
+  - production base is `/cursor-default/`.
+  - live app is `https://rothermal.github.io/cursor-default/`.
+
+---
+
+## 3. Product decisions
+
+- Keep email/password as a fallback.
+- Google profile data is default-only:
+  - can seed profile display name/avatar.
+  - should not permanently lock the user's StatKeeper display name.
+- One auth identity owns data across all sports. Do not tie auth to Basketball or Soccer.
+- Manual Google linking belongs to AUTH-2, but same-email automatic linking must be tested in
+  AUTH-1.
+
+> **Callout: existing account linking**
+>
+> Existing email/password accounts that use the same Gmail address should be able to use
+> Google sign-in and retain the same Supabase user/profile ownership. Supabase documents
+> automatic OAuth identity linking for matching verified email addresses. AUTH-1 should
+> explicitly test this path with an existing email/password account before handoff.
+
+---
+
+## 4. OAuth behavior and redirect strategy
+
+Use Supabase's browser OAuth flow:
+
+```ts
+await supabase.auth.signInWithOAuth({
+  provider: 'google',
+  options: {
+    redirectTo: getOAuthRedirectUrl(),
+  },
+})
+```
+
+Recommended redirect helper:
+
+```ts
+export function getOAuthRedirectUrl(): string {
+  return `${window.location.origin}${window.location.pathname}`
+}
+```
+
+Why:
+
+- Local dev returns to `http://localhost:5173/`.
+- GitHub Pages returns to `https://rothermal.github.io/cursor-default/`.
+- HashRouter will treat a no-hash return as the root route, which should be sport choice
+  after NAV-1.
+- Avoid hard-coding `/`, which would be wrong for GitHub Pages project hosting.
+
+Do not request Google offline access/provider refresh tokens in AUTH-1. StatKeeper only
+needs the Supabase session, not access to Google APIs.
+
+---
+
+## 5. Supabase and Google setup notes
+
+Supabase project configuration:
+
+- Enable the Google provider in Supabase Auth.
+- Add Google Client ID and Client Secret to the Google provider.
+- Set Site URL to production:
+  - `https://rothermal.github.io/cursor-default/`
+- Add redirect URLs:
+  - `http://localhost:5173/`
+  - `http://localhost:5173/**` if local paths need wildcard support.
+  - `https://rothermal.github.io/cursor-default/`
+  - exact production redirect URLs are preferred over production wildcards.
+
+Google Cloud / Google Auth Platform configuration:
+
+- Create OAuth client ID with application type **Web application**.
+- Authorized JavaScript origins:
+  - `http://localhost:5173`
+  - `https://rothermal.github.io`
+- Authorized redirect URI:
+  - Supabase project's callback URL, usually
+    `https://<project-ref>.supabase.co/auth/v1/callback`.
+- Scopes:
+  - `openid`
+  - email/profile scopes required by Supabase/Google login.
+- Consent screen:
+  - app name.
+  - support email.
+  - app logo if available.
+  - home page.
+  - privacy policy.
+  - terms of service if available.
+  - authorized domains.
+  - developer contact.
+- During Google test mode, add test users.
+
+Production note:
+
+- If/when StatKeeper moves to a custom domain, revisit Site URL, allowed redirect URLs,
+  Google authorized domains, and Google JavaScript origins.
+
+---
+
+## 6. Profile defaults
+
+Current profile trigger only uses:
+
+```sql
+new.raw_user_meta_data ->> 'display_name'
+```
+
+Google OAuth users may provide names through metadata fields such as `full_name`, `name`, or
+similar provider metadata, plus `avatar_url`/picture metadata. AUTH-1 should make profile
+creation tolerate both email/password and Google sign-ups.
+
+Recommended migration:
+
+- Update `public.handle_new_user()` to set:
+  - `display_name` from `display_name`, then `full_name`, then `name`, then email.
+  - `avatar_url` from `avatar_url` or `picture` if present.
+  - `email` from `new.email` if the current schema includes `profiles.email`.
+- Do not overwrite existing profiles during OAuth sign-in.
+- Do not add profile editing UI in AUTH-1.
+
+No RLS behavior should need to change.
+
+---
+
+## 7. Implementation tasks
+
+### D1: Auth context API
+
+- [ ] Add `signInWithGoogle()` to `AuthContextType`.
+- [ ] Implement it with `supabase.auth.signInWithOAuth({ provider: 'google', options })`.
+- [ ] Return `{ error: string | null }` for consistency with `signIn`/`signUp`.
+- [ ] Use a redirect helper based on `window.location.origin + window.location.pathname`.
+- [ ] Preserve current `getSession` and `onAuthStateChange` session handling.
+- [ ] Preserve `isConfigured` behavior when Supabase env vars are absent.
+
+### D2: Auth page UI
+
+- [ ] Add a "Continue with Google" button above email/password fields.
+- [ ] Make Google the primary visual CTA.
+- [ ] Keep Sign In / Sign Up email/password tabs.
+- [ ] Add clear loading/error behavior for Google click failures.
+- [ ] Follow Google sign-in button branding rules closely enough for verification:
+  - recognizable Google mark.
+  - standard wording such as "Continue with Google" or "Sign in with Google".
+  - button at least as prominent as other third-party providers.
+- [ ] Do not add a large redesign beyond this auth surface.
+
+### D3: Profile trigger migration
+
+- [ ] Add a new numbered migration updating `public.handle_new_user()`.
+- [ ] Preserve email/password `display_name` behavior.
+- [ ] Add Google-friendly fallbacks for `full_name`, `name`, and avatar metadata.
+- [ ] Preserve/backfill `profiles.email` if the current schema includes it.
+- [ ] Confirm the migration is safe to apply after existing migrations.
+- [ ] Update README migration list.
+
+### D4: Setup documentation
+
+- [ ] Update README Supabase setup with Google OAuth steps.
+- [ ] Document local and production redirect URLs.
+- [ ] Document Google authorized JavaScript origins.
+- [ ] Document Supabase callback URL placement in Google OAuth client.
+- [ ] Document consent screen/test-user requirements.
+- [ ] Update `docs/REGRESSION_TESTING.md` auth section with Google OAuth checks.
+- [ ] Update `docs/AGENT_CODEBASE_OVERVIEW.md` auth row.
+- [ ] Update `AGENTS.md` if operational auth gotchas are worth capturing.
+
+### D5: Account-linking QA
+
+- [ ] Create or use an existing email/password account with a Gmail address.
+- [ ] Confirm the account email if confirmation is enabled.
+- [ ] Sign out.
+- [ ] Use Google sign-in with the same Gmail address.
+- [ ] Verify the same app account/data is retained:
+  - same user id if visible in Supabase/Auth dashboard.
+  - existing teams/games still visible.
+  - local owner-gated persisted game data does not bleed between users.
+- [ ] Record any Supabase provider behavior that differs from the expected automatic-linking
+  path.
+
+---
+
+## 8. Suggested file list
+
+Likely touched:
+
+- `src/context/AuthContext.tsx`
+- `src/pages/Auth.tsx`
+- `supabase/migrations/034_google_auth_profile_defaults.sql` or next available number
+- `README.md`
+- `docs/REGRESSION_TESTING.md`
+- `docs/AGENT_CODEBASE_OVERVIEW.md`
+- `docs/PLAN_APP_FOUNDATION_ROADMAP.md`
+
+Possibly touched:
+
+- `AGENTS.md`
+- `src/lib/authRedirect.ts` or similar small helper if keeping redirect logic out of context.
+- `src/lib/authRedirect.test.ts` if the helper is pure/testable.
+
+---
+
+## 9. Acceptance criteria
+
+- Supabase-unconfigured mode still bypasses auth and runs offline/local.
+- Email/password sign-in still works.
+- Email/password sign-up still works.
+- Google button appears on the auth page as the primary CTA.
+- Clicking Google starts the Supabase Google OAuth flow.
+- OAuth return lands back in the app on local dev.
+- OAuth return lands back in the app on GitHub Pages production path.
+- New Google user gets a usable profile row.
+- Existing same-Gmail email/password user can sign in with Google without losing existing
+  teams/games/account ownership.
+- No sport-specific data ownership changes are introduced.
+- No Google provider tokens are stored in localStorage.
+
+---
+
+## 10. Regression tests
+
+Automated:
+
+- Run `pnpm test`.
+- Run `pnpm build`.
+- Run `pnpm lint` and note existing Fast Refresh warnings if unchanged.
+- Add unit coverage for redirect helper if it is extracted as a pure helper.
+
+Manual:
+
+- Supabase disabled:
+  - open app.
+  - verify no auth screen and no crash.
+- Email/password:
+  - sign in.
+  - sign out.
+  - sign up with display name.
+- Google local dev:
+  - configure Google/Supabase local redirect.
+  - click Continue with Google.
+  - complete OAuth.
+  - verify return to app.
+- Google production:
+  - configure GitHub Pages redirect.
+  - deploy.
+  - complete OAuth from `https://rothermal.github.io/cursor-default/`.
+- Same-email linking:
+  - verify existing Gmail email/password account keeps data after Google sign-in.
+- Profile defaults:
+  - inspect `profiles.display_name`, `profiles.email`, and `profiles.avatar_url` for a new
+    Google user.
+- Account switching:
+  - sign out clears the currently persisted game storage as it does today.
+  - signing into another user does not expose prior user's cloud data.
+
+---
+
+## 11. Risks and guardrails
+
+- **HashRouter and OAuth fragments:** avoid hash-specific redirect URLs in AUTH-1. Redirect
+  to the app base path and let HashRouter load sport choice.
+- **GitHub Pages base path:** do not hard-code `/`; production needs `/cursor-default/`.
+- **Provider setup outside code:** OAuth will not work until Supabase and Google Console are
+  configured correctly. Document this clearly in README/regression tests.
+- **Account linking expectations:** automatic same-email linking depends on verified/unique
+  email behavior. Test it explicitly before handoff.
+- **Profile defaults:** Google metadata keys may differ; use conservative fallbacks and do
+  not overwrite existing profiles.
+- **Scope creep into AUTH-2:** do not build manual linking, connected methods, editable
+  display name, or avatar management in AUTH-1.
+- **Google branding:** custom button styling should stay close to Google's published
+  requirements.
+
+---
+
+## 12. Pre-handoff decisions for implementation
+
+Recommended defaults are listed first.
+
+- **Auth model:** Google primary, email/password fallback.
+- **OAuth redirect:** `window.location.origin + window.location.pathname`.
+- **Post-login destination:** app root/sport choice.
+- **Manual Google linking:** defer to AUTH-2.
+- **Profile defaults:** update trigger to accept Google name/avatar metadata.
+- **Google tokens:** do not request or store provider tokens.
+- **Database migration:** include a small trigger update migration if implementation confirms
+  Google metadata is not captured by the current trigger.
+
+No additional product decisions are required before implementation if these defaults are
+accepted.
+
+---
+
+## 13. Research references
+
+- Supabase Google OAuth setup: `https://supabase.com/docs/guides/auth/social-login/auth-google`
+- Supabase redirect URLs: `https://supabase.com/docs/guides/auth/redirect-urls`
+- Supabase identity linking: `https://supabase.com/docs/guides/auth/auth-identity-linking`
+- Supabase `signInWithOAuth`: `https://supabase.com/docs/reference/javascript/auth-signinwithoauth`
+- Supabase `linkIdentity`: `https://supabase.com/docs/reference/javascript/auth-linkidentity`
+- Google sign-in branding guidelines: `https://developers.google.com/identity/branding-guidelines`
+- Google OAuth consent screen / verification: `https://support.google.com/cloud/answer/13461325`

--- a/docs/PLAN_AUTH_2_ACCOUNT_MANAGEMENT.md
+++ b/docs/PLAN_AUTH_2_ACCOUNT_MANAGEMENT.md
@@ -1,0 +1,350 @@
+# Plan: AUTH-2 Account management
+
+Execution plan for the second authentication slice from
+[PLAN_APP_FOUNDATION_ROADMAP.md](PLAN_APP_FOUNDATION_ROADMAP.md). AUTH-2 fills in the
+Account section created by NAV-2 with profile editing, connected sign-in method display, and
+manual Google account linking.
+
+AUTH-2 depends on AUTH-1 because the Google provider, OAuth redirect behavior, and profile
+defaults must exist before account management can link or display Google identity state.
+
+---
+
+## 1. Goal
+
+Give signed-in users a focused Account page where they can understand and manage their
+StatKeeper account identity without mixing account controls into sport settings or advanced
+admin tools.
+
+Primary requirements:
+
+- Show the signed-in email.
+- Show and edit StatKeeper display name.
+- Show connected sign-in methods.
+- Allow a logged-in user to manually link Google.
+- Keep Google profile data default-only; StatKeeper display name remains editable.
+- Keep all account identity sport-agnostic.
+
+---
+
+## 2. Current and expected prerequisites
+
+Current repo state before the auth roadmap:
+
+- `profiles.display_name`, `profiles.avatar_url`, and `profiles.email` exist through
+  migrations.
+- Profile rows are keyed by Supabase auth user id.
+- RLS allows users to update their own profile.
+- Current `AuthContext` exposes `user`, `session`, `signOut`, and auth loading state.
+
+Expected after NAV-2:
+
+- `/settings/account` exists as the account destination.
+- Account page currently shows basic signed-in email/sign-out/local-mode state.
+
+Expected after AUTH-1:
+
+- Google OAuth sign-in/sign-up exists.
+- Same-Gmail automatic linking has been tested.
+- Google-friendly profile defaults are handled on new profile creation.
+- Google provider and redirect URLs are configured in Supabase/Google.
+
+---
+
+## 3. Product decisions
+
+- Account is a separate Settings tab/page.
+- StatKeeper display name is independent from team/player names.
+- Google name/avatar can seed defaults but should not overwrite user-edited StatKeeper
+  profile fields after account creation.
+- Manual Google linking belongs in AUTH-2.
+- Account management applies across all sports. No Basketball/Soccer-specific account
+  behavior.
+- Do not build account deletion in AUTH-2.
+- Do not build sign-in method unlink/removal in AUTH-2 unless explicitly requested later.
+
+> **Callout: linked identity safety**
+>
+> AUTH-2 should show connected methods and allow adding Google. It should not remove sign-in
+> methods yet. Unlinking is technically supported by Supabase, but a rushed unlink flow can
+> strand a user if they remove their only practical sign-in path. Treat unlink/removal as a
+> future phase with recovery rules and confirmation copy.
+
+---
+
+## 4. Account page target UX
+
+Route:
+
+```text
+/#/settings/account
+```
+
+Recommended sections:
+
+```text
+Account
+  Profile
+    Email
+    Display name [editable]
+    Avatar [display-only or deferred]
+
+  Sign-in methods
+    Email/password: connected or unavailable
+    Google: connected / link Google
+
+  Session
+    Sign out
+```
+
+The page should stay short. Account should not become a second admin page.
+
+---
+
+## 5. Data model and profile behavior
+
+Source of truth:
+
+- `profiles.display_name` is the app-facing display name.
+- `profiles.email` is used for invite lookup/display support.
+- `profiles.avatar_url` may display a Google/default avatar if available.
+- `auth.user.email` remains the current authenticated email from Supabase Auth.
+- `auth.user.user_metadata` can mirror display/profile values, but app UI should prefer
+  `profiles`.
+
+Recommended behavior:
+
+- Load the current user's profile row on Account page mount.
+- If no profile row exists, create/repair a minimal row for the current user:
+  - `id = user.id`
+  - `email = user.email`
+  - `display_name = user.user_metadata.display_name/full_name/name/email fallback`
+  - optional `avatar_url`
+- Editing display name updates `profiles.display_name`.
+- Optionally update auth metadata through `supabase.auth.updateUser({ data })` after the
+  profile update succeeds, but do not make auth metadata the only source of truth.
+- Do not overwrite display name from Google on every sign-in.
+
+No schema migration is expected for AUTH-2 if AUTH-1 has already updated profile defaults.
+
+---
+
+## 6. Connected methods behavior
+
+Use Supabase Auth identities for connected-method display.
+
+Recommended display:
+
+- `email`: "Email/password" or "Email" depending on provider label returned by Supabase.
+- `google`: "Google".
+- Unknown providers: render provider id as a fallback.
+
+Manual Google link:
+
+- If Google identity is not connected, show "Link Google".
+- Clicking "Link Google" calls Supabase identity linking for provider `google`.
+- Use the same OAuth redirect strategy from AUTH-1 so GitHub Pages/local paths return
+  cleanly.
+- After OAuth completes and returns to the app, reload identities/profile state.
+- If Google is already connected, show "Connected" and do not offer another link action.
+
+Unlinking:
+
+- Deferred.
+- If it is added later, require at least one other usable sign-in method and strong
+  confirmation.
+
+---
+
+## 7. Implementation tasks
+
+### D1: Account profile service
+
+- [ ] Add a small helper module for current-user profile load/update/repair.
+- [ ] Load `profiles.id`, `display_name`, `email`, and `avatar_url` for `auth.user.id`.
+- [ ] Repair missing profile row if needed.
+- [ ] Update `profiles.display_name` with trim/validation.
+- [ ] Optionally mirror display name to `auth.user.user_metadata` with `updateUser`.
+- [ ] Keep errors user-visible but concise.
+
+Suggested file:
+
+- `src/lib/accountProfile.ts`
+
+### D2: Auth context account helpers
+
+- [ ] Add or expose account methods only if they are broadly useful:
+  - `getUserIdentities()`
+  - `linkGoogleIdentity()`
+  - `refreshUser()` if needed after metadata changes.
+- [ ] Keep low-level profile CRUD outside `AuthContext` unless the existing architecture
+  clearly favors context methods.
+- [ ] Reuse AUTH-1 redirect helper for manual Google linking.
+
+Potential APIs:
+
+```ts
+supabase.auth.getUserIdentities()
+supabase.auth.linkIdentity({ provider: 'google' })
+supabase.auth.updateUser({ data: { display_name: nextName } })
+```
+
+Implementation should confirm exact `linkIdentity` option typing against the installed
+`@supabase/supabase-js` version before coding redirect options.
+
+### D3: Account settings UI
+
+- [ ] Expand the NAV-2 Account section/page.
+- [ ] Show signed-in email.
+- [ ] Show editable display name field.
+- [ ] Save display name with loading/success/error states.
+- [ ] Show avatar only if available and it does not complicate layout.
+- [ ] Show connected methods from `getUserIdentities()`.
+- [ ] Show "Link Google" when Google is not connected.
+- [ ] Show "Google connected" when present.
+- [ ] Keep Sign Out on the Account page.
+- [ ] Show local/offline mode message when Supabase is not configured.
+
+### D4: Manual Google linking flow
+
+- [ ] Add "Link Google" action for logged-in users.
+- [ ] Use Supabase `linkIdentity({ provider: 'google' })`.
+- [ ] Ensure manual linking is enabled in Supabase project auth configuration.
+- [ ] Return to the Account page when possible.
+- [ ] Reload identities after return.
+- [ ] Show clear failure messaging if linking is disabled or provider setup is incomplete.
+
+### D5: Documentation
+
+- [ ] Update README auth/account feature notes.
+- [ ] Update `docs/REGRESSION_TESTING.md` with account management checks.
+- [ ] Update `docs/AGENT_CODEBASE_OVERVIEW.md` auth/account route notes.
+- [ ] Update `AGENTS.md` only if there is an operational gotcha agents should see quickly.
+- [ ] Update `docs/PLAN_APP_FOUNDATION_ROADMAP.md` if AUTH-2 decisions change.
+
+---
+
+## 8. Suggested file list
+
+Likely touched:
+
+- `src/components/settings/AccountSettings.tsx`
+- `src/context/AuthContext.tsx`
+- `src/lib/accountProfile.ts`
+- `src/lib/authRedirect.ts` or the AUTH-1 redirect helper location
+- `docs/REGRESSION_TESTING.md`
+- `docs/AGENT_CODEBASE_OVERVIEW.md`
+- `README.md`
+
+Possibly touched:
+
+- `src/pages/Settings.tsx`
+- `src/lib/settingsNavigation.ts`
+- `src/lib/accountProfile.test.ts`
+- `AGENTS.md`
+
+No Supabase migration should be required unless implementation reveals that profile defaults
+or RLS still need adjustment after AUTH-1.
+
+---
+
+## 9. Acceptance criteria
+
+- `/settings/account` shows current signed-in email.
+- `/settings/account` shows current StatKeeper display name from `profiles`.
+- User can edit and save display name.
+- Saved display name persists after refresh/sign-out/sign-in.
+- Existing team/member displays that read `profiles.display_name` reflect the updated name
+  where appropriate.
+- Connected sign-in methods are listed.
+- Google-connected users see Google as connected.
+- Email/password-only users can start manual Google linking from Account.
+- Manual Google linking returns to the app and updates connected-method display.
+- Sign out still clears persisted game storage as it does today.
+- Supabase-unconfigured mode shows a local/offline account state and does not crash.
+- No sport-specific account behavior is introduced.
+
+---
+
+## 10. Regression tests
+
+Automated:
+
+- Run `pnpm test`.
+- Run `pnpm build`.
+- Run `pnpm lint` and note existing Fast Refresh warnings if unchanged.
+- Add tests for profile helper fallback/repair logic if extracted.
+
+Manual:
+
+- Supabase disabled:
+  - open `/settings/account`.
+  - verify local/offline state renders without cloud calls.
+- Email/password account:
+  - open `/settings/account`.
+  - edit display name.
+  - refresh and verify persisted display name.
+  - sign out and sign back in.
+- Google-created account:
+  - verify profile defaults display.
+  - edit display name.
+  - sign out/in with Google and verify Google does not overwrite edited name.
+- Connected methods:
+  - email/password account shows email method.
+  - Google account shows Google method.
+  - same-Gmail linked account shows both if Supabase returns both identities.
+- Manual link:
+  - start from email/password account.
+  - click Link Google.
+  - complete Google OAuth.
+  - return to account page.
+  - verify Google appears connected.
+- Team/member display:
+  - update display name.
+  - verify team member/invite displays still work.
+
+---
+
+## 11. Risks and guardrails
+
+- **Manual linking setup:** Supabase manual linking may need to be enabled in project auth
+  configuration. Surface this clearly if the API returns a setup error.
+- **Provider return path:** reuse AUTH-1 redirect logic so GitHub Pages and local dev do not
+  diverge.
+- **Display name source drift:** prefer `profiles.display_name` for app display; auth
+  metadata is optional mirror data.
+- **Google overwrite risk:** do not re-import Google profile name over a user-edited display
+  name during normal sign-in.
+- **Unlink risk:** do not implement unlink/remove in AUTH-2 unless separately planned.
+- **RLS/profile repair:** if profile repair fails due RLS, show an actionable error and do
+  not silently proceed with incomplete profile state.
+- **Account scope creep:** no account deletion, password reset overhaul, MFA, avatar upload,
+  or email-change flow in AUTH-2.
+
+---
+
+## 12. Pre-handoff decisions for implementation
+
+Recommended defaults are listed first.
+
+- **Display name source:** `profiles.display_name`.
+- **Auth metadata:** optional mirror after successful profile update.
+- **Avatar:** display-only if already present; no upload/edit in AUTH-2.
+- **Connected methods:** display list from `getUserIdentities()`.
+- **Manual Google linking:** include.
+- **Unlink/removal:** defer.
+- **Account deletion:** defer.
+- **Password/email changes:** defer.
+
+No additional product decisions are required before implementation if these defaults are
+accepted.
+
+---
+
+## 13. Research references
+
+- Supabase `getUserIdentities`: `https://supabase.com/docs/reference/javascript/auth-getuseridentities`
+- Supabase `linkIdentity`: `https://supabase.com/docs/reference/javascript/auth-linkidentity`
+- Supabase `unlinkIdentity`: `https://supabase.com/docs/reference/javascript/auth-unlinkidentity`
+- Supabase `updateUser`: `https://supabase.com/docs/reference/javascript/auth-updateuser`
+- Supabase identity linking guide: `https://supabase.com/docs/guides/auth/auth-identity-linking`

--- a/docs/PLAN_NAV_1_APP_SHELL_AND_SPORT_DASHBOARDS.md
+++ b/docs/PLAN_NAV_1_APP_SHELL_AND_SPORT_DASHBOARDS.md
@@ -1,0 +1,424 @@
+# Plan: NAV-1 App shell and sport dashboards
+
+Execution plan for the first navigation foundation slice from
+[PLAN_APP_FOUNDATION_ROADMAP.md](PLAN_APP_FOUNDATION_ROADMAP.md). NAV-1 introduces a
+sport-aware app structure while keeping the existing basketball game flow and legacy routes
+working.
+
+---
+
+## 1. Goal
+
+Make the authenticated app easier to navigate and ready for multiple sports by splitting the
+current home responsibilities into:
+
+- **Sport choice:** choose the sport context after login.
+- **Sport dashboard:** resume/start/manage work for one sport.
+- **Global app shell:** persistent access to core global destinations, especially Settings.
+
+NAV-1 should be a functional re-architecture with light visual polish only. A broad reskin
+is intentionally deferred until the UI hierarchy is stable.
+
+---
+
+## 2. Current state
+
+Current route table:
+
+- `/` renders `SportSelect`.
+- `SportSelect` currently handles sport choice, active game resume, parked games, new game
+  creation, Cloud Games, Teams, Season Stats, Settings, sign-out, and sync/status display.
+- `/setup`, `/players`, `/checkout`, `/game`, `/summary` are the current live-game path.
+- `/teams`, `/team`, `/games`, `/leaderboard`, and related drill-downs are global routes.
+- `HashRouter` is required; URLs are `/#/path`.
+
+Current implementation starting points:
+
+- `src/App.tsx` route table.
+- `src/pages/SportSelect.tsx` current overloaded home screen.
+- `src/context/GameContext.tsx` exposes active game, parked games, start/park/resume/discard.
+- `src/context/SettingsContext.tsx` exposes enabled sports.
+- `src/config/sports.ts` defines all sport configs; Basketball is enabled by default, Soccer
+  exists but is disabled by default today.
+- `src/lib/teamInfo.ts` owns team route helpers such as `gameSetupPath`.
+
+---
+
+## 3. Target UX model
+
+```text
+Login / Auth
+  -> Sport choice (/, /sports)
+      -> Basketball dashboard (/sport/basketball)
+          -> Resume active basketball game
+          -> Parked basketball games
+          -> New basketball game
+          -> Basketball teams
+          -> Basketball cloud games
+          -> Basketball season stats
+      -> Soccer dashboard (/sport/soccer)
+          -> Future-ready dashboard using enabled sport config
+
+Global shell
+  -> Sports
+  -> Settings
+  -> Account placeholder or future destination
+```
+
+The dashboard scope is the important behavior change: active/parked/new/team/cloud actions
+should be filtered to the selected sport where the data supports it.
+
+---
+
+## 4. Settled NAV-1 decisions
+
+- Keep `/` as the main sport choice route during NAV-1 to preserve existing "home" links.
+- Add `/sports` as an alias route for the same sport choice page.
+- Add `/sport/:sportId` for sport dashboards.
+- Keep existing game-flow routes (`/setup`, `/players`, `/checkout`, `/game`, `/summary`)
+  working in NAV-1.
+- Prefer query params for existing global list routes in this phase, e.g. `/teams?sport=basketball`
+  and `/games?sport=basketball`, instead of creating duplicate full pages immediately.
+- Do not move the basketball rebound setting in NAV-1; that belongs to NAV-2 settings split.
+- Keep visual changes modest: clearer hierarchy, shorter pages, stable mobile layout.
+- Do not enable Soccer by default in NAV-1 unless a later phase explicitly decides to.
+
+---
+
+## 5. Recommended implementation shape
+
+### App shell
+
+Add a small authenticated shell component around the protected route table.
+
+Suggested file:
+
+- `src/components/AppShell.tsx`
+
+Responsibilities:
+
+- Render shared layout around authenticated pages.
+- Provide compact global navigation to:
+  - sport choice (`/` or `/sports`)
+  - settings/admin (`/admin` for now)
+  - account placeholder only if implemented in this phase
+- Avoid taking over page-level back buttons. Existing pages can keep their local back
+  actions until later cleanup.
+- Hide or simplify shell chrome on full-focus pages if needed, especially `/game`.
+
+Recommendation:
+
+- Start with a compact top header, not a full bottom nav.
+- Use text or existing emoji/symbols for now because this repo does not currently have an
+  icon dependency.
+- Keep the shell optional per route so `/game` can remain focused if the header feels too
+  crowded on mobile.
+
+### Sport choice page
+
+Refactor `SportSelect` so it becomes sport choice only.
+
+Possible file direction:
+
+- Keep `src/pages/SportSelect.tsx` as the route page for `/` and `/sports`.
+- Extract reusable sport tile/card helpers only if the file stays large.
+
+Responsibilities:
+
+- List enabled sports from `SettingsContext`.
+- Show high-level status per sport:
+  - active game indicator if the active game belongs to that sport
+  - parked game count for that sport
+  - optional sync/error indicator if any parked game for that sport needs attention
+- Navigate to `/sport/:sportId` when a sport is chosen.
+- If no sports are enabled, show a path to Settings.
+
+Do not start a new game directly from sport choice in NAV-1. The sport dashboard should own
+new game creation.
+
+### Sport dashboard page
+
+Add a dedicated sport dashboard.
+
+Suggested file:
+
+- `src/pages/SportDashboard.tsx`
+
+Responsibilities:
+
+- Resolve `sportId` from route params.
+- Validate that the sport exists and is enabled.
+- Show sport-scoped actions:
+  - resume active game for this sport
+  - start new game for this sport
+  - parked games for this sport
+  - teams for this sport
+  - cloud games for this sport
+  - season stats for this sport
+- If the active game belongs to another sport, starting a new game should still follow the
+  existing park-confirm flow.
+- If the selected sport is disabled, show a Settings CTA instead of silently failing.
+
+Recommended dashboard sections:
+
+```text
+Header: Basketball
+Primary action row:
+  - Resume active game (if active basketball game exists)
+  - New basketball game
+Parked games:
+  - Basketball-only parked rows with Resume / Discard
+Manage:
+  - Teams
+  - Cloud Games
+  - Season Stats
+```
+
+---
+
+## 6. Routing plan
+
+Add routes:
+
+```tsx
+<Route path="/" element={<SportSelect />} />
+<Route path="/sports" element={<SportSelect />} />
+<Route path="/sport/:sportId" element={<SportDashboard />} />
+```
+
+Keep existing routes:
+
+```tsx
+<Route path="/setup" element={<GameSetup />} />
+<Route path="/players" element={<PlayerSetup />} />
+<Route path="/checkout" element={<GameCheckout />} />
+<Route path="/game" element={<GameTracker />} />
+<Route path="/summary" element={<GameSummary />} />
+<Route path="/admin" element={<Admin />} />
+<Route path="/teams" element={<TeamsList />} />
+<Route path="/games" element={<Games />} />
+```
+
+Possible later routes, not required for NAV-1:
+
+```text
+/#/sport/:sportId/setup
+/#/sport/:sportId/parked
+/#/sport/:sportId/cloud-games
+/#/account
+/#/settings
+```
+
+NAV-1 should prefer additive route aliases and query params over deep rewrites.
+
+---
+
+## 7. Sport-scoped helpers
+
+Add small helper functions instead of duplicating filtering in multiple pages.
+
+Suggested file:
+
+- `src/lib/sportNavigation.ts`
+
+Possible helpers:
+
+```ts
+sportDashboardPath(sportId: string): string
+sportTeamsPath(sportId: string): string
+sportGamesPath(sportId: string): string
+sportLeaderboardPath(sportId: string): string
+isGameForSport(summaryOrState, sportId: string): boolean
+```
+
+Also consider extracting current `SportSelect` utility logic:
+
+- active game score line
+- parked sync label
+- route after resuming a parked game
+- active/parked game filtering by sport
+
+Keep these pure where possible so they can get targeted unit tests.
+
+---
+
+## 8. Detailed tasks
+
+### D1: Route and shell foundation
+
+- [ ] Add `SportDashboard` route to `src/App.tsx`.
+- [ ] Add `/sports` alias for sport choice.
+- [ ] Add `AppShell` around authenticated routes or around selected authenticated pages.
+- [ ] Keep dev-only `/dev/shot-chart` behavior unchanged.
+- [ ] Ensure unauthenticated Supabase-configured users still see `Auth`.
+- [ ] Ensure unconfigured/offline-local mode still enters the app without auth.
+
+### D2: Sport choice simplification
+
+- [ ] Refactor `SportSelect` to list enabled sports and route to `/sport/:sportId`.
+- [ ] Remove direct new-game start from sport cards.
+- [ ] Show active/parked indicators per sport.
+- [ ] Keep "no sports enabled" Settings CTA.
+- [ ] Move sign-out/account-adjacent controls out of `SportSelect` if the shell or account
+  placeholder handles them; otherwise leave sign-out here until NAV-2/AUTH-2.
+
+### D3: Basketball dashboard
+
+- [ ] Add `src/pages/SportDashboard.tsx`.
+- [ ] Render selected sport metadata from `src/config/sports.ts`.
+- [ ] Show active game card only when the active game's `state.sport.id` matches `sportId`.
+- [ ] Show parked game rows filtered by `summary.sportId === sportId`.
+- [ ] Reuse the existing resume/discard behavior from `SportSelect`.
+- [ ] Move the current "start new game" behavior into the dashboard.
+- [ ] Navigate new games to `/setup` after `startNewGame(sport)`.
+- [ ] Link Teams to `/teams?sport=:sportId`.
+- [ ] Link Cloud Games to `/games?sport=:sportId`.
+- [ ] Link Season Stats to `/leaderboard?sport=:sportId` if the current page can tolerate
+  or ignore that param safely.
+
+### D4: Sport filtering follow-through
+
+- [ ] Review `Teams` for existing sport filter behavior and make `/teams?sport=:sportId`
+  preselect/filter by sport if needed.
+- [ ] Review `Games` for existing sport filtering and make `/games?sport=:sportId` filter
+  cloud games if needed.
+- [ ] Review `Leaderboard` for `sport` query-param behavior and make the dashboard link
+  land sensibly.
+- [ ] If any of these pages need larger refactors, document the gap and keep NAV-1 focused.
+
+### D5: Back links and route helpers
+
+- [ ] Add route helper functions for sport dashboard links.
+- [ ] Update obvious "Back home" buttons where they should return to the sport dashboard
+  instead of generic sport choice.
+- [ ] Keep legacy `/` navigation valid where the sport context is unknown.
+- [ ] Do not break team drill-down canonical routes (`/team?teamId=...`).
+
+### D6: Documentation
+
+- [ ] Update `AGENTS.md` route/gotcha notes for sport choice and sport dashboards.
+- [ ] Update `docs/AGENT_CODEBASE_OVERVIEW.md` route table.
+- [ ] Update `docs/PLAN_APP_FOUNDATION_ROADMAP.md` if NAV-1 decisions change while planning.
+- [ ] Update `docs/REGRESSION_TESTING.md` with manual nav checks.
+- [ ] Update README only if the user-facing feature list or route guidance changes materially.
+
+---
+
+## 9. Suggested file list
+
+Likely touched:
+
+- `src/App.tsx`
+- `src/pages/SportSelect.tsx`
+- `src/pages/SportDashboard.tsx`
+- `src/components/AppShell.tsx`
+- `src/lib/sportNavigation.ts`
+- `src/pages/Teams.tsx`
+- `src/pages/Games.tsx`
+- `src/pages/Leaderboard.tsx`
+- `AGENTS.md`
+- `docs/AGENT_CODEBASE_OVERVIEW.md`
+- `docs/REGRESSION_TESTING.md`
+
+Possibly touched:
+
+- `src/lib/teamInfo.ts` if helper paths move there instead of a new nav helper.
+- `src/context/GameContext.tsx` only if current resume/start helpers need a tiny API
+  improvement. Avoid broader GameContext changes in NAV-1.
+- `src/pages/GameSetup.tsx`, `src/pages/GameTracker.tsx`, `src/pages/GameSummary.tsx` for
+  back-link polish only.
+
+---
+
+## 10. Acceptance criteria
+
+- `/` and `/sports` show sport choice.
+- Enabled sports appear as tiles/cards.
+- Clicking Basketball opens `/sport/basketball`.
+- `/sport/basketball` shows basketball-scoped active game, parked games, new game, teams,
+  cloud games, and season stats actions.
+- Starting a basketball game from `/sport/basketball` reaches the existing setup flow.
+- Resuming a parked basketball game restores the correct setup/players/game route.
+- Parked games from other sports do not appear in the basketball dashboard.
+- Existing routes still work when opened directly:
+  - `/setup`
+  - `/players`
+  - `/game`
+  - `/summary`
+  - `/teams`
+  - `/games`
+  - `/admin`
+- Settings/Admin is reachable from primary authenticated pages through the app shell or
+  equivalent global control.
+- Supabase-unconfigured local mode still works.
+- Dev shot chart preview remains reachable at `/#/dev/shot-chart` in dev.
+
+---
+
+## 11. Regression tests
+
+Automated:
+
+- Add/adjust unit tests for pure sport navigation helpers if added.
+- Run `pnpm test`.
+- Run `pnpm build`.
+- Run `pnpm lint` and note existing Fast Refresh warnings if unchanged.
+
+Manual:
+
+- Fresh load with only Basketball enabled:
+  - `/` shows Basketball sport choice.
+  - Basketball opens `/sport/basketball`.
+  - New game starts the current setup flow.
+- Active basketball game:
+  - dashboard shows active game and score.
+  - Resume opens `/game`.
+- Parked basketball game:
+  - dashboard lists it.
+  - Resume restores the correct route.
+  - Discard removes it after confirmation.
+- Mixed parked sports:
+  - temporarily enable another sport and create/park a local game.
+  - Basketball dashboard hides the other sport's parked row.
+  - Sport choice shows counts on both sport tiles.
+- Cloud-enabled account:
+  - Teams link lands on basketball team context/filter.
+  - Cloud Games link lands on basketball game context/filter.
+  - Season Stats link lands sensibly.
+- Supabase not configured:
+  - app still enters without auth.
+  - sport choice and dashboard work.
+
+---
+
+## 12. Risks and guardrails
+
+- **Route churn:** many pages navigate to `/`. Keep `/` stable in NAV-1 and add `/sports`
+  as an alias rather than forcing all links to change at once.
+- **Scope creep into NAV-2:** sport-specific settings belong to NAV-2, not NAV-1.
+- **Scope creep into soccer:** NAV-1 should be soccer-ready, not a soccer implementation.
+- **GameContext risk:** avoid changing reducer/persistence behavior unless a small helper
+  is clearly needed.
+- **Mobile crowding:** the app shell should stay compact and should not make live tracking
+  harder to use.
+- **Cloud filters:** if Teams/Games filtering is larger than expected, preserve query params
+  and document the follow-up rather than bloating NAV-1.
+
+---
+
+## 13. Pre-handoff decisions for implementation
+
+Recommended defaults are listed first.
+
+- **Shell placement:** compact top header, hidden/minimal on `/game` if needed.
+- **Sport choice route:** keep `/` as canonical for now; `/sports` is an alias.
+- **Dashboard route:** `/sport/:sportId`.
+- **Dashboard links to global pages:** use query params first (`/teams?sport=...`,
+  `/games?sport=...`) instead of duplicate sport-specific pages.
+- **Account link:** either omit until NAV-2/AUTH-2 or add a very small placeholder route if
+  the shell feels incomplete without it. Recommendation: omit from NAV-1 shell unless it is
+  cheap and clearly useful.
+- **Soccer visibility:** do not enable Soccer by default in NAV-1.
+
+No additional user-facing design questions are required before implementation if these
+defaults are accepted.

--- a/docs/PLAN_NAV_2_SETTINGS_ADMIN_SPLIT.md
+++ b/docs/PLAN_NAV_2_SETTINGS_ADMIN_SPLIT.md
@@ -1,0 +1,482 @@
+# Plan: NAV-2 Settings and admin split
+
+Execution plan for the second navigation foundation slice from
+[PLAN_APP_FOUNDATION_ROADMAP.md](PLAN_APP_FOUNDATION_ROADMAP.md). NAV-2 splits the current
+long Settings/Admin page into focused settings destinations so routine preferences, account
+controls, sport-specific configuration, data/sync tools, and advanced/destructive tools do
+not all live in one scrolling surface.
+
+NAV-2 should follow NAV-1's app shell and sport dashboard work. It should not require Google
+OAuth or soccer implementation to be complete.
+
+---
+
+## 1. Goal
+
+Make settings easier to scan and safer to use by introducing a focused settings structure:
+
+```text
+Settings
+  -> Account
+  -> App / General
+  -> Sports
+      -> Basketball
+      -> Soccer later
+      -> Future sports
+  -> Data & Sync
+  -> Advanced
+```
+
+The intent is to reduce scrolling, put sport-specific settings under the relevant sport,
+and separate advanced/destructive admin tools from normal user preferences.
+
+---
+
+## 2. Current state
+
+Current route and page:
+
+- `/admin` renders `src/pages/Admin.tsx`.
+- The page title is "Settings", but the route and component are still named Admin.
+- The page is a single long screen with expandable sections.
+
+Current `Admin.tsx` responsibilities:
+
+- Enabled sport toggles.
+- Basketball court-capture setting:
+  - missed-shot rebound prompt.
+- Local parked-game storage information.
+- Parked game export/import.
+- Cloud team shortcuts:
+  - Teams & Rosters.
+  - Cloud Games.
+- Seasons:
+  - create/edit/delete seasons.
+  - basketball team stat rules per season.
+- Player merge advanced tool and audit list.
+- Data management/destructive deletion:
+  - teams.
+  - games.
+  - players.
+  - tournaments.
+- Multiple confirmation dialogs and Supabase-backed loading/error states.
+
+Current related files:
+
+- `src/pages/Admin.tsx`
+- `src/context/SettingsContext.tsx`
+- `src/context/AuthContext.tsx`
+- `src/context/GameContext.tsx`
+- `src/components/SeasonTeamStatsEditor.tsx`
+- `src/components/MergePlayerWizard.tsx`
+- `src/components/ConfirmDialog.tsx`
+- `src/lib/gameParking.ts`
+- `src/lib/mergePlayerScope.ts`
+
+---
+
+## 3. Target UX model
+
+Use a Settings hub plus focused sections. On mobile, each section should feel like its own
+short page or route-level tab, not one giant accordion.
+
+Recommended route shape:
+
+```text
+/#/settings
+/#/settings/account
+/#/settings/app
+/#/settings/sports
+/#/settings/sports/basketball
+/#/settings/data
+/#/settings/advanced
+
+Legacy:
+/#/admin -> redirects or aliases to /settings
+```
+
+Recommended section ownership:
+
+| Destination | Owns |
+|-------------|------|
+| Account | signed-in email, sign out, future profile and connected sign-in methods |
+| App / General | enabled sports and app-wide preferences |
+| Sports | sport settings index |
+| Sports -> Basketball | missed-shot rebound prompt, basketball team stat rules entry points |
+| Data & Sync | parked-game storage, export/import, cloud game/team shortcuts |
+| Advanced | player merge, destructive delete tools, diagnostics/debug utilities |
+
+---
+
+## 4. Settled NAV-2 decisions
+
+- Account should be a separate tab/page, not buried in a long Settings scroll.
+- Sport-specific settings belong under that sport.
+- The basketball missed-shot rebound setting should move to Basketball settings.
+- Keep broad visual reskin deferred; NAV-2 is structural polish.
+- Keep `/admin` working for existing links during this phase.
+- Do not build Google account linking in NAV-2; leave placeholders/structure for AUTH-2.
+- Do not implement soccer settings yet; create a future-ready location only.
+- Keep dangerous/destructive tools away from normal settings.
+
+---
+
+## 5. Recommended implementation shape
+
+### Settings shell
+
+Add a route-level settings shell that renders section navigation and the active section.
+
+Suggested files:
+
+- `src/pages/Settings.tsx`
+- `src/components/settings/SettingsLayout.tsx`
+- `src/lib/settingsNavigation.ts`
+
+Responsibilities:
+
+- Render a compact settings header.
+- Provide route tabs/section links.
+- Keep mobile section navigation easy to tap and avoid horizontal overflow.
+- Preserve a clear Back action to sport choice or previous page.
+- Let individual section components own their data loading and actions.
+
+### Section components
+
+Suggested files:
+
+```text
+src/components/settings/AccountSettings.tsx
+src/components/settings/AppSettings.tsx
+src/components/settings/SportsSettings.tsx
+src/components/settings/BasketballSettings.tsx
+src/components/settings/DataSyncSettings.tsx
+src/components/settings/AdvancedSettings.tsx
+```
+
+These names can change during implementation, but the section boundaries should remain.
+
+### Legacy Admin route
+
+Recommended first pass:
+
+- Keep `src/pages/Admin.tsx`, but reduce it to a compatibility wrapper that redirects or
+  renders the new settings route.
+- Add `/settings` and nested settings routes to `src/App.tsx`.
+- Update app shell/settings buttons to use `/settings`.
+- Keep `/admin` valid for older links and docs until later cleanup.
+
+---
+
+## 6. Section-by-section scope
+
+### Account
+
+NAV-2 scope:
+
+- Show current signed-in email when Supabase is configured and a user exists.
+- Provide Sign Out.
+- Show an offline/local-mode message when Supabase is not configured.
+- Reserve obvious placement for future display name and connected sign-in methods.
+
+Deferred to AUTH-2:
+
+- Editable display name.
+- Connected sign-in methods.
+- Manual "Link Google".
+- Avatar behavior.
+
+### App / General
+
+NAV-2 scope:
+
+- Enabled sport toggles.
+- Any truly app-wide preferences that are not sport-specific.
+- "No sports enabled" recovery path still works.
+
+Guardrail:
+
+- Do not place basketball-only settings here.
+
+### Sports
+
+NAV-2 scope:
+
+- Show a sport settings index using `src/config/sports.ts`.
+- Basketball links to `/settings/sports/basketball`.
+- Disabled/future sports can be shown as disabled or "coming later" entries if they have no
+  settings yet.
+
+### Sports -> Basketball
+
+NAV-2 scope:
+
+- Move missed-shot rebound prompt here.
+- Link or embed basketball team stat rules in a clear basketball area.
+- Preserve current `SettingsContext` storage for `courtCapture.reboundPromptAfterMiss`.
+
+Open implementation choice:
+
+- Team stat rules currently live inside the Seasons section because they are configured per
+  season. NAV-2 can either:
+  - keep season CRUD in Data & Sync/Advanced and provide a Basketball settings link to the
+    relevant team-stat editor area; or
+  - move the season list/editor into Basketball settings with a sport filter.
+
+Recommendation:
+
+- Keep full season CRUD together in Data & Sync for NAV-2, but add a Basketball settings
+  entry that explains/links to basketball team stat rules. Move the actual editor only if it
+  stays small.
+
+### Data & Sync
+
+NAV-2 scope:
+
+- Local parked-game storage usage.
+- Export parked games.
+- Import parked games.
+- Cloud Teams shortcut.
+- Cloud Games shortcut.
+- Seasons CRUD if not moved elsewhere.
+
+Rationale:
+
+- Seasons are data/model management, not app preferences.
+- Parked-game import/export and cloud game navigation are normal user-facing data tools,
+  not advanced/destructive tools.
+
+### Advanced
+
+NAV-2 scope:
+
+- Player merge advanced tool and recent merge audit.
+- Destructive deletion tools for teams/games/players/tournaments.
+- Any migration/diagnostic warnings that are mainly for operators.
+
+Guardrails:
+
+- Use explicit confirmation dialogs.
+- Keep scary actions visually separated from routine settings.
+- Preserve existing RLS/migration error messaging.
+
+---
+
+## 7. Routing plan
+
+Add routes:
+
+```tsx
+<Route path="/settings" element={<Settings />} />
+<Route path="/settings/account" element={<Settings />} />
+<Route path="/settings/app" element={<Settings />} />
+<Route path="/settings/sports" element={<Settings />} />
+<Route path="/settings/sports/:sportId" element={<Settings />} />
+<Route path="/settings/data" element={<Settings />} />
+<Route path="/settings/advanced" element={<Settings />} />
+```
+
+Keep route:
+
+```tsx
+<Route path="/admin" element={<Admin />} />
+```
+
+Recommended `/admin` behavior:
+
+- Redirect to `/settings`, or render `Settings` with a compatibility note only if needed.
+- Do not remove `/admin` in NAV-2 because many pages and docs still reference it.
+
+---
+
+## 8. Detailed tasks
+
+### D1: Settings route foundation
+
+- [ ] Add settings route helpers.
+- [ ] Add `Settings` page and section routing.
+- [ ] Add `SettingsLayout` with section navigation.
+- [ ] Add `/settings/*` routes in `src/App.tsx`.
+- [ ] Keep `/admin` as a legacy route.
+- [ ] Update NAV-1 app shell/settings links to point to `/settings`.
+
+### D2: Extract app/general settings
+
+- [ ] Move enabled sport toggles out of `Admin.tsx`.
+- [ ] Preserve `SettingsContext.toggleSport` behavior.
+- [ ] Keep the "at least one sport enabled" status visible.
+- [ ] Verify sport choice still handles zero enabled sports with a Settings CTA.
+
+### D3: Extract sport settings
+
+- [ ] Add sports settings index.
+- [ ] Add Basketball settings section.
+- [ ] Move missed-shot rebound prompt to Basketball settings.
+- [ ] Preserve the existing local storage key/shape for this setting.
+- [ ] Add future-ready placeholder entries for soccer/future sports only if useful.
+- [ ] Avoid enabling soccer by default.
+
+### D4: Extract account settings
+
+- [ ] Add Account section.
+- [ ] Show signed-in email if available.
+- [ ] Add Sign Out.
+- [ ] Show offline/local-mode account message when Supabase is not configured.
+- [ ] Add AUTH-2 placeholder copy only if it does not clutter the page.
+
+### D5: Extract Data & Sync
+
+- [ ] Move local parked-game storage usage to Data & Sync.
+- [ ] Move parked-game export/import to Data & Sync.
+- [ ] Move Cloud Teams and Cloud Games shortcuts to Data & Sync.
+- [ ] Decide whether Seasons CRUD stays here in NAV-2.
+- [ ] Preserve import result messages and error handling.
+- [ ] Preserve storage estimate behavior.
+
+### D6: Extract Advanced
+
+- [ ] Move Player merge advanced tool to Advanced.
+- [ ] Move destructive data management/delete tools to Advanced.
+- [ ] Preserve existing delete confirmation dialogs.
+- [ ] Preserve merge audit loading/error behavior.
+- [ ] Preserve current Supabase/RLS/migration guidance messages.
+
+### D7: Compatibility cleanup
+
+- [ ] Replace obvious `navigate('/admin')` calls with `/settings` or a specific settings route.
+- [ ] Keep fallback links to `/admin` harmless.
+- [ ] Update route docs.
+- [ ] Ensure `Settings` is reachable from the global app shell.
+- [ ] Make sure `Back` actions do not trap users inside settings sections.
+
+### D8: Documentation
+
+- [ ] Update `AGENTS.md` with new settings/admin routing.
+- [ ] Update `docs/AGENT_CODEBASE_OVERVIEW.md` route table.
+- [ ] Update `docs/PLAN_APP_FOUNDATION_ROADMAP.md` if NAV-2 scope changes.
+- [ ] Update `docs/REGRESSION_TESTING.md` with settings section checks.
+- [ ] Update README if user-facing settings instructions change materially.
+
+---
+
+## 9. Suggested file list
+
+Likely touched:
+
+- `src/App.tsx`
+- `src/pages/Admin.tsx`
+- `src/pages/Settings.tsx`
+- `src/components/settings/SettingsLayout.tsx`
+- `src/components/settings/AccountSettings.tsx`
+- `src/components/settings/AppSettings.tsx`
+- `src/components/settings/SportsSettings.tsx`
+- `src/components/settings/BasketballSettings.tsx`
+- `src/components/settings/DataSyncSettings.tsx`
+- `src/components/settings/AdvancedSettings.tsx`
+- `src/lib/settingsNavigation.ts`
+- `src/components/AppShell.tsx`
+- `AGENTS.md`
+- `docs/AGENT_CODEBASE_OVERVIEW.md`
+- `docs/REGRESSION_TESTING.md`
+
+Possibly touched:
+
+- `src/context/SettingsContext.tsx` if sport-specific settings need clearer grouping helpers.
+- `src/pages/SportSelect.tsx` or `src/pages/SportDashboard.tsx` if Settings CTAs need route
+  updates.
+- `src/pages/Leaderboard.tsx`, `src/pages/TeamInfo.tsx`, `src/pages/TeamRoster.tsx`,
+  `src/pages/TeamSchedule.tsx`, `src/pages/GameInfo.tsx`, `src/pages/SeasonInfo.tsx` for
+  `/admin` link updates.
+
+---
+
+## 10. Acceptance criteria
+
+- `/settings` loads a settings hub or default settings section.
+- `/settings/account` shows account status and sign-out behavior.
+- `/settings/app` shows enabled sport toggles.
+- `/settings/sports` shows sport settings entry points.
+- `/settings/sports/basketball` contains the missed-shot rebound prompt.
+- Toggling missed-shot rebound prompt still controls the F9 rebound-after-miss popup.
+- `/settings/data` contains parked-game storage/export/import and cloud data shortcuts.
+- `/settings/advanced` contains player merge and destructive data management tools.
+- `/admin` still works and leads users to the new settings experience.
+- Existing destructive actions still require confirmation.
+- Existing import/export behavior and messages remain intact.
+- Supabase-unconfigured local mode still renders settings sections without cloud-only crashes.
+- Settings pages are shorter and avoid the current long-scroll admin layout.
+
+---
+
+## 11. Regression tests
+
+Automated:
+
+- Run `pnpm test`.
+- Run `pnpm build`.
+- Run `pnpm lint` and note existing Fast Refresh warnings if unchanged.
+- Add unit tests for route helper functions if `settingsNavigation.ts` has logic beyond
+  simple string builders.
+
+Manual:
+
+- Open `/settings`, `/settings/account`, `/settings/app`, `/settings/sports`,
+  `/settings/sports/basketball`, `/settings/data`, and `/settings/advanced`.
+- Open `/admin` and verify compatibility behavior.
+- Toggle enabled sports and verify sport choice reflects the change.
+- Toggle Basketball missed-shot rebound prompt:
+  - disabled: missed court shot does not open rebound prompt.
+  - enabled: missed court shot opens rebound prompt.
+- Export parked games from Data & Sync.
+- Import parked games from Data & Sync and verify result messaging.
+- Cloud-enabled account:
+  - Cloud Teams shortcut works.
+  - Cloud Games shortcut works.
+  - Seasons list/create/edit still works if kept in NAV-2.
+  - Player merge advanced tool still opens and audit messaging still works.
+- Destructive tools:
+  - confirm dialogs still appear.
+  - cancel leaves data unchanged.
+- Supabase not configured:
+  - account section shows local/offline mode.
+  - cloud-only sections do not crash.
+
+---
+
+## 12. Risks and guardrails
+
+- **Large component extraction:** `Admin.tsx` is big and stateful. Extract sections in a way
+  that preserves current behavior before polishing.
+- **Cloud-only assumptions:** some sections require Supabase. Keep clear unavailable states
+  when `isConfigured` or `user` is absent.
+- **Accidental data loss:** destructive actions must keep confirmations and current RLS/error
+  handling.
+- **Settings storage drift:** moving the rebound prompt must not change the
+  `statkeeper_settings.courtCapture.reboundPromptAfterMiss` storage shape.
+- **Scope creep into AUTH-2:** Account section can show current identity and sign out, but
+  profile editing and Google linking belong to AUTH-2.
+- **Scope creep into soccer:** create the structure for sport settings, but do not define
+  soccer settings yet.
+- **Nested-card cleanup:** while extracting, avoid creating cards inside cards for whole
+  sections. Repeated rows, forms, and modals can stay card-like; page sections should be
+  simple focused layouts.
+
+---
+
+## 13. Pre-handoff decisions for implementation
+
+Recommended defaults are listed first.
+
+- **Settings navigation:** route-level tabs/sections using `/settings/...`.
+- **Legacy `/admin`:** redirect/alias to `/settings`.
+- **Account in NAV-2:** current email/sign-out/local-mode status only; AUTH-2 fills in
+  display name, connected methods, and Google linking.
+- **Basketball rebound prompt:** move to `/settings/sports/basketball`.
+- **Season CRUD:** keep with Data & Sync in NAV-2 unless extraction proves cleaner under
+  Basketball settings.
+- **Player merge:** Advanced.
+- **Destructive delete tools:** Advanced.
+- **Visual scope:** structural polish only; no broad reskin.
+
+No additional product decisions are required before implementation if these defaults are
+accepted.


### PR DESCRIPTION
Summary:
- add umbrella app foundation roadmap
- add NAV-1 and NAV-2 planning docs
- add AUTH-1 and AUTH-2 planning docs

Tests: not run (docs-only).