### PR TITLE
Add admin security roadmap plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ docs/
 ├── PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md # F5–F13 roadmap; F11/F13 held
 ├── PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md # Held draft: shot detail / edit
 ├── PLAN_MULTI_GAME_PARKING.md # Roadmap: local parking + sync queue + cloud ordering hardening shipped
+├── PLAN_ADMIN_SECURITY_ROADMAP.md # Admin/security/access roadmap
+├── PLAN_SEC_*.md        # Admin/security/access phase plans with Q&A sections
 ├── REGRESSION_TESTING.md  # High-level test scripts for all features
 ├── completed/             # Shipped features — design & implementation references
 │   ├── PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md
@@ -359,7 +361,7 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 
 - [ ] **Multi-game storage/ops follow-ups** — optional historical orphan cleanup tooling, full transactional/idempotent cloud sync, IndexedDB storage, import conflict UI, and richer quota recovery UX ([plan](docs/PLAN_MULTI_GAME_PARKING.md))
 - [ ] **Stat view follow-ups** — the major career/season/team/tournament stat views are shipped; use [DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md) and [completed/STAT_TRACKING_UI_PROGRESS.md](docs/completed/STAT_TRACKING_UI_PROGRESS.md) as references for smaller refinements
-- [ ] Team collaboration invites: multi-parent workflows, invite links (design: [DESIGN_MULTI_PARENT_INVITE_LINKS.md](docs/archived/DESIGN_MULTI_PARENT_INVITE_LINKS.md))
+- [ ] Admin/security/access roadmap — role matrix, team access cleanup, viewer role, invite links, guardianship review, app-level access, and audit trail ([roadmap](docs/PLAN_ADMIN_SECURITY_ROADMAP.md))
 - [ ] Per-sport stat refinements and additional stats (minutes for hockey/soccer/football, missed shots for hockey)
 - [ ] Player transfer UI: search/autocomplete for adding existing players to new teams (player pool / Add Existing already ships; this is UX polish)
 - [ ] Optional stat descriptions — toggle full stat names vs abbreviations

--- a/docs/PLAN_ADMIN_SECURITY_ROADMAP.md
+++ b/docs/PLAN_ADMIN_SECURITY_ROADMAP.md
@@ -1,0 +1,187 @@
+# Plan: Admin security and access roadmap
+
+High-level roadmap for tightening StatKeeper's admin, security, visibility, and access
+model before expanding into additional sports.
+
+This plan consolidates earlier notes from:
+
+- `docs/archived/DESIGN_USER_PERMISSIONS_AND_ROLES.md`
+- `docs/archived/DESIGN_MULTI_PARENT_INVITE_LINKS.md`
+- `docs/INTEGRATION_PLAN.md`
+- `docs/completed/PLAN_TEAM_INFO_DRILLDOWN_IMPLEMENTATION.md`
+- `docs/completed/DESIGN_SEASONS_DATA_MODEL.md`
+- `docs/completed/DESIGN_PLAYER_MERGE.md`
+
+---
+
+## 1. Goal
+
+Create a clear, testable access model for:
+
+- who can use the app,
+- who can see teams, players, games, and stats,
+- who can track games,
+- who can manage teams, rosters, members, and invites,
+- who can correct finalized stats,
+- who can manage player guardianship,
+- who can perform support/admin actions across the app.
+
+The first pass should improve current basketball/team workflows while staying sport-agnostic
+so soccer, baseball, football, and other future sports inherit the same permissions model.
+
+---
+
+## 2. Current Model
+
+Shipped today:
+
+- Supabase auth gates cloud usage.
+- Team roles are stored in `team_members.role`: `owner`, `admin`, `scorer`.
+- Team membership has accepted and pending states through `team_members.accepted_at`.
+- Owner/admin users can invite members, manage roster/member surfaces, merge players,
+  reassign primary recorders, and correct finalized stats.
+- Scorer users can view team info and track games, but should not get privileged
+  management actions.
+- `player_guardians` links users to players and allows player pool reuse and player
+  profile editing.
+- Email invites exist. Invite links are designed but not implemented.
+- App-level account management exists, but app-level approval/suspension/admin support
+  does not.
+
+---
+
+## 3. Known Gaps
+
+- No single access matrix documents roles, resources, and actions.
+- No true read-only team role. "Scorer" is not read-only because it can track games.
+- Pending invites may be treated as membership in some broad team/member policies.
+- Owner/admin/scorer UI gates are repeated in several files.
+- Admin member-management behavior should be made explicit across UI, RPCs, and RLS.
+- Guardianship is powerful but not deeply managed or audited.
+- Invite by email requires the invitee to already have an account.
+- No app-level access status for private beta, suspensions, support users, or global admins.
+- No unified audit trail for role changes, invite activity, guardian changes, or access changes.
+
+---
+
+## 4. Guiding Decisions
+
+- Keep app-level roles separate from team roles.
+- Keep team-level roles sport-agnostic.
+- Treat player guardianship as a player relationship, not a team role.
+- Prefer shared permission helpers over one-off UI checks.
+- RLS and RPC authorization are the source of enforcement; UI gates are user experience,
+  not security.
+- Pending invite rows should not grant the same visibility as accepted membership unless
+  a phase explicitly decides otherwise.
+- Avoid broad "super admin" behavior until app-level access is planned and audited.
+- Add migrations in small, reviewable phases.
+
+---
+
+## 5. Phase Roadmap
+
+| Phase | Plan | Purpose |
+|---|---|---|
+| SEC-0 | `PLAN_SEC_0_ACCESS_MATRIX_AND_AUDIT.md` | Define the role/action matrix and inspect current UI/RLS behavior. |
+| SEC-1 | `PLAN_SEC_1_TEAM_ACCESS_CLEANUP.md` | Clean up current owner/admin/scorer behavior without adding new roles. |
+| SEC-2 | `PLAN_SEC_2_VIEWER_ROLE.md` | Add a true read-only `viewer` team role. |
+| SEC-3 | `PLAN_SEC_3_INVITE_LINKS.md` | Implement DB-backed invite links and join flow. |
+| SEC-4 | `PLAN_SEC_4_GUARDIANSHIP_REVIEW.md` | Make player guardianship clearer, safer, and manageable. |
+| SEC-5 | `PLAN_SEC_5_APP_LEVEL_ACCESS.md` | Add optional app-level access controls such as active/pending/suspended and app admin. |
+| SEC-6 | `PLAN_SEC_6_AUDIT_TRAIL.md` | Add durable audit records and an admin/support view for sensitive changes. |
+
+Recommended order:
+
+1. SEC-0
+2. SEC-1
+3. SEC-2
+4. SEC-3
+5. SEC-4
+6. SEC-5
+7. SEC-6
+
+SEC-5 and SEC-6 can move earlier if private-beta access or support/admin workflows become
+urgent.
+
+---
+
+## 6. Q&A Cadence
+
+Each phase plan includes a Q&A section. Before implementing a phase, use that section to
+answer one question at a time in chat.
+
+Recommended Q&A pattern:
+
+1. Confirm the product default.
+2. Decide the strictness level.
+3. Decide whether the phase needs a Supabase migration.
+4. Decide which manual regression users/accounts are required.
+5. Decide what is explicitly deferred.
+
+When a Q&A answer is chosen, update the phase plan before implementation so the code pass
+has stable decisions.
+
+### Resolved Q&A defaults
+
+- Pending invitees see invite summary only until they accept.
+- Admins can invite/remove scorers/viewers, but cannot remove the owner or change
+  owner/admin roles.
+- Scorers can start, resume, and track games.
+- Guardians keep current player profile edit behavior, narrowed in SEC-4 to player identity
+  fields rather than roster/team fields.
+- App-level access waits until SEC-5.
+- SEC-1 may include narrow RLS fixes if pending invite visibility is too broad.
+- Scorers who reach `/team/manage` get read-only/unavailable behavior or redirect to
+  Team Info.
+- Add a reusable access-denied/unavailable component in SEC-1.
+- Viewer is a read-only accepted team member: same read visibility, in-progress games
+  read-only, same member list, email-invite first, no guardian claims.
+- Invite links create Scorer/Viewer only, are single-use, expire after 7 days, require
+  confirmation, and show active links with Copy/Revoke.
+- Guardian claims remain self-service; creator, self, and team owner/admin can remove
+  guardians; durable audit waits for SEC-6.
+- New signups are active by default; app-admin tools live under Settings -> Advanced ->
+  App access when pending/suspended workflows ship; suspended sessions do not keep local
+  app access; app admins do not broadly bypass team RLS.
+- Audit is visible to team owner/admin for team-scoped events and app admins for all events;
+  no personal activity page in v1; audit writes use action-specific RPCs/triggers; keep
+  `player_merge_audit` separate; member and invite-link events ship first.
+
+---
+
+## 7. Cross-Sport Notes
+
+All SEC phases should work for every sport.
+
+- Basketball-specific settings stay under Settings -> Sports -> Basketball.
+- Team roles should not mention basketball.
+- Game tracking permission should apply to any sport tracker.
+- Future soccer field/baseball diamond/football field UIs should call the same team access
+  helpers that basketball uses.
+- Invite links, viewer role, guardianship, and app-level access should not need sport-specific
+  schema.
+
+---
+
+## 8. Regression Themes
+
+Every implementation phase should add or update checks for:
+
+- owner/admin/scorer behavior,
+- pending vs accepted invite visibility,
+- owner/admin-only controls hidden from lower roles,
+- server/RLS denial when UI gates are bypassed,
+- local/offline behavior where applicable,
+- multi-sport team/game behavior once more sports ship.
+
+---
+
+## 9. Non-Goals
+
+- Full organization/league hierarchy.
+- Paid subscriptions.
+- Public team pages.
+- Email delivery service for invites.
+- Cross-tenant support dashboard with direct data editing.
+- Replacing Supabase Auth.

--- a/docs/PLAN_SEC_0_ACCESS_MATRIX_AND_AUDIT.md
+++ b/docs/PLAN_SEC_0_ACCESS_MATRIX_AND_AUDIT.md
@@ -1,0 +1,186 @@
+# Plan: SEC-0 Access matrix and audit
+
+SEC-0 is a planning and audit phase. It should produce the role/action matrix that later
+phases implement.
+
+Depends on: AUTH-2, NAV-2, Team Info drilldown.
+
+---
+
+## 1. Goal
+
+Define exactly what each account, team, and player relationship can do.
+
+The output should be a single matrix that future phases can reference when changing UI,
+RPCs, RLS policies, and regression tests.
+
+---
+
+## 2. Current Inputs
+
+- Team roles: `owner`, `admin`, `scorer`.
+- Player relationship: `player_guardians`.
+- Invite state: `team_members.accepted_at`.
+- Admin correction authority: owner/admin.
+- Merge authority: owner/admin on every involved team.
+- Existing placeholder: `docs/archived/DESIGN_USER_PERMISSIONS_AND_ROLES.md`.
+
+---
+
+## 3. Scope
+
+- Inventory current permissions by resource and action.
+- Define the target role/action matrix.
+- Identify mismatches between desired behavior and current UI/RLS.
+- Decide which changes belong in SEC-1 through SEC-6.
+- Add regression scenarios for each role.
+
+Resources to include:
+
+- account/profile,
+- app access,
+- seasons,
+- teams,
+- team members,
+- team invites,
+- invite links,
+- roster rows,
+- players,
+- player guardians,
+- games,
+- game tracking,
+- game finalization,
+- stats and corrections,
+- primary recorder reassignment,
+- parked games/local data,
+- settings/admin pages.
+
+---
+
+## 4. Out Of Scope
+
+- Adding new roles.
+- Changing migrations.
+- Changing UI behavior.
+- Building invite links.
+- Building app-level access.
+
+SEC-0 may create docs only.
+
+---
+
+## 5. Recommended Matrix Shape
+
+Rows:
+
+- App user states: signed out, active user, suspended user, app admin.
+- Team roles: owner, admin, scorer, future viewer.
+- Player relationship: guardian, creator.
+- Invite states: pending invitee, accepted member.
+
+Columns:
+
+- View team.
+- View roster.
+- View schedule.
+- View finalized stats.
+- Track game.
+- Start/resume cloud game.
+- Finalize game.
+- Edit roster.
+- Edit player profile.
+- Claim/manage guardianship.
+- Invite members.
+- Remove members.
+- Change member role.
+- Correct stats.
+- Reassign primary recorder.
+- Merge players.
+- Delete team/game/player.
+- Export/import local parked games.
+
+Use values:
+
+- Allow.
+- Deny.
+- Own only.
+- Owner only.
+- Owner/admin.
+- Future phase.
+
+---
+
+## 6. Implementation Notes
+
+Recommended files:
+
+- `docs/PLAN_ADMIN_SECURITY_ROADMAP.md`
+- `docs/PLAN_SEC_0_ACCESS_MATRIX_AND_AUDIT.md`
+- `docs/REGRESSION_TESTING.md`
+- optionally `docs/ACCESS_MATRIX.md` if the matrix becomes large.
+
+Code inspection targets:
+
+- `src/pages/Teams.tsx`
+- `src/pages/TeamManage.tsx`
+- `src/pages/TeamInfo.tsx`
+- `src/pages/GameSummary.tsx`
+- `src/pages/GameSetup.tsx`
+- `src/pages/Games.tsx`
+- `src/lib/mergePlayerScope.ts`
+- `supabase/migrations/011_team_invites.sql`
+- `supabase/migrations/013_rls_auth_uid_cached.sql`
+- `supabase/migrations/018_seasons_and_roster_junction.sql`
+- `supabase/migrations/024_player_merge_rpcs.sql`
+
+---
+
+## 7. Q&A Session
+
+Ask these one at a time before implementation.
+
+1. Should pending invitees see any team data before accepting?
+   - Recommended: No, only enough data to decide whether to accept.
+   - Option B: Yes, pending invitees can preview team name/season only.
+   - Option C: Yes, pending invitees get full member visibility.
+
+2. Should `admin` be able to remove members and change roles, or owner only?
+   - Recommended: Admin can invite/remove scorers/viewers but cannot remove owner or change owner/admin roles.
+   - Option B: Owner only manages all members.
+   - Option C: Admin has near-owner powers except deleting/transferring team.
+
+3. Should `scorer` be allowed to start new games?
+   - Recommended: Yes, scorer can start/track games for accepted teams.
+   - Option B: Scorer can only resume games created by owner/admin.
+   - Option C: Scorer can only track assigned games.
+
+4. Should player guardianship allow player profile edits by default?
+   - Recommended: Yes for existing behavior, but SEC-4 reviews approval/removal.
+   - Option B: Guardian edit becomes owner/admin approved.
+   - Option C: Guardian can view/pool only, not edit profile fields.
+
+5. Does app-level access control need to ship before viewer/invite links?
+   - Recommended: No, keep SEC-5 later unless private beta/suspension is urgent.
+   - Option B: Yes, add app access first.
+
+---
+
+## 8. Resolved Decisions
+
+- Pending invitees see invite summary only before accepting.
+- Admins can invite/remove scorers/viewers, but cannot remove owner or change owner/admin
+  roles.
+- Scorers can start, resume, and track games for accepted teams.
+- Guardians keep current player profile edit behavior; SEC-4 narrows and clarifies the
+  management model.
+- App-level access control does not block viewer role or invite links; it remains SEC-5.
+
+---
+
+## 9. Acceptance Criteria
+
+- A reviewed matrix exists.
+- Every later SEC phase has stable dependencies and deferrals.
+- Current mismatches are listed with file/RLS references.
+- Regression checklist includes owner/admin/scorer/pending invite cases.
+- No runtime behavior changes are made in SEC-0.

--- a/docs/PLAN_SEC_1_TEAM_ACCESS_CLEANUP.md
+++ b/docs/PLAN_SEC_1_TEAM_ACCESS_CLEANUP.md
@@ -1,0 +1,136 @@
+# Plan: SEC-1 Team access cleanup
+
+SEC-1 cleans up the current owner/admin/scorer model before adding new roles.
+
+Depends on: SEC-0.
+
+---
+
+## 1. Goal
+
+Make the existing role model consistent across UI, RPCs, RLS, and docs.
+
+SEC-1 should not add `viewer`, invite links, or app-level access. It should reduce risk in
+the current behavior before expanding the access model.
+
+---
+
+## 2. Current Behavior To Preserve
+
+- Owner/admin can manage roster and members.
+- Owner/admin can invite users by email.
+- Owner/admin can merge players when authorized for every involved team.
+- Owner/admin can correct finalized stats and reassign primary recorder.
+- Scorer can view accepted teams and track games.
+- Lower roles should not see or successfully call privileged actions.
+
+---
+
+## 3. Scope
+
+- Create shared role/permission helpers in app code.
+- Replace repeated inline owner/admin checks where practical.
+- Make member-management UI use the same permission helper.
+- Review `team_members.accepted_at` behavior in client queries and RLS.
+- Ensure pending invites do not accidentally grant full accepted-member visibility.
+- Confirm admin member removal/changing behavior is intentional.
+- Improve unavailable/error copy when an action is denied by RLS.
+- Add targeted tests for pure permission helpers.
+- Update regression docs.
+
+---
+
+## 4. Out Of Scope
+
+- New database role values.
+- Invite links.
+- Guardian approval flow.
+- App-level user access.
+- Audit table.
+- Big UI redesign.
+
+---
+
+## 5. Suggested Implementation
+
+Potential helper:
+
+```ts
+type TeamRole = 'owner' | 'admin' | 'scorer'
+
+canManageTeam(role)
+canManageMembers(role)
+canInviteMembers(role)
+canTrackGames(role)
+canCorrectStats(role)
+canMergePlayers(role)
+canDeleteTeam(role)
+```
+
+Potential files:
+
+- `src/lib/teamPermissions.ts`
+- `src/lib/teamPermissions.test.ts`
+- `src/pages/Teams.tsx`
+- `src/pages/TeamManage.tsx`
+- `src/pages/TeamInfo.tsx`
+- `src/pages/GameSummary.tsx`
+- `docs/REGRESSION_TESTING.md`
+
+Potential migration/RLS review:
+
+- `011_team_invites.sql`
+- `013_rls_auth_uid_cached.sql`
+- `018_seasons_and_roster_junction.sql`
+
+If SEC-1 reveals that accepted-member filtering must change in RLS, split the SQL change
+into a small migration rather than burying it in a broad UI cleanup.
+
+---
+
+## 6. Q&A Session
+
+Ask these one at a time before implementation.
+
+1. Should SEC-1 include RLS changes if pending invites currently see too much?
+   - Recommended: Yes, if the mismatch is confirmed and can be fixed narrowly.
+   - Option B: Document only and defer RLS to SEC-2.
+
+2. Should admins be allowed to remove other admins?
+   - Recommended: No, owner-only for removing/changing admin roles.
+   - Option B: Yes, admins can remove any non-owner.
+   - Option C: Owner-only for all removal.
+
+3. Should owners be transferable in SEC-1?
+   - Recommended: No, owner transfer is a later dedicated phase.
+   - Option B: Add owner transfer now.
+
+4. Should scorer users see `/team/manage` at all?
+   - Recommended: They may reach it, but it should be read-only or redirect to Team Info.
+   - Option B: Hide/redirect entirely.
+
+5. Should SEC-1 add an access-denied component?
+   - Recommended: Yes, a small reusable "You do not have access" state.
+   - Option B: Keep page-specific copy only.
+
+---
+
+## 7. Resolved Decisions
+
+- Include narrow RLS fixes if audit confirms pending invites see too much.
+- Admins cannot remove other admins; admins remove scorers/viewers only.
+- Owner transfer is not part of SEC-1.
+- Scorers reaching `/team/manage` get read-only/unavailable behavior or redirect to Team
+  Info.
+- Add a reusable access-denied/unavailable component.
+
+---
+
+## 8. Acceptance Criteria
+
+- Shared permission helper exists and is tested.
+- Owner/admin/scorer gates use the helper on key pages.
+- Scorer cannot see privileged controls.
+- Bypassing UI still fails server-side for privileged writes.
+- Pending invite behavior is documented and tested.
+- Existing owner/admin/scorer happy paths still work.

--- a/docs/PLAN_SEC_2_VIEWER_ROLE.md
+++ b/docs/PLAN_SEC_2_VIEWER_ROLE.md
@@ -1,0 +1,137 @@
+# Plan: SEC-2 Viewer role
+
+SEC-2 adds a true read-only team role.
+
+Depends on: SEC-0, SEC-1.
+
+---
+
+## 1. Goal
+
+Allow a user to see team information without being able to track games or manage team data.
+
+This supports parents, family, or supporters who should follow roster/schedule/results but
+should not affect stats or game operations.
+
+---
+
+## 2. Proposed Role
+
+Add `viewer` to `team_members.role`.
+
+Viewer can:
+
+- view accepted team,
+- view Team Info,
+- view roster,
+- view schedule,
+- view finalized game summaries,
+- view season/player/team stats where already visible to team members.
+
+Viewer cannot:
+
+- start games,
+- resume/track games,
+- finalize games,
+- edit roster,
+- edit team metadata,
+- invite/remove members,
+- correct stats,
+- reassign primary recorder,
+- merge players,
+- delete teams/games/players,
+- claim guardianship unless SEC-4 explicitly allows it.
+
+---
+
+## 3. Scope
+
+- Add `viewer` role support in DB constraints/RPC validation.
+- Update invite dropdowns to include Viewer.
+- Update permission helper from SEC-1.
+- Hide or disable track/start/manage actions for viewer.
+- Ensure RLS allows read paths but denies write paths.
+- Add regression checks for viewer.
+
+---
+
+## 4. Out Of Scope
+
+- Public/no-login team pages.
+- Partial player visibility.
+- Guardian approval changes.
+- App-level suspension/approval.
+- Org/league roles.
+
+---
+
+## 5. Suggested Implementation
+
+Migration:
+
+- Update any role CHECK constraints if present.
+- Update `invite_team_member` role validation.
+- Update invite-link role validation later in SEC-3.
+- Review policies that assume all team members can write.
+
+App:
+
+- Update `TeamRole` union.
+- Update permission helper.
+- Add Viewer option to invite UI.
+- Remove or disable start/track actions when role is viewer.
+- Ensure Team Info read paths still work.
+
+Tests:
+
+- Permission helper tests.
+- Manual user flow with owner/admin/scorer/viewer.
+
+---
+
+## 6. Q&A Session
+
+Ask these one at a time before implementation.
+
+1. Should viewer see in-progress games?
+   - Recommended: Yes, list them as read-only, but no Resume/Track action.
+   - Option B: Only finalized games.
+   - Option C: No cloud games, only roster/schedule.
+
+2. Should viewer see all player profiles/stats?
+   - Recommended: Yes, same read visibility as accepted team members.
+   - Option B: Only roster and game summaries.
+   - Option C: Only team-level stats.
+
+3. Should viewer appear in the same member list?
+   - Recommended: Yes, with role label "Viewer".
+   - Option B: Separate "Viewers" section.
+
+4. Should viewer be inviteable by email only at first?
+   - Recommended: Yes, then invite links support viewer in SEC-3.
+   - Option B: Wait for SEC-3 and ship viewer with invite links.
+
+5. Should viewer be allowed to claim player guardianship?
+   - Recommended: No, defer to SEC-4.
+   - Option B: Yes, if they can see the player.
+
+---
+
+## 7. Resolved Decisions
+
+- Viewer can see in-progress games read-only, with no Resume/Track action.
+- Viewer gets the same read visibility as accepted team members.
+- Viewer appears in the same member list with role label "Viewer".
+- Viewer is inviteable by email first; invite-link support follows in SEC-3.
+- Viewer cannot claim guardianship.
+
+---
+
+## 8. Acceptance Criteria
+
+- Owner/admin can invite a viewer.
+- Viewer can accept invite and see team read-only pages.
+- Viewer cannot track/start/resume/finalize games.
+- Viewer cannot manage roster/members/invites.
+- Viewer cannot correct stats, merge players, or reassign primary.
+- Server-side checks deny viewer writes even if UI is bypassed.

--- a/docs/PLAN_SEC_3_INVITE_LINKS.md
+++ b/docs/PLAN_SEC_3_INVITE_LINKS.md
@@ -1,0 +1,143 @@
+# Plan: SEC-3 Invite links
+
+SEC-3 implements shareable team invite links.
+
+Depends on: SEC-0, SEC-1. Ideally follows SEC-2 if `viewer` should be a link role.
+
+---
+
+## 1. Goal
+
+Let owner/admin users add parents or team helpers without knowing their email in advance.
+
+The inviter creates a link, shares it externally, and the invitee signs in or signs up to
+join the team.
+
+---
+
+## 2. Recommended Model
+
+Use a DB-backed token table rather than signed stateless links.
+
+Reasons:
+
+- revocable,
+- expirable,
+- auditable later,
+- listable in team management,
+- easier to extend to multi-use links.
+
+Default v1:
+
+- URL: `/#/invite/:token`
+- single-use token,
+- default expiry: 7 days,
+- fixed role selected when link is created,
+- owner/admin can create link,
+- owner/admin can revoke link.
+
+---
+
+## 3. Scope
+
+- Add `team_invite_links` table.
+- Add RPCs to create, resolve, redeem, and revoke links.
+- Add Team Manage UI for create/copy/revoke invite links.
+- Add route/page `/#/invite/:token`.
+- Support signed-out users returning to the invite after auth.
+- Preserve existing email invite flow.
+- Add regression tests for owner/admin/link/invitee cases.
+
+---
+
+## 4. Out Of Scope
+
+- Sending email/SMS.
+- Multi-use/unlimited links in v1.
+- Public team pages.
+- Org/league invites.
+- QR codes.
+- Invite analytics beyond basic audit fields.
+
+---
+
+## 5. Data Model Sketch
+
+Table: `team_invite_links`
+
+Columns:
+
+- `id uuid primary key`
+- `team_id uuid not null references teams(id) on delete cascade`
+- `role text not null`
+- `token text not null unique`
+- `created_by uuid not null references profiles(id)`
+- `expires_at timestamptz not null`
+- `redeemed_by uuid null references profiles(id)`
+- `redeemed_at timestamptz null`
+- `created_at timestamptz not null default now()`
+
+RPCs:
+
+- `create_team_invite_link(p_team_id uuid, p_role text, p_expires_in_days int)`
+- `get_team_invite_link(p_token text)`
+- `redeem_team_invite_link(p_token text)`
+- `revoke_team_invite_link(p_link_id uuid)`
+
+Security:
+
+- token must be cryptographically random and URL-safe.
+- create/revoke require owner/admin.
+- redeem requires signed-in user.
+- resolve can return only limited team info for signed-out users.
+- expired/redeemed/revoked links cannot be redeemed.
+
+---
+
+## 6. Q&A Session
+
+Ask these one at a time before implementation.
+
+1. Which roles can invite links create?
+   - Recommended: Scorer and Viewer if SEC-2 shipped; otherwise Scorer only.
+   - Option B: Scorer/Admin/Viewer.
+   - Option C: Scorer only for v1.
+
+2. Should links be single-use or multi-use?
+   - Recommended: Single-use for v1.
+   - Option B: Multi-use with max uses.
+   - Option C: Unlimited until expiry.
+
+3. What should default expiry be?
+   - Recommended: 7 days.
+   - Option B: 24 hours.
+   - Option C: 30 days.
+
+4. Should signed-in invitees auto-join or confirm first?
+   - Recommended: Confirm first: "Join Team as Role?"
+   - Option B: Auto-join after opening valid link.
+
+5. Should link creation show active links in v1?
+   - Recommended: Yes, list active links with Copy/Revoke.
+   - Option B: Only show the last created link.
+
+---
+
+## 7. Resolved Decisions
+
+- Invite links can create Scorer and Viewer only.
+- Invite links are single-use in v1.
+- Default expiry is 7 days.
+- Signed-in invitees confirm before joining.
+- Team Manage shows active invite links with role, expiry, Copy, and Revoke.
+
+---
+
+## 8. Acceptance Criteria
+
+- Owner/admin can create and copy an invite link.
+- Unauthorized users cannot create/revoke links.
+- Signed-out invitee can authenticate and return to invite.
+- Signed-in invitee can redeem link and join team.
+- Redeemed/expired/revoked links cannot be reused.
+- Existing email invite flow still works.

--- a/docs/PLAN_SEC_4_GUARDIANSHIP_REVIEW.md
+++ b/docs/PLAN_SEC_4_GUARDIANSHIP_REVIEW.md
@@ -1,0 +1,120 @@
+# Plan: SEC-4 Guardianship review
+
+SEC-4 clarifies and hardens player-level guardianship.
+
+Depends on: SEC-0, SEC-1. Can happen before or after SEC-3.
+
+---
+
+## 1. Goal
+
+Make player guardianship understandable and safe.
+
+Guardianship is separate from team roles. It controls a user's relationship to a player
+across teams/seasons, especially player pool reuse and player profile editing.
+
+---
+
+## 2. Current Behavior
+
+- `player_guardians` links users to players.
+- Player creators are backfilled/created as guardians.
+- A user can claim guardianship from roster UI.
+- Guardians can edit player profile fields.
+- Guardians can find players in their player pool for future rosters.
+- Player merge preserves guardian links.
+
+---
+
+## 3. Scope
+
+- Decide whether guardian claims stay self-service or require approval.
+- Add clearer UI for who is a guardian of a player.
+- Add remove guardian action for appropriate users.
+- Decide whether guardian edit rights should be full or limited.
+- Add regression checks for creator, guardian, team admin, scorer, and future viewer.
+- Document how guardianship interacts with team roles.
+
+---
+
+## 4. Out Of Scope
+
+- Legal/identity verification.
+- Child account support.
+- Public profile sharing.
+- Org-level player ownership.
+- Split/undo player merge.
+
+---
+
+## 5. Implementation Options
+
+Option A: keep self-service claim, improve management.
+
+- Lowest friction.
+- Current behavior mostly stays.
+- Add guardian list and remove action.
+
+Option B: owner/admin approval required.
+
+- Safer for data control.
+- Requires pending guardian claims.
+- More UI and migration work.
+
+Option C: guardian code/link.
+
+- Team owner gives a claim code or link for a player.
+- Safer than self-service but less heavy than full approval workflow.
+- Could share mechanics with invite links.
+
+Recommended first pass: Option A unless user trust/privacy concerns are high.
+
+---
+
+## 6. Q&A Session
+
+Ask these one at a time before implementation.
+
+1. Should guardian claims remain self-service?
+   - Recommended: Yes for now, with clearer UI and removal controls.
+   - Option B: Require owner/admin approval.
+   - Option C: Use player-specific claim links/codes.
+
+2. Who can remove a guardian?
+   - Recommended: player creator, current guardian removing self, and owner/admin of a team the player is on.
+   - Option B: creator only plus self-remove.
+   - Option C: owner/admin only.
+
+3. What can guardians edit?
+   - Recommended: player profile identity fields only, not roster/team fields.
+   - Option B: full player edits as today.
+   - Option C: read/pool only, no edits.
+
+4. Should viewers be allowed to become guardians?
+   - Recommended: No by default; require scorer/admin or explicit approval.
+   - Option B: Yes if they can see roster.
+
+5. Should guardianship changes be audited immediately?
+   - Recommended: Defer durable audit to SEC-6 but add enough UI history/copy now.
+   - Option B: Add audit table in SEC-4.
+
+---
+
+## 7. Resolved Decisions
+
+- Guardian claims remain self-service.
+- Player creator, current guardian removing self, and owner/admin of a team the player is on
+  can remove guardians.
+- Guardians can edit player profile identity fields only, not roster/team fields.
+- Viewers cannot become guardians by default.
+- Durable guardianship audit is deferred to SEC-6.
+
+---
+
+## 8. Acceptance Criteria
+
+- Users can understand whether they are a guardian of a player.
+- Authorized users can remove guardian links according to selected policy.
+- Guardian edit behavior is documented and tested.
+- Team role and guardian relationship are not conflated.
+- Player pool behavior still works.

--- a/docs/PLAN_SEC_5_APP_LEVEL_ACCESS.md
+++ b/docs/PLAN_SEC_5_APP_LEVEL_ACCESS.md
@@ -1,0 +1,130 @@
+# Plan: SEC-5 App-level access
+
+SEC-5 adds optional platform-level access control separate from team roles.
+
+Depends on: AUTH-2. Can happen before SEC-2/SEC-3 if private beta or suspension controls
+become urgent.
+
+---
+
+## 1. Goal
+
+Control who can use StatKeeper after authentication.
+
+Supabase Auth proves identity. App-level access decides whether that identity is active,
+pending approval, suspended, or allowed to perform platform support/admin actions.
+
+---
+
+## 2. Proposed Concepts
+
+Account status:
+
+- `active`
+- `pending`
+- `suspended`
+
+App role:
+
+- `user`
+- `app_admin`
+
+These should not replace team roles. A user can be app-level `user` and team-level `owner`
+on one team, `scorer` on another, and `viewer` on another.
+
+---
+
+## 3. Scope
+
+- Add app access table or profile extension.
+- Load app access state after login.
+- Gate the authenticated app shell for pending/suspended users.
+- Add app-admin-only view under Settings or a new admin route.
+- Allow app admin to approve/suspend/reactivate users.
+- Add clear user-facing copy for pending/suspended states.
+- Keep local/offline mode behavior understandable.
+
+---
+
+## 4. Out Of Scope
+
+- Billing.
+- Organization-level administration.
+- Full support dashboard with data editing.
+- Impersonation.
+- Password/email management.
+
+---
+
+## 5. Data Model Options
+
+Option A: add columns to `profiles`.
+
+- `app_status text default 'active'`
+- `app_role text default 'user'`
+
+Pros: simple.
+
+Cons: mixes profile data with access control.
+
+Option B: new `account_access` table.
+
+- `user_id uuid primary key references profiles(id)`
+- `status text not null default 'active'`
+- `app_role text not null default 'user'`
+- `updated_by uuid null`
+- `updated_at timestamptz not null`
+
+Pros: clearer boundary and easier auditing.
+
+Cons: new table/RLS/RPCs.
+
+Recommended: Option B.
+
+---
+
+## 6. Q&A Session
+
+Ask these one at a time before implementation.
+
+1. Should new Google/email signups be active by default?
+   - Recommended: Yes for now.
+   - Option B: Pending by default for private beta.
+   - Option C: Active only for allowlisted domains/emails.
+
+2. Do we need app admins immediately?
+   - Recommended: Only if pending/suspended workflow ships.
+   - Option B: Add status table now but app-admin UI later.
+
+3. Where should app-admin tools live?
+   - Recommended: Settings -> Advanced -> App access, visible only to app admins.
+   - Option B: New `/app-admin` route.
+
+4. Should suspended users keep local/offline access?
+   - Recommended: No for cloud-authenticated session; show suspended state.
+   - Option B: Yes, allow offline-only local tracking.
+
+5. Should app admins bypass team RLS?
+   - Recommended: No. App admin support actions should use explicit RPCs, not broad bypass.
+   - Option B: Limited read-only support RPCs.
+
+---
+
+## 7. Resolved Decisions
+
+- New Google/email signups are active by default.
+- App admins are only needed when pending/suspended workflow ships.
+- App-admin tools live under Settings -> Advanced -> App access.
+- Suspended users do not keep local/offline access through that authenticated session.
+- App admins do not bypass team RLS; support/admin actions use explicit narrow RPCs if
+  needed later.
+
+---
+
+## 8. Acceptance Criteria
+
+- Active users can use the app normally.
+- Pending users see a pending/access message.
+- Suspended users see a suspended/access message and cannot access cloud app routes.
+- App admins can view/manage access state if the UI ships.
+- Team roles remain unchanged and separate.

--- a/docs/PLAN_SEC_6_AUDIT_TRAIL.md
+++ b/docs/PLAN_SEC_6_AUDIT_TRAIL.md
@@ -1,0 +1,138 @@
+# Plan: SEC-6 Audit trail
+
+SEC-6 adds durable audit history for sensitive access and admin actions.
+
+Depends on: SEC-0. Best after SEC-1 through SEC-5 define the actions worth auditing.
+
+---
+
+## 1. Goal
+
+Record who changed important access or admin state, what changed, and when.
+
+This helps support, debugging, trust, and future app-admin workflows.
+
+---
+
+## 2. Candidate Events
+
+Team/member:
+
+- member invited,
+- invite accepted/declined,
+- invite link created/redeemed/revoked,
+- member role changed,
+- member removed,
+- owner transferred.
+
+Player/guardian:
+
+- guardian claimed,
+- guardian approved,
+- guardian removed,
+- player merged.
+
+Game/stats:
+
+- stat correction created/updated/deleted,
+- primary recorder reassigned,
+- game finalized/unfinalized if that ever exists.
+
+App access:
+
+- user approved,
+- user suspended,
+- user reactivated,
+- app role changed.
+
+---
+
+## 3. Scope
+
+- Define audit event schema.
+- Add write helpers/RPCs for new SEC actions.
+- Decide whether to backfill existing audit sources such as `player_merge_audit`.
+- Add read UI for relevant scopes.
+- Add regression checks for audit writes on sensitive actions.
+
+---
+
+## 4. Out Of Scope
+
+- Full immutable event-sourcing rewrite.
+- Reconstructing all historical activity.
+- User-facing activity feeds for every minor change.
+- Impersonation logs unless impersonation is introduced.
+
+---
+
+## 5. Data Model Sketch
+
+Table: `access_audit_events`
+
+Columns:
+
+- `id uuid primary key`
+- `event_type text not null`
+- `actor_user_id uuid null references profiles(id)`
+- `target_user_id uuid null references profiles(id)`
+- `team_id uuid null references teams(id)`
+- `player_id uuid null references players(id)`
+- `game_id uuid null references games(id)`
+- `metadata jsonb not null default '{}'::jsonb`
+- `created_at timestamptz not null default now()`
+
+RLS:
+
+- App admins can read all if SEC-5 exists.
+- Team owner/admin can read events scoped to their teams.
+- Users can read events where they are actor/target if product wants that transparency.
+- Writes should happen through RPCs or triggers, not direct client inserts.
+
+---
+
+## 6. Q&A Session
+
+Ask these one at a time before implementation.
+
+1. Should audit be team-visible or app-admin-only?
+   - Recommended: Team owner/admin can see team-scoped audit; app admins can see all.
+   - Option B: App-admin-only.
+   - Option C: Minimal internal table, no UI yet.
+
+2. Should users see audit events about themselves?
+   - Recommended: Not in v1, except through normal UI state.
+   - Option B: Yes, account activity page.
+
+3. Should audit writes be centralized in one RPC?
+   - Recommended: Use small action-specific RPCs/triggers rather than client-side direct insert.
+   - Option B: One generic `record_audit_event` RPC.
+
+4. Should existing `player_merge_audit` be kept separate?
+   - Recommended: Keep it, optionally mirror future merge events into unified audit.
+   - Option B: Migrate/replace with unified audit.
+
+5. Which event should SEC-6 implement first?
+   - Recommended: Member role/removal/invite-link events.
+   - Option B: App access events if SEC-5 ships first.
+   - Option C: Guardian events if SEC-4 ships first.
+
+---
+
+## 7. Resolved Decisions
+
+- Team owner/admin can see team-scoped audit; app admins can see all.
+- Users do not get a personal audit/activity page in v1.
+- Audit writes use action-specific RPCs/triggers, not one generic write-anything endpoint.
+- Keep `player_merge_audit` separate, with optional future mirroring.
+- Implement member role/removal and invite-link events first.
+
+---
+
+## 8. Acceptance Criteria
+
+- Sensitive actions write audit events.
+- Authorized users can read the intended audit scope.
+- Unauthorized users cannot read other teams' audit events.
+- Audit metadata is useful but does not expose secrets or invite tokens.
+- Existing feature flows still work.

--- a/docs/archived/DESIGN_USER_PERMISSIONS_AND_ROLES.md
+++ b/docs/archived/DESIGN_USER_PERMISSIONS_AND_ROLES.md
@@ -1,6 +1,8 @@
 # Design (placeholder): User permissions & roles
 
-**Status:** Placeholder for **fine-grained** permissions beyond today’s **`team_members.role`** (`owner` | `admin` | `scorer`). Those coarse roles **are implemented** (invites, RLS, merge authorization, etc.). This doc is for a future permission matrix (read vs CRUD per resource).
+**Status:** Superseded by [`PLAN_ADMIN_SECURITY_ROADMAP.md`](../PLAN_ADMIN_SECURITY_ROADMAP.md) and the `PLAN_SEC_*.md` phase plans. This archived placeholder is retained for historical context.
+
+Original placeholder scope: fine-grained permissions beyond today’s **`team_members.role`** (`owner` | `admin` | `scorer`). Those coarse roles **are implemented** (invites, RLS, merge authorization, etc.). The active roadmap now covers the future permission matrix (read vs CRUD per resource).
 
 ## Intent
 


### PR DESCRIPTION
## Summary
- add a high-level admin/security/access roadmap
- add SEC-0 through SEC-6 phase plans with Q&A sections and resolved decisions
- point README to the new roadmap and mark the old permissions placeholder as superseded

## Verification
- git diff --check
- docs-only change; app tests not run