### PR TITLE
SEC-0: define access matrix and audit current security

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ docs/
 ├── PLAN_COURT_CAPTURE_ENHANCEMENTS_ROADMAP.md # F5–F13 roadmap; F11/F13 held
 ├── PLAN_F13_SHOT_DETAIL_EDIT_MODAL.md # Held draft: shot detail / edit
 ├── PLAN_MULTI_GAME_PARKING.md # Roadmap: local parking + sync queue + cloud ordering hardening shipped
+├── ACCESS_MATRIX.md       # Approved role/action contract and current security audit
 ├── PLAN_ADMIN_SECURITY_ROADMAP.md # Admin/security/access roadmap
 ├── PLAN_SEC_*.md        # Admin/security/access phase plans with Q&A sections
 ├── REGRESSION_TESTING.md  # High-level test scripts for all features
@@ -362,7 +363,7 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 
 - [ ] **Multi-game storage/ops follow-ups** — optional historical orphan cleanup tooling, full transactional/idempotent cloud sync, IndexedDB storage, import conflict UI, and richer quota recovery UX ([plan](docs/PLAN_MULTI_GAME_PARKING.md))
 - [ ] **Stat view follow-ups** — the major career/season/team/tournament stat views are shipped; use [DESIGN_STAT_TRACKING_UI.md](docs/DESIGN_STAT_TRACKING_UI.md) and [completed/STAT_TRACKING_UI_PROGRESS.md](docs/completed/STAT_TRACKING_UI_PROGRESS.md) as references for smaller refinements
-- [ ] Admin/security/access roadmap — role matrix, team access cleanup, viewer role, invite links, guardianship review, app-level access, and audit trail ([roadmap](docs/PLAN_ADMIN_SECURITY_ROADMAP.md))
+- [ ] Admin/security/access roadmap — SEC-0 access matrix/audit complete; team access cleanup, viewer role, invite links, guardianship review, app-level access, and audit trail remain ([matrix](docs/ACCESS_MATRIX.md), [roadmap](docs/PLAN_ADMIN_SECURITY_ROADMAP.md))
 - [ ] Per-sport stat refinements and additional stats (minutes for hockey/soccer/football, missed shots for hockey)
 - [ ] Player transfer UI: search/autocomplete for adding existing players to new teams (player pool / Add Existing already ships; this is UX polish)
 - [ ] Optional stat descriptions — toggle full stat names vs abbreviations

--- a/docs/ACCESS_MATRIX.md
+++ b/docs/ACCESS_MATRIX.md
@@ -1,0 +1,260 @@
+# StatKeeper access matrix
+
+Status: SEC-0 approved baseline (2026-07-15).
+
+This document is the product and security contract for SEC-1 through SEC-6. It records
+the intended access model separately from the current implementation so later phases can
+change UI gates, RPCs, and RLS policies without re-deciding the role model.
+
+Audit snapshot:
+
+- App source at `d4b8536` on `stattracker`.
+- Supabase migrations through `034_google_auth_profile_defaults.sql`.
+- SEC-0 changes documentation only. Findings below are not fixed by SEC-0.
+
+---
+
+## 1. Access model
+
+Access is composed from three independent layers:
+
+1. Account access: signed out, active, suspended, or app admin.
+2. Team relationship: owner, admin, scorer, viewer, or pending invitee.
+3. Player relationship: creator or guardian.
+
+The layers do not replace each other. For example, an app admin does not automatically
+become a team admin, and a team owner does not automatically become a player's guardian.
+
+Server-side authorization is authoritative. UI visibility is a usability layer and must
+match the server, but hiding a control is never the security boundary.
+
+### Terms
+
+- **Accepted member**: a `team_members` row with non-null `accepted_at`.
+- **Pending invitee**: a `team_members` row with null `accepted_at`.
+- **Own**: the authenticated account owns or created the resource.
+- **Relationship required**: access comes from creator/guardian status, not team role.
+- **Future**: the behavior is approved but ships in the named SEC phase.
+
+---
+
+## 2. Target team-role matrix
+
+This is the target contract. `viewer` becomes available in SEC-2. Until then, its column
+describes the approved future behavior.
+
+| Resource or action | Owner | Admin | Scorer | Viewer | Pending invitee |
+|---|---|---|---|---|---|
+| View team, roster, and schedule | Allow | Allow | Allow | Allow (SEC-2) | Deny |
+| View in-progress game listing | Allow | Allow | Allow | Read-only (SEC-2) | Deny |
+| View finalized games and stats | Allow | Allow | Allow | Allow (SEC-2) | Deny |
+| View member names, roles, and invite status | Allow | Allow | Allow | Allow (SEC-2) | Own invite summary only |
+| View member email addresses | Allow for management | Allow for management | Deny | Deny | Deny |
+| Start a team game | Allow | Allow | Allow | Deny | Deny |
+| Resume and track an in-progress game | Allow | Allow | Allow | Deny | Deny |
+| Finalize an in-progress game | Allow | Allow | Allow | Deny | Deny |
+| Edit team name or nickname | Allow | Allow | Deny | Deny | Deny |
+| Delete team | Allow | Deny | Deny | Deny | Deny |
+| Add, reactivate, or remove a roster entry | Allow | Allow | Deny | Deny | Deny |
+| Edit team-specific jersey/position fields | Allow | Allow | Deny | Deny | Deny |
+| Edit player identity fields | Relationship required | Relationship required | Relationship required | Relationship required | Relationship required |
+| Permanently delete a player record | Creator only | Creator only | Creator only | Creator only | Creator only |
+| Create a tournament while setting up a game | Allow | Allow | Allow | Deny | Deny |
+| Rename or delete a tournament | Allow | Allow | Deny | Deny | Deny |
+| Invite a scorer | Allow | Allow | Deny | Deny | Deny |
+| Invite an admin | Allow | Deny | Deny | Deny | Deny |
+| Invite a viewer | Allow (SEC-2) | Allow (SEC-2) | Deny | Deny | Deny |
+| Remove a scorer or viewer | Allow | Allow | Deny | Deny | Deny |
+| Remove or change an admin | Allow | Deny | Deny | Deny | Deny |
+| Remove or change the owner | Deny; transfer needs a future flow | Deny | Deny | Deny | Deny |
+| Change scorer/viewer role | Allow | Allow | Deny | Deny | Deny |
+| Correct finalized stats | Allow | Allow | Deny | Deny | Deny |
+| Reassign primary recorder | Allow | Allow | Deny | Deny | Deny |
+| Merge players | Allow when owner/admin on every involved team | Same | Deny | Deny | Deny |
+| Delete a cloud game | Allow | Allow | Deny | Deny | Deny |
+| Accept or decline invite | Not applicable | Not applicable | Not applicable | Not applicable | Own invite only |
+| Leave team | Deny until ownership is transferred | Allow | Allow | Allow (SEC-2) | Decline instead |
+
+Rules that cut across the table:
+
+- Accepted membership is required for every team-derived read or write.
+- Finalization ends normal raw game/stat writes. Later changes use explicit correction or
+  admin actions rather than editing recorder submissions in place.
+- Team role alone never grants permission to edit a player's global identity or delete
+  the global player record.
+- Owner transfer is not implied by role editing and needs a dedicated future design.
+
+---
+
+## 3. Target player-relationship matrix
+
+Player identity and roster membership are separate resources. A global player can appear
+on more than one team, while jersey number, position, and active status belong to each
+`team_players` row.
+
+| Resource or action | Creator | Guardian | Team owner/admin only | Scorer | Viewer | Pending invitee |
+|---|---|---|---|---|---|---|
+| View player identity outside a team | Allow | Allow | No relationship from role alone | Deny | Deny | Deny |
+| View player through an accepted team | Allow if related | Allow if related | Allow | Allow | Allow (SEC-2) | Deny |
+| Edit first/last/nickname identity fields | Allow | Allow | Only if also creator/guardian | Only if creator/guardian | Only if creator/guardian | Only if creator/guardian |
+| Edit jersey, position, or active status | Only if team owner/admin | Only if team owner/admin | Allow | Deny | Deny | Deny |
+| Add known player to a team | Only if team owner/admin | Only if team owner/admin | Allow when player is available in pool | Deny | Deny | Deny |
+| Claim guardianship | Allow if not already linked | Allow if not already linked | Allow (SEC-4) | Allow (SEC-4) | Deny | Deny |
+| Remove own guardianship | Allow | Allow | Not applicable | Not applicable | Not applicable | Not applicable |
+| Remove another guardian | Allow | Deny | Allow for a team containing player (SEC-4) | Deny | Deny | Deny |
+| Delete global player | Allow | Deny unless creator | Deny unless creator | Deny unless creator | Deny unless creator | Deny |
+| Merge player records | Relationship does not grant merge | Same | Owner/admin on every involved team | Deny | Deny | Deny |
+
+Guardian claims remain self-service in SEC-4, but they must be made from an authorized
+player context. Knowing a player UUID alone must not be sufficient. Guardianship does not
+grant team management, stat correction, or game tracking rights.
+
+---
+
+## 4. Account and app-level matrix
+
+| Resource or action | Signed out | Active user | Suspended user | App admin |
+|---|---|---|---|---|
+| Authenticate or recover account | Allow | Allow | Allow | Allow |
+| Use configured cloud app routes | Deny | Allow subject to relationships | Deny (SEC-5) | Allow subject to relationships |
+| Edit account profile and identities | Deny | Own account | Own account access flow only | Own account |
+| Use local app/sport preferences | Local-only mode only | Allow | Deny during authenticated suspended session (SEC-5) | Allow |
+| Export/import device parked games | Local-only mode only | Own device data | Deny during authenticated suspended session (SEC-5) | Own device data |
+| Manage owned seasons | Deny | Own seasons | Deny | Own seasons unless an explicit support RPC exists |
+| Manage app access state | Deny | Deny | Deny | Allow through narrow SEC-5 RPCs |
+| Bypass team RLS | Deny | Deny | Deny | Deny |
+| Read all audit events | Deny | Team-scoped owner/admin only (SEC-6) | Deny | Allow (SEC-6) |
+
+When Supabase is not configured, StatKeeper's existing local-only mode remains available
+without an account. SEC-5 applies to authenticated cloud sessions and must not silently
+turn app-admin status into broad team-data access.
+
+---
+
+## 5. Current implementation inventory
+
+The table below describes the effective model before SEC-1. Unless stated otherwise,
+current team policies treat any `team_members` row as membership and do not require
+`accepted_at`.
+
+| Resource | Current effective access | Primary source |
+|---|---|---|
+| `profiles` | Own profile plus rows allowed through the team-share policy; every visible row includes email, and owners can resolve owned-team profiles | `013_rls_auth_uid_cached.sql` |
+| `teams` | Owner or any membership row reads; owner/admin updates; owner deletes | `013_rls_auth_uid_cached.sql` |
+| `team_members` | User reads/updates/deletes own row; owner reads/deletes all; direct self-insert is allowed | `011_team_invites.sql`, `013_rls_auth_uid_cached.sql` |
+| Member profile RPC | Owner/admin role can list all members and emails | `get_team_members_with_profiles` in migration 011 |
+| Invite RPCs | Owner/admin role can look up and invite; accepted state is not checked | `lookup_user_by_email`, `invite_team_member` in migration 011 |
+| `seasons` | Owner and members of a season's teams read; owner alone writes/deletes | `018_seasons_and_roster_junction.sql` |
+| `team_players` | Team members read; owner/admin writes | `018_seasons_and_roster_junction.sql` |
+| `players` | Creator, guardian, or team member reads; creator/guardian updates; creator deletes | `018_seasons_and_roster_junction.sql` |
+| `player_guardians` | Self and team members read; anyone can insert a link for self; self/creator deletes | `018_seasons_and_roster_junction.sql` |
+| `games` | Team members read/insert/update; owner/admin deletes | `013_rls_auth_uid_cached.sql` |
+| `game_stats` | Team members read; recorder inserts/updates own rows | `013_rls_auth_uid_cached.sql` |
+| `player_checkouts` | Team members read; user writes/deletes own rows | `013_rls_auth_uid_cached.sql` |
+| `stat_corrections` | Team members read; owner/admin writes | `013_rls_auth_uid_cached.sql` |
+| Primary recorder RPC | Owner/admin role can reassign | `014_set_primary_recorder.sql` |
+| `tournaments` | Team members read/create; owner/admin updates/deletes | `016_tournaments.sql` |
+| Player merge RPCs | Owner/admin on every involved team can preview/execute | `024_player_merge_rpcs.sql` |
+| `player_merge_audit` | User reads only merges they performed | `025_player_merge_audit_select_policy.sql` |
+| `shot_chart` | Team members read; recorder writes/deletes own rows | `032_shot_chart.sql` |
+| `client_sync_errors` | User inserts/reads own rows | `033_client_sync_errors.sql` |
+| Authenticated app shell | Any authenticated Supabase user enters; no app status exists | `src/App.tsx`, `src/context/AuthContext.tsx` |
+| Local parked games | Device-local records scoped by stored owner id | `src/lib/gameParking.ts` |
+
+---
+
+## 6. Audit findings and phase ownership
+
+Severity describes authorization impact if a caller bypasses the UI and uses the
+Supabase API directly.
+
+| ID | Severity | Finding | Evidence | Owner phase |
+|---|---|---|---|---|
+| SEC0-01 | Critical | Pending invites currently satisfy team membership checks and can inherit team reads/writes before acceptance. | Membership subqueries in migrations 013, 016, 018, and 032 omit `accepted_at`. | SEC-1 |
+| SEC0-02 | Critical | `team_members_insert_self` permits a signed-in user to insert their own membership row for a known team and choose any currently valid role. | Migration 013 checks only `user_id = auth.uid()`. | SEC-1 |
+| SEC0-03 | Critical | `team_members_update_accept` permits changes to the caller's whole membership row, not only `accepted_at`; role and team reassignment are not constrained by the policy. | Migration 013 `USING`/`WITH CHECK` only constrain `user_id`. | SEC-1 |
+| SEC0-04 | Critical | `invite_team_member` upserts any existing member without target hierarchy checks, so an authorized admin call can reset an owner/admin row to a pending lower role. | Migration 011 unconditional `ON CONFLICT ... UPDATE role, accepted_at`. | SEC-1 |
+| SEC0-05 | High | Pending owner/admin rows also satisfy privileged correction, primary-recorder, invite, member-list, and merge RPC checks. | Migrations 009/011/014/024 check role but not acceptance. | SEC-1 |
+| SEC0-06 | High | Recorder-owned stat, checkout, and shot writes verify the actor column but do not verify accepted membership, game/team relationship, player/game relationship, or final-game immutability. | Policies in migrations 013 and 032. | SEC-1 |
+| SEC0-07 | High | Any membership row can update any column on a team game, including final games; finalization and raw-stat immutability are client conventions only. | `games_update_member` in migration 013; `useFinalizeGame.ts`. | SEC-1 |
+| SEC0-08 | High | There is no display-only member identity surface: any visible `profiles` row includes email, and the member RPC returns email to owner/admin roles, including pending admins. | `profiles_select_own` in migration 013; `profiles.email` and `get_team_members_with_profiles` from migration 011. | SEC-1 |
+| SEC0-09 | Medium | Admin member removal is approved and shown by the UI, but direct RLS allows only owner or self deletion; admins receive an RLS error. The UI also offers removal for admin targets. | `Teams.tsx`; `team_members_delete` in migration 013. | SEC-1 |
+| SEC0-10 | Medium | `/team/manage` shows add/edit/remove roster controls to scorers even though roster RLS rejects them; team list and Advanced settings similarly show edit/delete controls beyond the caller's authority. | `Teams.tsx`, `Admin.tsx`. | SEC-1 |
+| SEC0-11 | Medium | Cloud Games lists only games created by the current user, so accepted scorers/admins cannot discover and resume teammates' games from that page. Other team pages can display those games. | `Games.tsx` filters `created_by`; `TeamInfo.tsx` loads by `team_id`. | SEC-1 |
+| SEC0-12 | Medium | Team Info asks an owner/admin-only RPC for member data for every role; scorers receive an unavailable member card instead of an accepted-member-safe summary. | `TeamInfo.tsx`; `get_team_members_with_profiles` in migration 011. | SEC-1 |
+| SEC0-13 | Medium | Guardian self-insert requires only `user_id = auth.uid()` and can target any known player UUID; team owner/admin removal is not implemented. | `player_guardians_insert/delete` in migration 018; `Teams.tsx`. | SEC-4, with narrow SEC-1 containment if needed |
+| SEC0-14 | Planned | There is no read-only viewer role, and existing policies assume every member may write games. | Team role check and game policies in migrations 002/013. | SEC-2 |
+| SEC0-15 | Planned | There is no app-level active/pending/suspended state or app-admin role. | `App.tsx`, `AuthContext.tsx`, `profiles` schema. | SEC-5 |
+| SEC0-16 | Planned | Sensitive access changes do not have a unified durable audit trail; player merge has its own limited audit table. | Migrations 024/025. | SEC-6 |
+
+### SEC-1 minimum server-side scope
+
+The audit makes a migration mandatory for SEC-1. UI helpers alone cannot close findings
+SEC0-01 through SEC0-08. SEC-1 should, at minimum:
+
+1. Replace direct self-insert/update member policies with narrow invite acceptance and
+   decline/member-management RPCs.
+2. Require accepted membership in every team-derived policy and privileged RPC.
+3. Enforce target-role hierarchy for invite, role-change, and removal operations.
+4. Bind stat, checkout, and shot writes to an accepted team member, the referenced game,
+   and an appropriate player; reject normal raw writes after finalization.
+5. Give accepted members a limited member-summary read path without exposing email.
+6. Make the app permission helper and controls match the server contract.
+
+---
+
+## 7. Phase boundaries
+
+| Phase | Takes ownership of |
+|---|---|
+| SEC-1 | Accepted-membership enforcement, current role hierarchy, member/profile privacy, game/stat write hardening, shared UI permission helpers, and current owner/admin/scorer UI drift. |
+| SEC-2 | `viewer` DB role, read-only RLS paths, and removal of start/resume/track/finalize controls for viewers. |
+| SEC-3 | Expiring single-use scorer/viewer invite links and their create/redeem/revoke RPCs. |
+| SEC-4 | Authorized guardian claims, guardian removal, identity-field boundaries, and viewer exclusion. |
+| SEC-5 | Account status, app-admin role, suspended-session gate, and narrow app-access RPCs. |
+| SEC-6 | Durable action-specific audit writes and team/app-admin audit views. |
+
+SEC-1 should not add viewer, invite-link, app-status, or unified audit schema. It may add
+small RPCs needed to make the existing three-role model safe.
+
+---
+
+## 8. Security regression scenarios
+
+These are the stable cross-phase scenarios. The SEC-0 branch documents them; rows owned
+by SEC-1 or later may fail until that phase ships.
+
+| Scenario | Expected result | First enforcing phase |
+|---|---|---|
+| Pending scorer opens a direct Team Info or game URL | Invite summary remains available, but team/game data is denied until acceptance. | SEC-1 |
+| Pending admin calls member, correction, primary-recorder, or merge APIs | Every call is denied. | SEC-1 |
+| Authenticated non-member inserts or rewrites their own `team_members` row | Denied; joining happens only through an invite acceptance/redeem action. | SEC-1 |
+| Owner invites an admin or scorer | Invite is created without changing protected existing owner/admin memberships. | SEC-1 |
+| Admin invites or removes a scorer | Allowed. | SEC-1 |
+| Admin attempts to invite, remove, or change an owner/admin | Denied in UI and server. | SEC-1 |
+| Scorer opens Team Info and starts/resumes/tracks/finalizes a game | Allowed after acceptance. | SEC-1 |
+| Scorer opens Team Manage or Advanced destructive tools | Read-only/unavailable state; no privileged controls or successful writes. | SEC-1 |
+| Scorer attempts correction, primary reassignment, merge, team delete, or game delete | Denied in UI and server. | SEC-1 |
+| Recorder submits a stat/shot for an unrelated or final game | Denied. | SEC-1 |
+| Accepted member reads team member summary | Names/roles are visible; email is withheld from non-managers. | SEC-1 |
+| Viewer opens team, roster, schedule, in-progress list, and final stats | Read-only views load; Start/Resume/Track/Finalize are absent and direct writes fail. | SEC-2 |
+| Viewer attempts guardianship claim | Denied. | SEC-4 |
+| Guardian edits player identity but attempts roster-field edit | Identity update succeeds; roster update is denied without owner/admin team role. | SEC-4 |
+| Suspended user returns with an authenticated session | Suspended state replaces cloud app routes; no team bypass or offline continuation. | SEC-5 |
+| App admin opens a team without membership | Team data remains denied unless a narrow support action explicitly applies. | SEC-5 |
+| Member role/removal or invite-link action succeeds | Action-specific audit event records actor, target, team, action, and timestamp without token secrets. | SEC-6 |
+
+---
+
+## 9. Review rule for later phases
+
+Every SEC implementation PR should link this matrix and state:
+
+- which rows it begins enforcing,
+- which current findings it closes,
+- which rows remain future behavior,
+- which UI and server tests prove the same decision.
+
+If a later implementation needs a different product decision, update this matrix in the
+same PR and call out the decision explicitly. Do not silently encode a different rule in
+UI code or SQL.

--- a/docs/ACCESS_MATRIX.md
+++ b/docs/ACCESS_MATRIX.md
@@ -192,8 +192,8 @@ Supabase API directly.
 The audit makes a migration mandatory for SEC-1. UI helpers alone cannot close findings
 SEC0-01 through SEC0-08. SEC-1 should, at minimum:
 
-1. Replace direct self-insert/update member policies with narrow invite acceptance and
-   decline/member-management RPCs.
+1. Replace direct self-insert/update/delete member policies with narrow invite acceptance,
+   decline, leave, and role-safe member-management RPCs; owner self-removal is denied.
 2. Require accepted membership in every team-derived policy and privileged RPC.
 3. Enforce target-role hierarchy for invite, role-change, and removal operations.
 4. Bind stat, checkout, and shot writes to an accepted team member, the referenced game,

--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -243,7 +243,7 @@ flowchart LR
 
 | Doc | Topic |
 |-----|-------|
-| [`PLAN_ADMIN_SECURITY_ROADMAP.md`](PLAN_ADMIN_SECURITY_ROADMAP.md) | Access model, roles, invites, guardianship, audit — start with SEC-0 |
+| [`ACCESS_MATRIX.md`](ACCESS_MATRIX.md) / [`PLAN_ADMIN_SECURITY_ROADMAP.md`](PLAN_ADMIN_SECURITY_ROADMAP.md) | SEC-0 access contract/audit complete; SEC-1 team access cleanup is next |
 | [`PLAN_MULTI_GAME_PARKING.md`](PLAN_MULTI_GAME_PARKING.md) | P0–P3b shipped (incl. discard/hydrate race guards); IndexedDB + orphan ops follow-ups remain |
 | [`PLAN_APP_FOUNDATION_ROADMAP.md`](PLAN_APP_FOUNDATION_ROADMAP.md) | NAV/AUTH foundation shipped; soccer planning still gated on remaining foundation work |
 

--- a/docs/PLAN_ADMIN_SECURITY_ROADMAP.md
+++ b/docs/PLAN_ADMIN_SECURITY_ROADMAP.md
@@ -81,15 +81,15 @@ Shipped today:
 
 ## 5. Phase Roadmap
 
-| Phase | Plan | Purpose |
-|---|---|---|
-| SEC-0 | `PLAN_SEC_0_ACCESS_MATRIX_AND_AUDIT.md` | Define the role/action matrix and inspect current UI/RLS behavior. |
-| SEC-1 | `PLAN_SEC_1_TEAM_ACCESS_CLEANUP.md` | Clean up current owner/admin/scorer behavior without adding new roles. |
-| SEC-2 | `PLAN_SEC_2_VIEWER_ROLE.md` | Add a true read-only `viewer` team role. |
-| SEC-3 | `PLAN_SEC_3_INVITE_LINKS.md` | Implement DB-backed invite links and join flow. |
-| SEC-4 | `PLAN_SEC_4_GUARDIANSHIP_REVIEW.md` | Make player guardianship clearer, safer, and manageable. |
-| SEC-5 | `PLAN_SEC_5_APP_LEVEL_ACCESS.md` | Add optional app-level access controls such as active/pending/suspended and app admin. |
-| SEC-6 | `PLAN_SEC_6_AUDIT_TRAIL.md` | Add durable audit records and an admin/support view for sensitive changes. |
+| Phase | Plan | Purpose | Status |
+|---|---|---|---|
+| SEC-0 | `PLAN_SEC_0_ACCESS_MATRIX_AND_AUDIT.md` | Define the role/action matrix and inspect current UI/RLS behavior. | Complete; see [`ACCESS_MATRIX.md`](ACCESS_MATRIX.md) |
+| SEC-1 | `PLAN_SEC_1_TEAM_ACCESS_CLEANUP.md` | Clean up current owner/admin/scorer behavior without adding new roles. | Planned |
+| SEC-2 | `PLAN_SEC_2_VIEWER_ROLE.md` | Add a true read-only `viewer` team role. | Planned |
+| SEC-3 | `PLAN_SEC_3_INVITE_LINKS.md` | Implement DB-backed invite links and join flow. | Planned |
+| SEC-4 | `PLAN_SEC_4_GUARDIANSHIP_REVIEW.md` | Make player guardianship clearer, safer, and manageable. | Planned |
+| SEC-5 | `PLAN_SEC_5_APP_LEVEL_ACCESS.md` | Add optional app-level access controls such as active/pending/suspended and app admin. | Planned |
+| SEC-6 | `PLAN_SEC_6_AUDIT_TRAIL.md` | Add durable audit records and an admin/support view for sensitive changes. | Planned |
 
 Recommended order:
 

--- a/docs/PLAN_SEC_0_ACCESS_MATRIX_AND_AUDIT.md
+++ b/docs/PLAN_SEC_0_ACCESS_MATRIX_AND_AUDIT.md
@@ -1,5 +1,7 @@
 # Plan: SEC-0 Access matrix and audit
 
+Status: Complete. Approved baseline: [`ACCESS_MATRIX.md`](ACCESS_MATRIX.md).
+
 SEC-0 is a planning and audit phase. It should produce the role/action matrix that later
 phases implement.
 
@@ -179,8 +181,19 @@ Ask these one at a time before implementation.
 
 ## 9. Acceptance Criteria
 
-- A reviewed matrix exists.
-- Every later SEC phase has stable dependencies and deferrals.
-- Current mismatches are listed with file/RLS references.
-- Regression checklist includes owner/admin/scorer/pending invite cases.
-- No runtime behavior changes are made in SEC-0.
+- [x] A reviewed matrix exists.
+- [x] Every later SEC phase has stable dependencies and deferrals.
+- [x] Current mismatches are listed with file/RLS references.
+- [x] Regression checklist includes owner/admin/scorer/pending invite cases.
+- [x] No runtime behavior changes are made in SEC-0.
+
+---
+
+## 10. Implementation Result
+
+- Added `docs/ACCESS_MATRIX.md` as the stable target contract.
+- Audited app source and migrations through `034_google_auth_profile_defaults.sql`.
+- Confirmed SEC-1 requires a narrow security migration; UI permission helpers alone are
+  insufficient.
+- Assigned guardian, viewer, app-access, and audit work to SEC-2 through SEC-6 without
+  expanding SEC-0 into runtime changes.

--- a/docs/PLAN_SEC_1_TEAM_ACCESS_CLEANUP.md
+++ b/docs/PLAN_SEC_1_TEAM_ACCESS_CLEANUP.md
@@ -44,7 +44,8 @@ the current behavior before expanding the access model.
   and reject normal raw writes after game finalization.
 - Add a limited accepted-member summary path that does not expose member email to
   scorers.
-- Confirm admin member removal/changing behavior is intentional.
+- Add role-safe member management operations: admins can remove scorers, owners can
+  manage admins/scorers, and no generic self-delete path can remove the owner row.
 - Improve unavailable/error copy when an action is denied by RLS.
 - Add targeted tests for pure permission helpers.
 - Update regression docs.
@@ -113,9 +114,11 @@ each policy contract can be reviewed against `ACCESS_MATRIX.md`.
 
 Ask these one at a time before implementation.
 
-1. Should SEC-1 include RLS changes if pending invites currently see too much?
-   - Recommended: Yes, if the mismatch is confirmed and can be fixed narrowly.
-   - Option B: Document only and defer RLS to SEC-2.
+1. How should the mandatory SEC-1 database hardening be packaged?
+   - Resolved: One new reviewable migration with separate membership/RPC and
+     game/stat-policy sections.
+   - Option B: Two sequential migrations, one for membership/RPCs and one for
+     game/stat policies.
 
 2. Should admins be allowed to remove other admins?
    - Recommended: No, owner-only for removing/changing admin roles.
@@ -138,8 +141,11 @@ Ask these one at a time before implementation.
 
 ## 7. Resolved Decisions
 
-- Include narrow RLS fixes if audit confirms pending invites see too much.
+- SEC-0 confirmed the RLS/RPC mismatch. Ship the hardening in one new migration with
+  separate membership/RPC and game/stat-policy sections.
 - Admins cannot remove other admins; admins remove scorers/viewers only.
+- Owners cannot leave or delete their own membership row until a future ownership
+  transfer flow exists.
 - Owner transfer is not part of SEC-1.
 - Scorers reaching `/team/manage` get read-only/unavailable behavior or redirect to Team
   Info.
@@ -155,6 +161,8 @@ Ask these one at a time before implementation.
 - Bypassing UI still fails server-side for privileged writes.
 - Pending invite behavior is documented and tested.
 - Direct self-join/self-promotion and protected-member mutation paths are denied.
+- Admin scorer-removal succeeds through a role-safe server action; admin/owner targets
+  remain protected, and owner self-removal is denied.
 - Stat/checkout/shot writes require the correct accepted team/game/player relationship,
   and normal raw writes cannot change finalized games.
 - Non-manager member summaries do not expose email.

--- a/docs/PLAN_SEC_1_TEAM_ACCESS_CLEANUP.md
+++ b/docs/PLAN_SEC_1_TEAM_ACCESS_CLEANUP.md
@@ -4,6 +4,10 @@ SEC-1 cleans up the current owner/admin/scorer model before adding new roles.
 
 Depends on: SEC-0.
 
+SEC-0 input: [`ACCESS_MATRIX.md`](ACCESS_MATRIX.md), especially findings SEC0-01 through
+SEC0-12. The audit confirms SEC-1 requires a server-side migration; app permission helpers
+alone are not sufficient.
+
 ---
 
 ## 1. Goal
@@ -33,6 +37,13 @@ the current behavior before expanding the access model.
 - Make member-management UI use the same permission helper.
 - Review `team_members.accepted_at` behavior in client queries and RLS.
 - Ensure pending invites do not accidentally grant full accepted-member visibility.
+- Replace broad direct self-insert/update membership policies with narrow acceptance,
+  decline, role-change, and removal operations.
+- Require accepted membership in team-derived policies and privileged RPCs.
+- Bind recorder-owned stat, checkout, and shot writes to the referenced team/game/player
+  and reject normal raw writes after game finalization.
+- Add a limited accepted-member summary path that does not expose member email to
+  scorers.
 - Confirm admin member removal/changing behavior is intentional.
 - Improve unavailable/error copy when an action is denied by RLS.
 - Add targeted tests for pure permission helpers.
@@ -75,16 +86,26 @@ Potential files:
 - `src/pages/TeamManage.tsx`
 - `src/pages/TeamInfo.tsx`
 - `src/pages/GameSummary.tsx`
+- `src/pages/Games.tsx`
+- `src/pages/Admin.tsx`
 - `docs/REGRESSION_TESTING.md`
 
 Potential migration/RLS review:
 
+- new migration `035_team_access_hardening.sql`
+- `008_player_checkouts.sql`
+- `009_stat_corrections.sql`
 - `011_team_invites.sql`
 - `013_rls_auth_uid_cached.sql`
+- `014_set_primary_recorder.sql`
+- `016_tournaments.sql`
 - `018_seasons_and_roster_junction.sql`
+- `024_player_merge_rpcs.sql`
+- `032_shot_chart.sql`
 
-If SEC-1 reveals that accepted-member filtering must change in RLS, split the SQL change
-into a small migration rather than burying it in a broad UI cleanup.
+Add a new, reviewable migration rather than editing applied migration history. Keep
+membership/RPC hardening and game/stat write hardening in clearly separated sections so
+each policy contract can be reviewed against `ACCESS_MATRIX.md`.
 
 ---
 
@@ -133,4 +154,8 @@ Ask these one at a time before implementation.
 - Scorer cannot see privileged controls.
 - Bypassing UI still fails server-side for privileged writes.
 - Pending invite behavior is documented and tested.
+- Direct self-join/self-promotion and protected-member mutation paths are denied.
+- Stat/checkout/shot writes require the correct accepted team/game/player relationship,
+  and normal raw writes cannot change finalized games.
+- Non-manager member summaries do not expose email.
 - Existing owner/admin/scorer happy paths still work.

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -452,6 +452,28 @@ High-level test scripts for features built so far. Use these to sanity-check aft
 
 ---
 
+## 10a. Security role baseline (SEC-0 target)
+
+**Precondition:** Four accounts: team owner, accepted admin, accepted scorer, and a user
+with a pending invite. Use test data only. The full approved contract and API-level cases
+live in [`ACCESS_MATRIX.md`](ACCESS_MATRIX.md). SEC-0 documents these expectations; cases
+tagged SEC-1 may fail until SEC-1 ships.
+
+| Step | Action | Expected |
+|---|---|---|
+| 10a.1 | Pending invitee opens direct Team Info, roster, game, and stats URLs | Invite summary remains visible, but all team data is denied until acceptance (SEC-1) |
+| 10a.2 | Pending invitee attempts a direct team member, game, stat, correction, or merge write | Server denies every write (SEC-1) |
+| 10a.3 | Owner invites an admin and a scorer | Both invites are created without changing any existing owner/admin membership |
+| 10a.4 | Admin invites and then removes a scorer | Both actions succeed; the scorer loses team access (SEC-1) |
+| 10a.5 | Admin attempts to remove or change owner/admin membership | Controls are absent and direct API calls are denied (SEC-1) |
+| 10a.6 | Accepted scorer opens Team Info and starts, resumes, tracks, and finalizes a game | Game workflow succeeds |
+| 10a.7 | Accepted scorer opens Team Manage and Advanced settings | Read-only/unavailable state; roster/member/destructive controls are absent (SEC-1) |
+| 10a.8 | Scorer attempts stat correction, primary-recorder reassignment, player merge, team delete, or game delete | UI does not offer action and server denies direct call |
+| 10a.9 | Accepted scorer views the team member summary | Names and roles are visible; member email addresses are not exposed (SEC-1) |
+| 10a.10 | Recorder attempts to write a stat or shot to an unrelated or final game | Server denies the write (SEC-1) |
+
+---
+
 ## 11. PWA & offline
 
 **Precondition:** Production build or deployed site (HTTPS or localhost).

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -471,6 +471,7 @@ tagged SEC-1 may fail until SEC-1 ships.
 | 10a.8 | Scorer attempts stat correction, primary-recorder reassignment, player merge, team delete, or game delete | UI does not offer action and server denies direct call |
 | 10a.9 | Accepted scorer views the team member summary | Names and roles are visible; member email addresses are not exposed (SEC-1) |
 | 10a.10 | Recorder attempts to write a stat or shot to an unrelated or final game | Server denies the write (SEC-1) |
+| 10a.11 | Owner attempts Leave Team or directly deletes their own membership row | Denied until a future ownership-transfer flow exists (SEC-1) |
 
 ---
 


### PR DESCRIPTION
## Summary

- add the approved owner/admin/scorer/viewer/pending and player-relationship access matrix
- document the effective UI, RPC, and RLS model plus 16 prioritized findings
- mark SEC-0 complete and expand SEC-1 around the confirmed server-side hardening work
- add the role-based security regression baseline and refresh roadmap/doc routing

## Notable audit result

SEC-1 requires a new migration. Current policies do not consistently require accepted membership, and the direct team member self-insert/update paths are broader than the invite UI intends. SEC-0 documents and assigns these findings without changing runtime behavior.

## Verification

- git diff --check
- docs-only change; build and runtime tests not run
