### PR TITLE
SOC-2A: add soccer match-state foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,10 +383,11 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 - [x] **Access audit trail (SEC-6)** — immutable member/invite-link/app-access events with team manager and app-admin history views ([plan](docs/PLAN_SEC_6_AUDIT_TRAIL.md))
 - [x] **Soccer product model (SOC-0)** — event-first soccer design, complete stat catalog, configurable match/lineup model, soccer field direction, and six-phase implementation roadmap ([plan](docs/PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md))
 - [x] **Shared event foundation (SOC-1)** - versioned raw streams, typed sport registry, deterministic projection and revisioned mutation engine, local parking/fingerprint support, and isolated recorder-owned cloud schema/repository ([plan](docs/PLAN_SOC_1_SHARED_EVENT_FOUNDATION.md))
+- [x] **Soccer match-state foundation (SOC-2A)** - resolved rule/setup snapshots, production soccer event schemas, semantic projector diagnostics, atomic event batches, exact participation projection, and local-only sync guards ([plan](docs/PLAN_SOC_2_MATCH_RULES_LINEUPS_AND_CLOCK.md))
 
 ### What's Next
 
-- [ ] **Soccer implementation (SOC-2 through SOC-6)** - match rules, lineups, and clock; soccer field and attacking events; defense/discipline/team events; cloud sync; summaries and release ([plan](docs/PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md))
+- [ ] **Soccer implementation (SOC-2B through SOC-6)** - setup/lineup UI, live clock and substitutions, soccer field and attacking events, defense/discipline/team events, cloud sync, summaries, and release ([SOC-2 plan](docs/PLAN_SOC_2_MATCH_RULES_LINEUPS_AND_CLOCK.md), [roadmap](docs/PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md))
 - [ ] **Basketball event-model migration (BKE-0 through BKE-4)** — required post-foundation redesign that unifies counters, action log, shot records, linked assists/rebounds, editing, and F13 on the shared event platform while preserving historical games ([roadmap](docs/PLAN_BASKETBALL_EVENT_MODEL_ROADMAP.md))
 - [ ] **Audit event-family follow-ups** — expand the SEC-6 trail to guardian changes, stat corrections, primary-recorder reassignment, and game lifecycle/finalization events ([plan](docs/PLAN_SEC_6_AUDIT_TRAIL.md))
 - [ ] **Multi-game storage/ops follow-ups** — optional historical orphan cleanup tooling, full transactional/idempotent cloud sync, IndexedDB storage, import conflict UI, and richer quota recovery UX ([plan](docs/PLAN_MULTI_GAME_PARKING.md))

--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -134,9 +134,9 @@ resolved setup and rebuildable runtime projection. Semantic failures preserve ra
 project through the last coherent event, and expose diagnostics.
 
 The `game_events` repository remains isolated and is **not** part of the automatic cloud
-queue until SOC-5. Aggregate reducer mutations and aggregate cloud sync are disabled once
-an event stream is initialized; do not mark event streams cloud-synced through snapshot
-sync.
+queue until SOC-5. Aggregate cloud sync is disabled as soon as sport-owned setup exists;
+aggregate reducer mutations are disabled once an event stream is initialized. Do not mark
+soccer setup or event streams cloud-synced through snapshot sync.
 
 ### localStorage keys
 

--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -128,9 +128,15 @@ Uses **HashRouter** — URLs look like `http://localhost:5173/#/game`, not `/gam
 `GameState.eventStream` is `null` for legacy aggregate-only games and a versioned raw stream
 for event-authoritative games. SOC-1 infrastructure lives in `src/lib/gameEvents/`: the
 generic engine validates, migrates, quarantines, and orders events, then one projector per
-sport rebuilds aggregate state. The production registry is intentionally empty until SOC-2.
-The `game_events` repository is isolated and is **not** part of the automatic cloud queue
-until SOC-5; do not mark event streams cloud-synced through aggregate snapshot sync.
+sport rebuilds aggregate state. SOC-2A registers production soccer match-state schemas and
+the projector in `src/lib/soccer/`. `GameState.sportGameState` holds soccer's immutable
+resolved setup and rebuildable runtime projection. Semantic failures preserve raw events,
+project through the last coherent event, and expose diagnostics.
+
+The `game_events` repository remains isolated and is **not** part of the automatic cloud
+queue until SOC-5. Aggregate reducer mutations and aggregate cloud sync are disabled once
+an event stream is initialized; do not mark event streams cloud-synced through snapshot
+sync.
 
 ### localStorage keys
 
@@ -257,7 +263,7 @@ flowchart LR
 |-----|-------|
 | [`ACCESS_MATRIX.md`](ACCESS_MATRIX.md) / [`PLAN_ADMIN_SECURITY_ROADMAP.md`](PLAN_ADMIN_SECURITY_ROADMAP.md) | SEC-0 through SEC-6 complete; later audit event-family expansion is documented in SEC-6 |
 | [`PLAN_MULTI_GAME_PARKING.md`](PLAN_MULTI_GAME_PARKING.md) | P0–P3b shipped (incl. discard/hydrate race guards); IndexedDB + orphan ops follow-ups remain |
-| [`PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md`](PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md) / [`PLAN_APP_FOUNDATION_ROADMAP.md`](PLAN_APP_FOUNDATION_ROADMAP.md) | SOC-0 product model complete; SOC-1 shared event foundation is the next soccer phase |
+| [`PLAN_SOC_2_MATCH_RULES_LINEUPS_AND_CLOCK.md`](PLAN_SOC_2_MATCH_RULES_LINEUPS_AND_CLOCK.md) / [`PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md`](PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md) | SOC-2A domain/event foundation complete; SOC-2B setup, roster, lineup, and kickoff UI is next |
 | [`PLAN_BASKETBALL_EVENT_MODEL_ROADMAP.md`](PLAN_BASKETBALL_EVENT_MODEL_ROADMAP.md) | Required follow-up: BKE-0 planning after SOC-1; no BKE-1+ implementation before SOC-5 |
 
 ### Held / waiting for feedback

--- a/docs/PLAN_SOC_2_MATCH_RULES_LINEUPS_AND_CLOCK.md
+++ b/docs/PLAN_SOC_2_MATCH_RULES_LINEUPS_AND_CLOCK.md
@@ -31,7 +31,7 @@ Those remain in later soccer phases.
 - Add atomic batch event mutations and reducer support.
 - Project soccer starts, appearances, and exact participation time into local state.
 - Preserve soccer setup and raw events through persistence, parking, import, and hydration.
-- Explicitly exclude event-backed games from aggregate automatic cloud sync until SOC-5.
+- Explicitly exclude soccer setup and event-backed games from aggregate automatic cloud sync until SOC-5.
 - Add focused unit and persistence tests. No user-facing soccer workflow ships in this slice.
 
 ### SOC-2B: Setup, roster, lineup, and kickoff
@@ -355,9 +355,10 @@ to `null`.
 The local dirty fingerprint includes the authoritative setup snapshot and raw events. It
 excludes the rebuildable soccer projection and derived diagnostics.
 
-Until SOC-5, any game with an initialized event stream is local-only for automatic cloud
-sync. It must not enter the legacy aggregate snapshot queue, create a cloud game, or be
-marked synced through that path. Source roster ids in soccer setup do not change this rule.
+Until SOC-5, any game with sport-owned setup or an initialized event stream is local-only
+for automatic cloud sync. It must not enter the legacy aggregate snapshot queue, create a
+cloud game, or be marked synced through that path. Source roster ids in soccer setup do not
+change this rule. The aggregate sync function also enforces this boundary for direct callers.
 
 ---
 
@@ -377,7 +378,7 @@ marked synced through that path. Source roster ids in soccer setup do not change
 - Starts, appearances, and seconds project into player compatibility stats.
 - Soccer state and raw events survive hydrate, parking, export, and import.
 - Legacy saves normalize without changing basketball behavior.
-- Event-backed games are excluded from aggregate auto-sync and queue dirtying.
+- Setup-only and event-backed soccer games are excluded from aggregate auto-sync and queue dirtying.
 
 ### Later slice checks
 

--- a/docs/PLAN_SOC_2_MATCH_RULES_LINEUPS_AND_CLOCK.md
+++ b/docs/PLAN_SOC_2_MATCH_RULES_LINEUPS_AND_CLOCK.md
@@ -1,0 +1,458 @@
+# Plan: SOC-2 Match Rules, Lineups, and Clock
+
+Detailed implementation plan for soccer match setup, participation, timing, and match-state
+history. SOC-2 builds on the shared event foundation from SOC-1 and is intentionally split
+into three sequential pull requests so each change remains reviewable and testable.
+
+Status: Product decisions resolved; SOC-2A implementation complete; SOC-2B is next.
+
+---
+
+## 1. Goal
+
+Create the soccer match-state foundation needed before field events and scoring are added.
+The phase must support configurable competition rules, a selected match roster, an opening
+lineup, game-specific roles, an accurate clock, periods, substitutions, corrections, and a
+readable match history.
+
+SOC-2 does not add soccer shots, goals, score controls, field capture, or cloud event sync.
+Those remain in later soccer phases.
+
+---
+
+## 2. Delivery Slices
+
+### SOC-2A: Domain and event foundation
+
+- Add typed soccer rule, setup, participant, role, and runtime projection models.
+- Add `sportGameState` to `GameState` as a discriminated sport-owned container.
+- Register production soccer match-state event schemas and the soccer projector.
+- Add semantic projection diagnostics that stop at the last coherent event.
+- Add atomic batch event mutations and reducer support.
+- Project soccer starts, appearances, and exact participation time into local state.
+- Preserve soccer setup and raw events through persistence, parking, import, and hydration.
+- Explicitly exclude event-backed games from aggregate automatic cloud sync until SOC-5.
+- Add focused unit and persistence tests. No user-facing soccer workflow ships in this slice.
+
+### SOC-2B: Setup, roster, lineup, and kickoff
+
+- Add a development-only soccer entry through the normal sport chooser and dashboard.
+- Add soccer-specific match information and per-game rule overrides under `/setup`.
+- Add the two-step `/players` flow: Match Roster, then Starter/Bench roles and review.
+- Support cloud roster selection as a read-only setup source without creating a cloud game.
+- Support stable game-local anonymous participants.
+- Validate player-count and goalkeeper rules, with an explicit short-handed confirmation.
+- Start a match by atomically recording opening lineup, period start, and clock start events.
+
+### SOC-2C: Live clock, periods, lineup, and correction UI
+
+- Add the soccer `/game` clock, period, lineup, substitution, role, and direction controls.
+- Add live elapsed time and participation time without per-second reducer writes.
+- Add period transitions, extra-time choices, match end, and explicit reopen behavior.
+- Add compact match-history correction tools for all SOC-2 event types.
+- Show projection diagnostics and block dependent controls when history is incoherent.
+- Keep the completed match route as a read-only soccer review surface.
+
+SOC-2B starts only after SOC-2A is merged. SOC-2C starts only after SOC-2B is merged.
+
+---
+
+## 3. Authority and State Model
+
+### Hybrid authority
+
+The fully resolved match setup is persisted as a snapshot in `GameState`. Dynamic match
+state is authoritative in the event stream and is rebuilt by the soccer projector.
+
+```text
+GameState
+  sportGameState
+    sportId: soccer
+    version
+    setup
+      resolved rules snapshot
+      tracked-team designation
+      source team/season references
+      selected match participants
+      initial attacking direction
+    projection
+      match and period status
+      clock anchor
+      on-field and bench participants
+      current roles
+      exact participation intervals and totals
+      substitution usage
+      current attacking direction
+```
+
+The setup snapshot remains sufficient to reproduce the match rules used by an existing
+game even if app defaults change later. Projection data is a cache and is always
+rebuildable from the setup plus active events.
+
+### Rules precedence
+
+SOC-2 exposes app defaults and per-game overrides:
+
+```text
+game override -> app soccer defaults
+```
+
+The typed resolver should accept future personal and season layers, but those settings are
+not exposed until SOC-6. The intended final precedence remains:
+
+```text
+game override -> season rules -> personal defaults -> app defaults
+```
+
+Mid-match rule changes are validated `match_rules_changed` events. They do not rewrite
+the immutable opening snapshot or shortcut completed period history.
+
+---
+
+## 4. Match Rules
+
+### Defaults
+
+First-use defaults are:
+
+- two 45-minute regulation periods,
+- count-up clock with continuous match display,
+- 11 maximum on-field players,
+- no return substitutions,
+- unlimited substitutions and substitution windows unless configured,
+- optional extra time and shootout availability represented explicitly.
+
+All defaults are editable before kickoff.
+
+### Period structure
+
+Regulation is an ordered list of segments with stable ids, labels, and nominal durations.
+Presets may create common structures, but custom segment count, duration, and labels are
+supported. Extra time is modeled as a separate ordered segment collection.
+
+The clock supports:
+
+- count up or count down for display,
+- continuous match elapsed time or per-period display,
+- canonical cumulative active `elapsedMs` regardless of display mode,
+- manual start, pause, correction, and period transitions,
+- stoppage/overrun after nominal duration without automatic period end.
+
+The user manually ends every period. Ending a period atomically pauses the clock and marks
+the period complete. The next period is shown, with its expected attacking direction, but
+requires an explicit Start Period action.
+
+### Player and substitution limits
+
+Configured player count is the maximum allowed on field. A short-handed start is allowed
+only after confirmation.
+
+Rules may independently configure:
+
+- total incoming substitutions (`null` means unlimited),
+- substitution windows (`null` means unlimited), and
+- whether a player may return after leaving.
+
+One substitution-window event may contain several player changes. It consumes one window
+and one substitution per incoming replacement. Halftime changes are flagged and do not
+consume a window. When return substitutions are disabled, normal re-entry is blocked; an
+explicit game-wide rule-change event may enable it.
+
+---
+
+## 5. Participants, Lineups, and Roles
+
+### Match roster
+
+Before kickoff, the recorder selects a Match Roster. Each selected participant is assigned
+Starter or Bench plus an initial game role. Unselected roster members are Absent and
+receive no appearance or minutes.
+
+Cloud roster data may be used as a read-only source. The soccer setup snapshot preserves
+source team and season ids, but SOC-2 does not populate `cloudSync` or create a cloud game.
+
+Late arrivals are introduced by a timestamped match-roster addition event. The participant
+may be added to the bench or atomically enter the field, but an appearance is recorded only
+when they enter.
+
+### Participant identity
+
+Participants can reference an existing local/cloud-backed player or use a stable game-local
+anonymous identity. Anonymous participants can start, substitute, receive roles, accrue
+minutes, and be corrected. A later participant-resolution event can map that identity to a
+roster player and retroactively rebuild starts, appearances, and minutes.
+
+No full opponent lineup is modeled in SOC-2. Opponent identity remains lightweight match
+context until later event phases need specific opponent actors.
+
+### Roles
+
+Every match participant has a game-specific role and eligibility. Structured role groups
+are Goalkeeper, Defender, Midfielder, Forward, and Custom, with an optional display label.
+Roles are not permanent player attributes.
+
+At kickoff exactly one on-field participant must be the goalkeeper. The goalkeeper may be
+a roster player or a stable `Goalkeeper unknown` participant. Bench players may be marked
+as backup goalkeepers. Only one on-field goalkeeper may be active at a time.
+
+Role changes are timestamped events. A player may move among roles throughout the match.
+SOC-2 displays total minutes; the event model preserves enough history for future
+minutes-by-role analysis.
+
+### Opening and live lineup
+
+The opening lineup is one atomic event containing all starters and their roles. Live
+substitutions normally pair player out and player in, while explicit exit-only and
+entry-only variants support injuries, cards, short-handed play, and corrections.
+
+The live UI uses On Field and Bench tabs with role labels and focused substitution and role
+actions. The full-field lineup visualization belongs to SOC-3.
+
+---
+
+## 6. Clock and Participation
+
+### Persisted clock anchor
+
+The running clock is represented by a persisted real-time anchor plus canonical elapsed
+time. The UI renders from that anchor on a lightweight timer. It must not dispatch reducer
+actions or write local storage every second.
+
+The anchor allows the clock to continue accurately while the tab is in the background or
+the device is locked. Pausing closes active participation intervals at the resulting match
+time. Starting the clock opens intervals for every active on-field participant.
+
+### Time precision
+
+Exact milliseconds are authoritative. Live match and match review display `MM:SS`.
+Season and career aggregates use rounded whole minutes.
+
+Participation projects these compatibility statistics into `Player.stats`:
+
+- `soc_start`
+- `soc_app`
+- `soc_min_sec`
+
+Exact milliseconds and open interval anchors remain in the soccer projection. `soc_min_sec`
+is an aggregate compatibility cache, not the timing source of truth.
+
+### Corrections
+
+A clock correction is an explicit `clock_adjusted` event and changes the timeline from that
+point forward. Earlier event timestamps remain unchanged. Individual historical events may
+also be corrected through revisioned event edits.
+
+---
+
+## 7. Match Lifecycle and Direction
+
+### Lifecycle
+
+The projected lifecycle supports:
+
+```text
+not_started -> in_progress -> period_break -> in_progress -> ended
+```
+
+After the final regulation period, the UI offers extra time when configured or End Match.
+Shootout availability and lifecycle status are represented, but shootout kicks are SOC-4.
+
+`match_ended` is a local event in SOC-2. It stops minutes, locks match controls, and does not
+finalize or upload a cloud game. A `match_reopened` event returns the match to the break
+after its last completed period so corrections or additional play are explicit history.
+
+### Team designation and field direction
+
+Score/event identity remains Tracked Team versus Opponent. Setup separately records whether
+the tracked team is Home, Away, or Neutral.
+
+The recorder selects the tracked team's first-period attacking direction. Normal and
+extra-time periods alternate automatically. A manual direction-change event can override
+the calculated direction. Shootout direction is deferred with shootout capture.
+
+---
+
+## 8. Event Catalog
+
+SOC-2A registers versioned production schemas for:
+
+- `soccer.opening_lineup`
+- `soccer.period_started`
+- `soccer.period_ended`
+- `soccer.clock_started`
+- `soccer.clock_paused`
+- `soccer.clock_adjusted`
+- `soccer.match_rules_changed`
+- `soccer.substitution_window`
+- `soccer.role_changed`
+- `soccer.attacking_direction_changed`
+- `soccer.match_roster_added`
+- `soccer.participant_resolved`
+- `soccer.match_ended`
+- `soccer.match_reopened`
+
+Starting a match is one batch mutation containing separate opening-lineup, period-started,
+and clock-started events. The entire batch is appended and projected once, or not at all.
+Ending a period similarly batches clock pause and period end when needed.
+
+Capture sequence is the primary order for soccer state transitions. Period and elapsed
+time remain event metadata and review context; a later clock correction must not reorder
+earlier actions.
+
+---
+
+## 9. Semantic Projection and Diagnostics
+
+Envelope/schema validation from SOC-1 runs before the soccer projector. The soccer
+projector then validates state-machine semantics, including:
+
+- legal lifecycle and period transitions,
+- clock start/pause state,
+- known participant references,
+- on-field count and goalkeeper invariants,
+- role and substitution legality,
+- return-substitution and configured limits,
+- nonnegative and coherent canonical times,
+- match end/reopen rules.
+
+If a historical edit invalidates a later event, all raw events remain preserved. Projection
+continues only through the last valid event. The offending event and all later events are
+reported as unprojected diagnostics. Dependent controls and finalization are blocked until
+the history is repaired.
+
+Projection health is derived and never persisted. The persisted sport projection contains
+only deterministic soccer runtime state.
+
+---
+
+## 10. Routing and User Experience
+
+SOC-2 reuses the existing routes with soccer-specific components:
+
+- `/setup`: match information and rules,
+- `/players`: Match Roster, then lineup and roles,
+- `/game`: live clock, lineup, match controls, and focused history.
+
+Soccer remains unavailable in normal production settings until SOC-6. SOC-2B adds a
+development-only Soccer card through the normal sport chooser/dashboard so the standard
+route flow can be tested without a separate preview architecture.
+
+The clock receives the prominent Start/Pause control. Clock correction, period end,
+direction, and rule changes live in a compact action menu with confirmations for destructive
+transitions. No soccer score buttons or legacy soccer stat grid appear in SOC-2.
+
+After `match_ended`, `/game` becomes a read-only review of periods, clock, lineup, minutes,
+history, diagnostics, corrections, and reopen. The complete soccer summary is SOC-6.
+
+---
+
+## 11. Persistence and Sync Boundary
+
+The setup, projection, and raw event stream must round-trip through active local storage,
+parking, export/import, and hydration. Missing `sportGameState` on legacy saves normalizes
+to `null`.
+
+The local dirty fingerprint includes the authoritative setup snapshot and raw events. It
+excludes the rebuildable soccer projection and derived diagnostics.
+
+Until SOC-5, any game with an initialized event stream is local-only for automatic cloud
+sync. It must not enter the legacy aggregate snapshot queue, create a cloud game, or be
+marked synced through that path. Source roster ids in soccer setup do not change this rule.
+
+---
+
+## 12. Test Plan
+
+### SOC-2A automated coverage
+
+- Rule defaults, resolution, validation, custom periods, extra time, and limits.
+- Every soccer event schema accepts valid payloads and rejects malformed payloads.
+- Opening lineup and period/clock startup project deterministically.
+- Clock anchors, pause/resume, corrections, and exact participation intervals.
+- Paired, entry-only, exit-only, multi-change, halftime, return, and limited substitutions.
+- Role changes, goalkeeper rules, late arrivals, and anonymous participant resolution.
+- Period transitions, direction alternation/override, match end, and reopen.
+- Semantic failure stops projection at the last coherent event and reports later events.
+- Batch append is atomic and rebuilds once.
+- Starts, appearances, and seconds project into player compatibility stats.
+- Soccer state and raw events survive hydrate, parking, export, and import.
+- Legacy saves normalize without changing basketball behavior.
+- Event-backed games are excluded from aggregate auto-sync and queue dirtying.
+
+### Later slice checks
+
+SOC-2B and SOC-2C add component/route tests plus manual regression passes for narrow mobile,
+desktop, background/resume clock behavior, short-handed confirmation, substitutions,
+history correction, extra time, end, and reopen.
+
+---
+
+## 13. Explicit Deferrals
+
+- Shots, goals, assists, score derivation, cards, fouls, saves, and field events: SOC-3/4.
+- Opponent lineup management: not planned for the core single-recorder model.
+- Shootout kick capture and shootout score: SOC-4.
+- Automatic event cloud sync, finalization, and aggregate publication: SOC-5.
+- Production sport enablement, full summary, season rules/default settings, and aggregate
+  reporting: SOC-6.
+- Full-field lineup visualization: SOC-3.
+- Minutes by role: future derived analysis.
+- Personal and season rule editors: SOC-6.
+- Basketball conversion to the shared event model: separate basketball redesign roadmap.
+
+---
+
+## 14. Locked Decisions
+
+The implementation must preserve these reviewed decisions:
+
+1. Setup is snapshot authority; dynamic match state is event authority.
+2. A running persisted clock continues through backgrounding and device lock.
+3. Defaults are 2x45, count up, 11 players, and no return substitutions.
+4. SOC-2 exposes app and game rule layers; personal/season layers wait for SOC-6.
+5. Tracked/opponent identity is separate from Home/Away/Neutral designation.
+6. Player count is an on-field maximum; short-handed kickoff requires confirmation.
+7. Kickoff requires exactly one goalkeeper, including an unknown goalkeeper option.
+8. All participants have game roles; bench players may be backup goalkeepers.
+9. Role changes are timestamped and preserve future minutes-by-role derivation.
+10. Opening lineup is one atomic event.
+11. Substitutions support paired, exit-only, and entry-only changes.
+12. Disabled return substitutions require an explicit rule override before re-entry.
+13. `elapsedMs` is cumulative active playing time, including stoppage and excluding breaks.
+14. Count direction and continuous/per-period display are independent settings.
+15. Nominal duration never automatically ends a period.
+16. Direction alternates by period and supports an explicit manual override event.
+17. Extra-time structure is modeled now; shootout kick capture waits for SOC-4.
+18. Clock correction is an explicit event.
+19. SOC-2C has focused correction history; the complete timeline comes later.
+20. Soccer uses the existing setup, players, and game routes.
+21. Soccer is development-only until SOC-6.
+22. SOC-2 does not model an opponent lineup.
+23. Anonymous tracked participants are stable game-local identities.
+24. Match Roster separates selected participants from absent roster members.
+25. Exact milliseconds are stored; live review uses `MM:SS`; aggregates round minutes.
+26. Regulation and extra-time segments are ordered, configurable collections.
+27. Kickoff records lineup, period start, and clock start in one batch mutation.
+28. Clock corrections apply forward and do not reorder prior events.
+29. Opening rules are immutable; mid-match changes are events.
+30. `GameState` owns a discriminated `sportGameState` container.
+31. Live clock rendering does not write state every second.
+32. Starts, appearances, and seconds project into compatibility player stats.
+33. Soccer events remain local-only until SOC-5.
+34. Cloud rosters are read-only setup sources in SOC-2.
+35. Development preview follows the normal sport card and route flow.
+36. Live lineup uses On Field/Bench tabs; field placement waits for SOC-3.
+37. Start/Pause is prominent; secondary match controls use a compact menu.
+38. End Period pauses and completes; the next period starts explicitly.
+39. Substitution and window limits are nullable; halftime changes use no window.
+40. Invalid later history is preserved and produces an incomplete projection.
+41. Projection stops at the last valid event.
+42. Late arrivals use match-roster addition events and earn appearances only on entry.
+43. Match end is a local event and does not cloud-finalize.
+44. Reopen is an explicit event returning to the last completed-period break.
+45. One substitution-window event may contain multiple changes.
+46. Participant resolution retroactively maps an anonymous identity to a roster player.
+47. `/players` is a two-step Match Roster then Lineup/Roles flow.
+48. Ended matches remain reviewable on `/game` until SOC-6 adds full summary.
+49. SOC-2 has no score controls or legacy soccer stat grid.
+50. Delivery is split into SOC-2A domain, SOC-2B setup, and SOC-2C live control PRs.

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -600,7 +600,7 @@ actions are backfilled.
 
 **Precondition:** Existing basketball local/parked games; migration
 `042_game_events.sql` applied only when testing the isolated cloud repository. Soccer remains
-disabled and no production event definitions are registered in SOC-1.
+disabled in production; SOC-2A later installs production soccer match-state definitions.
 
 | Step | Action | Expected |
 |------|--------|----------|
@@ -612,6 +612,22 @@ disabled and no production event definitions are registered in SOC-1.
 | 11a.6 | Write a lower revision, then an equal revision with changed payload | RPC reports `stale`, then `conflict`; existing cloud row is unchanged |
 | 11a.7 | As viewer or with another recorder's row id, attempt an event write | RLS/RPC rejects the write; accepted viewers can read team event rows |
 | 11a.8 | Attempt an ordinary SQL/client delete | No client delete policy exists; revisioned tombstone update is the supported path |
+
+---
+
+## 11b. Soccer match-state foundation (SOC-2A)
+
+**Precondition:** Development branch with SOC-2A. Soccer remains hidden from production
+navigation; these checks primarily protect persistence and event authority before SOC-2B UI.
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 11b.1 | Run `pnpm test` | Soccer rules, all 14 match-state schemas, lifecycle replay, exact participation, batch atomicity, and semantic-stop tests pass |
+| 11b.2 | Initialize a soccer event stream in a test/dev state with a resolved `sportGameState` setup | Opening lineup, period start, and clock start can append as one batch and produce one coherent projection |
+| 11b.3 | Introduce an invalid historical substitution followed by later events | Raw events remain stored; projection stops before the invalid substitution; the offending and later rows have diagnostics |
+| 11b.4 | Park, export, import, and resume an event-backed soccer state | Setup and raw events survive; projection rebuilds; the parked record is not queued for aggregate cloud sync |
+| 11b.5 | Dispatch a legacy stat, score, shot, undo, or period action after event-stream initialization | Reducer returns the unchanged event-backed state |
+| 11b.6 | Resume a legacy basketball game and track/sync normally | `sportGameState` normalizes to `null`; aggregate reducer and cloud behavior remain unchanged |
 
 ---
 

--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -626,6 +626,7 @@ navigation; these checks primarily protect persistence and event authority befor
 | 11b.2 | Initialize a soccer event stream in a test/dev state with a resolved `sportGameState` setup | Opening lineup, period start, and clock start can append as one batch and produce one coherent projection |
 | 11b.3 | Introduce an invalid historical substitution followed by later events | Raw events remain stored; projection stops before the invalid substitution; the offending and later rows have diagnostics |
 | 11b.4 | Park, export, import, and resume an event-backed soccer state | Setup and raw events survive; projection rebuilds; the parked record is not queued for aggregate cloud sync |
+| 11b.4a | Configure soccer setup before stream initialization, then allow persistence/sync processing to run | The setup-only game remains local and aggregate sync does not create a cloud game |
 | 11b.5 | Dispatch a legacy stat, score, shot, undo, or period action after event-stream initialization | Reducer returns the unchanged event-backed state |
 | 11b.6 | Resume a legacy basketball game and track/sync normally | `sportGameState` normalizes to `null`; aggregate reducer and cloud behavior remain unchanged |
 

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -28,6 +28,7 @@ import { isPersistedSyncLastErrorNetworkish, logClientSyncError } from '../lib/l
 import { sanitizePlayerIdMapForCloud } from '../lib/uuidValidation'
 import { playerIdMapForRoster, shotChartForRoster } from '../lib/rosterAlignment'
 import { normalizeGameEventStream } from '../lib/gameEvents/stream'
+import { normalizeSportGameState } from '../lib/soccer/state'
 import { rebuildGameEventProjection } from '../lib/gameEvents/projection'
 import { gameEventProjectors, gameEventRegistry } from '../lib/gameEvents/runtime'
 import { sports } from '../config/sports'
@@ -40,6 +41,7 @@ import {
   shouldRejectSkippedFinalSync,
   shouldSkipAutoHydrateForDifferentCloudGame,
   withLastSyncedGameFingerprint,
+  isAggregateCloudSyncEligible,
 } from '../lib/gameSyncFingerprint'
 import {
   createInitialCloudSyncState,
@@ -100,6 +102,7 @@ function hasSyncPrereqs(state: GameState, isConfigured: boolean, userId: string 
     supabase &&
     state.sport &&
     state.gameInfo &&
+    isAggregateCloudSyncEligible(state) &&
     state.cloudSync.gameStatus !== 'final'
   )
 }
@@ -177,6 +180,7 @@ function buildHydratedStateFromCloudGame(
     actionLog: [],
     shotChart: cloudGame.shotChart ?? [],
     eventStream: null,
+    sportGameState: null,
     cloudSync: {
       ...createInitialCloudSyncState('synced'),
       seasonId: cloudGame.seasonId ?? null,
@@ -225,6 +229,7 @@ function loadState(userId: string | null): GameState {
             : 1,
         teamStatsConfig: parsed.teamStatsConfig ?? null,
         eventStream: normalizeGameEventStream(parsed.eventStream),
+        sportGameState: normalizeSportGameState(parsed.sportGameState),
         shotChart: shotChartForRoster(Array.isArray(parsed.shotChart) ? parsed.shotChart : [], restoredPlayers),
         players: restoredPlayers,
         actionLog: Array.isArray(parsed.actionLog) ? parsed.actionLog : [],

--- a/src/lib/clearShotChart.test.ts
+++ b/src/lib/clearShotChart.test.ts
@@ -62,6 +62,7 @@ function baseState(
     teamStatsConfig: null,
     shotChart,
     eventStream: null,
+    sportGameState: null,
   }
 }
 

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -5,6 +5,7 @@ import { hasMappableChartShot } from './shotChartSyncMapping'
 import { pickRecorderPerPlayer } from './shotChartReview'
 import { isValidRemotePlayerUuid } from './uuidValidation'
 import { logClientSyncError } from './logClientSyncError'
+import { isAggregateCloudSyncEligible } from './gameSyncFingerprint'
 import {
   getSeasonFromDate,
   invertPlayerIdMap,
@@ -729,6 +730,10 @@ export async function syncGameSnapshotToCloud({
 
   if (!state.sport || !state.gameInfo) {
     throw new Error('Game is not initialized')
+  }
+
+  if (!isAggregateCloudSyncEligible(state)) {
+    throw new Error('Sport-owned event games cannot use aggregate cloud sync')
   }
 
   if (state.cloudSync.gameId) {

--- a/src/lib/cloudSyncHardening.test.ts
+++ b/src/lib/cloudSyncHardening.test.ts
@@ -161,6 +161,8 @@ vi.mock('./supabase', () => ({
 }))
 
 import { syncGameSnapshotToCloud } from './cloudSync'
+import { resolveSoccerMatchRules } from './soccer/rules'
+import { createSoccerSportGameState } from './soccer/state'
 
 const basketball: SportConfig = {
   id: 'basketball',
@@ -217,6 +219,26 @@ describe('syncGameSnapshotToCloud hardening', () => {
     mock.linkUpdateError = null
     mock.gameDeleteError = null
     mock.existingGameStatus = 'in_progress'
+  })
+
+  it('rejects setup-only sport state before aggregate cloud writes', async () => {
+    const soccerState = state({
+      sport: { ...basketball, id: 'soccer', name: 'Soccer', scoreLabel: 'G' },
+      sportGameState: createSoccerSportGameState({
+        version: 1,
+        trackedTeamDesignation: 'home',
+        firstPeriodAttackingDirection: 'left_to_right',
+        sourceTeamId: null,
+        sourceSeasonId: null,
+        rulesSnapshot: resolveSoccerMatchRules(),
+        participants: [],
+      }),
+    })
+
+    await expect(
+      syncGameSnapshotToCloud({ state: soccerState, userId: 'user-1' })
+    ).rejects.toThrow('cannot use aggregate cloud sync')
+    expect(mock.ops).toEqual([])
   })
 
   it('returns skippedFinalGame without writing when the cloud game is already final', async () => {

--- a/src/lib/cloudSyncHardening.test.ts
+++ b/src/lib/cloudSyncHardening.test.ts
@@ -205,6 +205,7 @@ function state(overrides: Partial<GameState> = {}): GameState {
     shotChart: [],
     ...overrides,
     eventStream: overrides.eventStream === undefined ? null : overrides.eventStream,
+    sportGameState: overrides.sportGameState === undefined ? null : overrides.sportGameState,
   }
 }
 

--- a/src/lib/gameEvents/gameEvents.test.ts
+++ b/src/lib/gameEvents/gameEvents.test.ts
@@ -278,9 +278,9 @@ describe('game event mutations and projections', () => {
     expect(editedRaw.payload).toEqual({ value: 4 })
   })
 
-  it('keeps reducer initialization disabled until the production sport projector is installed', () => {
+  it('enables reducer initialization for soccer while preserving the legacy activity guard', () => {
     const initialized = gameReducer(state(), { type: 'INITIALIZE_EVENT_STREAM' })
-    expect(initialized.eventStream).toBeNull()
+    expect(initialized.eventStream).toEqual({ version: 1, events: [] })
     expect(gameReducer(state({ opponentScore: 1 }), { type: 'INITIALIZE_EVENT_STREAM' }).eventStream).toBeNull()
   })
 })

--- a/src/lib/gameEvents/gameEvents.test.ts
+++ b/src/lib/gameEvents/gameEvents.test.ts
@@ -278,9 +278,9 @@ describe('game event mutations and projections', () => {
     expect(editedRaw.payload).toEqual({ value: 4 })
   })
 
-  it('enables reducer initialization for soccer while preserving the legacy activity guard', () => {
+  it('keeps reducer initialization closed until production soccer setup exists', () => {
     const initialized = gameReducer(state(), { type: 'INITIALIZE_EVENT_STREAM' })
-    expect(initialized.eventStream).toEqual({ version: 1, events: [] })
+    expect(initialized.eventStream).toBeNull()
     expect(gameReducer(state({ opponentScore: 1 }), { type: 'INITIALIZE_EVENT_STREAM' }).eventStream).toBeNull()
   })
 })

--- a/src/lib/gameEvents/mutations.ts
+++ b/src/lib/gameEvents/mutations.ts
@@ -88,6 +88,56 @@ export function addGameEvent<TEvent extends GameEvent>(
   )
 }
 
+export function addGameEvents<TEvent extends GameEvent>(
+  state: GameState,
+  events: GameEvent[],
+  registry: GameEventRegistry<TEvent>,
+  projectors: GameEventProjectorRegistry<TEvent>
+): GameEventMutationResult {
+  if (!state.eventStream) {
+    return failed(state, 'stream_not_initialized', 'Initialize the event stream before adding events.')
+  }
+  if (events.length === 0) {
+    return failed(state, 'invalid_event', 'At least one event is required.')
+  }
+
+  const existingIds = new Set(
+    state.eventStream.events
+      .filter(isGameEventEnvelope)
+      .map(event => event.id)
+  )
+  const batchIds = new Set<string>()
+  for (const event of events) {
+    if (
+      !isGameEventEnvelope(event) ||
+      event.revision !== 1 ||
+      event.deletedAt !== null ||
+      !registry.inspect(event).ok
+    ) {
+      return failed(state, 'invalid_event', 'Every event in the batch must be valid.')
+    }
+    if (state.sport?.id !== event.sportId) {
+      return failed(state, 'sport_mismatch', 'Every event must match the active game sport.')
+    }
+    if (existingIds.has(event.id) || batchIds.has(event.id)) {
+      return failed(state, 'duplicate_event_id', 'Every event in the batch must have a unique id.')
+    }
+    batchIds.add(event.id)
+  }
+
+  return rebuildAsSuccess(
+    {
+      ...state,
+      eventStream: {
+        ...state.eventStream,
+        events: [...state.eventStream.events, ...events.map(cloneEvent)],
+      },
+    },
+    registry,
+    projectors
+  )
+}
+
 export function updateGameEvent<TEvent extends GameEvent>(
   state: GameState,
   eventId: string,

--- a/src/lib/gameEvents/mutations.ts
+++ b/src/lib/gameEvents/mutations.ts
@@ -35,11 +35,22 @@ export function initializeGameEventStream<TEvent extends GameEvent>(
   projectors: GameEventProjectorRegistry<TEvent>
 ): GameEventMutationResult {
   if (state.eventStream) return rebuildAsSuccess(state, registry, projectors)
-  if (!state.sport || !projectors.get(state.sport.id)) {
+  const projector = state.sport ? projectors.get(state.sport.id) : undefined
+  if (!state.sport || !projector) {
     return failed(
       state,
       'unsupported_event_sport',
       'The active sport does not have an installed event projector.'
+    )
+  }
+  if (
+    projector.requiresSportGameState &&
+    state.sportGameState?.sportId !== state.sport.id
+  ) {
+    return failed(
+      state,
+      'sport_setup_required',
+      'Configure the sport-specific game setup before initializing its event stream.'
     )
   }
   if (hasLegacyAggregateActivity(state)) {
@@ -75,7 +86,8 @@ export function addGameEvent<TEvent extends GameEvent>(
   if (state.eventStream.events.some(raw => isGameEventEnvelope(raw) && raw.id === event.id)) {
     return failed(state, 'duplicate_event_id', 'An event with this id already exists.')
   }
-  return rebuildAsSuccess(
+  return appendAndRequireComplete(
+    state,
     {
       ...state,
       eventStream: {
@@ -125,7 +137,8 @@ export function addGameEvents<TEvent extends GameEvent>(
     batchIds.add(event.id)
   }
 
-  return rebuildAsSuccess(
+  return appendAndRequireComplete(
+    state,
     {
       ...state,
       eventStream: {
@@ -249,5 +262,22 @@ function rebuildAsSuccess<TEvent extends GameEvent>(
   projectors: GameEventProjectorRegistry<TEvent>
 ): GameEventMutationResult {
   const rebuilt = rebuildGameEventProjection(state, registry, projectors)
+  return { ok: true, state: rebuilt.state, inspection: rebuilt.inspection }
+}
+
+function appendAndRequireComplete<TEvent extends GameEvent>(
+  originalState: GameState,
+  appendedState: GameState,
+  registry: GameEventRegistry<TEvent>,
+  projectors: GameEventProjectorRegistry<TEvent>
+): GameEventMutationResult {
+  const rebuilt = rebuildGameEventProjection(appendedState, registry, projectors)
+  if (!rebuilt.inspection.complete) {
+    return failed(
+      originalState,
+      'incomplete_projection',
+      'The event append would create invalid or incomplete match history.'
+    )
+  }
   return { ok: true, state: rebuilt.state, inspection: rebuilt.inspection }
 }

--- a/src/lib/gameEvents/projection.ts
+++ b/src/lib/gameEvents/projection.ts
@@ -4,6 +4,8 @@ import { inspectGameEventStream } from './stream'
 import type {
   GameEvent,
   GameEventInspection,
+  GameEventProjection,
+  SportGameEventProjectionResult,
   SportGameEventProjector,
 } from './types'
 
@@ -65,7 +67,18 @@ export function rebuildGameEventProjection<TEvent extends GameEvent>(
   }
   if (!inspection.complete) return { state, inspection }
 
-  const projection = projector.project(state, inspection.activeEvents)
+  const projected = projector.project(state, inspection.activeEvents)
+  const result = isSportProjectionResult(projected)
+    ? projected
+    : { projection: projected, diagnostics: [] }
+  const projection = result.projection
+  const nextInspection: GameEventInspection<TEvent> = result.diagnostics.length > 0
+    ? {
+        ...inspection,
+        complete: false,
+        diagnostics: [...inspection.diagnostics, ...result.diagnostics],
+      }
+    : inspection
   return {
     state: {
       ...state,
@@ -77,8 +90,18 @@ export function rebuildGameEventProjection<TEvent extends GameEvent>(
       homeTeamScore: projection.homeTeamScore,
       homeScoreAdjustment: 0,
       shotChart: projection.shotChart,
+      sportGameState:
+        projection.sportGameState === undefined
+          ? state.sportGameState
+          : projection.sportGameState,
       actionLog: [],
     },
-    inspection,
+    inspection: nextInspection,
   }
+}
+
+function isSportProjectionResult(
+  value: GameEventProjection | SportGameEventProjectionResult
+): value is SportGameEventProjectionResult {
+  return 'projection' in value && Array.isArray(value.diagnostics)
 }

--- a/src/lib/gameEvents/runtime.ts
+++ b/src/lib/gameEvents/runtime.ts
@@ -1,6 +1,7 @@
 import { GameEventProjectorRegistry } from './projection'
 import { GameEventRegistry } from './registry'
+import { soccerEventDefinitions } from '../soccer/events'
+import { soccerGameEventProjector } from '../soccer/projector'
 
-/** Production definitions are added by sport phases; SOC-1 intentionally leaves these empty. */
-export const gameEventRegistry = new GameEventRegistry()
-export const gameEventProjectors = new GameEventProjectorRegistry()
+export const gameEventRegistry = new GameEventRegistry(soccerEventDefinitions)
+export const gameEventProjectors = new GameEventProjectorRegistry([soccerGameEventProjector])

--- a/src/lib/gameEvents/types.ts
+++ b/src/lib/gameEvents/types.ts
@@ -117,6 +117,8 @@ export interface SportGameEventProjectionResult {
 
 export interface SportGameEventProjector<TEvent extends GameEvent = GameEvent> {
   sportId: string
+  /** Require matching sport-owned setup before an authoritative stream can be initialized. */
+  requiresSportGameState?: boolean
   project: (
     state: GameState,
     events: TEvent[]
@@ -131,6 +133,7 @@ export type GameEventEditableFields = Pick<
 export type GameEventMutationErrorCode =
   | 'legacy_activity_present'
   | 'unsupported_event_sport'
+  | 'sport_setup_required'
   | 'stream_not_initialized'
   | 'event_not_found'
   | 'duplicate_event_id'
@@ -138,6 +141,7 @@ export type GameEventMutationErrorCode =
   | 'sport_mismatch'
   | 'already_deleted'
   | 'not_deleted'
+  | 'incomplete_projection'
 
 export interface GameEventMutationError {
   code: GameEventMutationErrorCode

--- a/src/lib/gameEvents/types.ts
+++ b/src/lib/gameEvents/types.ts
@@ -84,6 +84,8 @@ export type GameEventDiagnosticCode =
   | 'missing_projector'
   | 'unmapped_player'
   | 'invalid_cloud_row'
+  | 'semantic_validation_failed'
+  | 'unprojected_event'
 
 export interface GameEventDiagnostic {
   code: GameEventDiagnosticCode
@@ -104,11 +106,21 @@ export interface GameEventProjection {
   opponentScore: number
   homeTeamScore: number | null
   shotChart: ShotRecord[]
+  /** Omitted by legacy fixture projectors; sport projectors replace it when supplied. */
+  sportGameState?: GameState['sportGameState']
+}
+
+export interface SportGameEventProjectionResult {
+  projection: GameEventProjection
+  diagnostics: GameEventDiagnostic[]
 }
 
 export interface SportGameEventProjector<TEvent extends GameEvent = GameEvent> {
   sportId: string
-  project: (state: GameState, events: TEvent[]) => GameEventProjection
+  project: (
+    state: GameState,
+    events: TEvent[]
+  ) => GameEventProjection | SportGameEventProjectionResult
 }
 
 export type GameEventEditableFields = Pick<

--- a/src/lib/gameParking.test.ts
+++ b/src/lib/gameParking.test.ts
@@ -134,6 +134,7 @@ function gameState(sport: SportConfig, teamName: string, opponentName: string): 
     teamStatsConfig: null,
     shotChart: [],
     eventStream: null,
+    sportGameState: null,
   }
 }
 
@@ -256,6 +257,35 @@ describe('gameParking', () => {
     saveParkedGameRecordState(summary.localGameId, syncedState, 'user-1')
 
     expect(getParkedGameRecord(summary.localGameId, 'user-1')?.sync.dirty).toBe(false)
+    expect(listDirtyParkedGameRecords('user-1')).toEqual([])
+  })
+
+  it('clears inherited aggregate retry state for event-backed parked games', () => {
+    const eventState: GameState = {
+      ...gameState(soccer, 'Aces', 'Hawks'),
+      eventStream: { version: 1, events: [] },
+    }
+    const incoming = {
+      ...importedRecord('event-backed-game', eventState),
+      sync: {
+        dirty: true,
+        revision: 4,
+        lastEnqueuedRevision: 4,
+        lastSuccessfulSyncRevision: 3,
+        attempts: 2,
+        lastError: 'legacy retry',
+        nextAttemptAt: '2026-07-12T12:10:00.000Z',
+      },
+    }
+
+    importParkedGames(importPayload([incoming]), 'user-1')
+
+    expect(getParkedGameRecord('event-backed-game', 'user-1')?.sync).toMatchObject({
+      dirty: false,
+      attempts: 0,
+      lastError: null,
+      nextAttemptAt: null,
+    })
     expect(listDirtyParkedGameRecords('user-1')).toEqual([])
   })
 

--- a/src/lib/gameParking.ts
+++ b/src/lib/gameParking.ts
@@ -1,6 +1,7 @@
 import type { CloudSyncStatus, GameState } from '../types'
 import {
   buildGameSyncFingerprint,
+  isAggregateCloudSyncEligible,
   shouldBlockDiscardUnsyncedGame,
 } from './gameSyncFingerprint'
 import {
@@ -11,6 +12,7 @@ import {
   PENDING_SYNC_KEY,
 } from './gameStorageKeys'
 import { normalizeGameEventStream } from './gameEvents/stream'
+import { normalizeSportGameState } from './soccer/state'
 
 const MANIFEST_VERSION = 1
 const EXPORT_VERSION = 1
@@ -233,11 +235,20 @@ function readRecord(localGameId: string): ParkedGameRecord | null {
 }
 
 function normalizePersistedGameState(state: GameState): GameState {
-  return { ...state, eventStream: normalizeGameEventStream(state.eventStream) }
+  return {
+    ...state,
+    eventStream: normalizeGameEventStream(state.eventStream),
+    sportGameState: normalizeSportGameState(state.sportGameState),
+  }
 }
 
 function hasSyncablePayload(state: GameState): boolean {
-  return Boolean(state.sport && state.gameInfo && state.cloudSync.gameStatus !== 'final')
+  return Boolean(
+    state.sport &&
+      state.gameInfo &&
+      isAggregateCloudSyncEligible(state) &&
+      state.cloudSync.gameStatus !== 'final'
+  )
 }
 
 function normalizeSyncState(
@@ -249,6 +260,17 @@ function normalizeSyncState(
     typeof value?.revision === 'number'
       ? Math.max(0, Math.floor(value.revision))
       : existing?.sync.revision ?? 0
+  if (!hasSyncablePayload(state)) {
+    return {
+      dirty: false,
+      revision,
+      lastEnqueuedRevision: null,
+      lastSuccessfulSyncRevision: revision,
+      attempts: 0,
+      lastError: null,
+      nextAttemptAt: null,
+    }
+  }
   const fingerprint = hasSyncablePayload(state) ? buildGameSyncFingerprint(state) : null
   const dirty = Boolean(
     hasSyncablePayload(state) &&
@@ -319,6 +341,7 @@ function hasPersistableGameState(state: GameState): boolean {
       state.actionLog.length > 0 ||
       state.shotChart.length > 0 ||
       state.eventStream !== null ||
+      state.sportGameState !== null ||
       state.cloudSync.gameId
   )
 }
@@ -785,6 +808,9 @@ function isImportableGameState(value: unknown): value is GameState {
         Number.isInteger(value.eventStream.version) &&
         value.eventStream.version >= 1 &&
         Array.isArray(value.eventStream.events))) &&
+    (value.sportGameState === undefined ||
+      value.sportGameState === null ||
+      normalizeSportGameState(value.sportGameState) !== null) &&
     isPlainObject(cloudSync)
   )
 }

--- a/src/lib/gameReducer.ts
+++ b/src/lib/gameReducer.ts
@@ -11,6 +11,7 @@ import { mergeCloudSyncState } from './cloudSyncState'
 import { getDisplayedHomeScore } from './gameScore'
 import {
   addGameEvent,
+  addGameEvents,
   deleteGameEvent,
   initializeGameEventStream,
   restoreGameEvent,
@@ -19,6 +20,7 @@ import {
 import { gameEventProjectors, gameEventRegistry } from './gameEvents/runtime'
 import { normalizeGameEventStream } from './gameEvents/stream'
 import { rebuildGameEventProjection } from './gameEvents/projection'
+import { normalizeSportGameState } from './soccer/state'
 import { playerIdMapForRoster, shotChartForRoster } from './rosterAlignment'
 
 export function createInitialCloudSyncState(status: CloudSyncStatus = 'idle'): CloudSyncState {
@@ -52,6 +54,7 @@ export function createInitialState(status: CloudSyncStatus = 'idle'): GameState 
     teamStatsConfig: null,
     shotChart: [],
     eventStream: null,
+    sportGameState: null,
   }
 }
 
@@ -111,6 +114,7 @@ export function applyUndoLastEntry(state: GameState): GameState | null {
 
 export function gameReducer(state: GameState, action: GameAction): GameState {
   const resetStatus: CloudSyncStatus = state.cloudSync.status === 'offline' ? 'offline' : 'idle'
+  if (state.eventStream && isLegacyAggregateMutation(action.type)) return state
 
   switch (action.type) {
     case 'SET_SPORT':
@@ -168,6 +172,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       const normalizedState: GameState = {
         ...s,
         eventStream: normalizeGameEventStream(s.eventStream),
+        sportGameState: normalizeSportGameState(s.sportGameState),
         shotChart: shotChartForRoster(s.shotChart, s.players),
         cloudSync: {
           ...cs,
@@ -429,6 +434,13 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
     case 'SET_TEAM_STATS_CONFIG':
       return { ...state, teamStatsConfig: action.config }
 
+    case 'SET_SPORT_GAME_STATE':
+      if (state.eventStream && state.eventStream.events.length > 0) return state
+      return {
+        ...state,
+        sportGameState: action.sportGameState,
+      }
+
     case 'INITIALIZE_EVENT_STREAM':
       return initializeGameEventStream(state, gameEventRegistry, gameEventProjectors).state
 
@@ -436,6 +448,14 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       return addGameEvent(
         state,
         action.event,
+        gameEventRegistry,
+        gameEventProjectors
+      ).state
+
+    case 'ADD_GAME_EVENTS':
+      return addGameEvents(
+        state,
+        action.events,
         gameEventRegistry,
         gameEventProjectors
       ).state
@@ -471,4 +491,21 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
     default:
       return state
   }
+}
+
+function isLegacyAggregateMutation(type: GameAction['type']): boolean {
+  return [
+    'ADD_SHOT',
+    'REMOVE_LAST_SHOT',
+    'UNDO_LAST_SHOT',
+    'CLEAR_SHOT_CHART',
+    'INCREMENT_STAT',
+    'DECREMENT_STAT',
+    'INCREMENT_OPPONENT_SCORE',
+    'DECREMENT_OPPONENT_SCORE',
+    'INCREMENT_HOME_SCORE',
+    'DECREMENT_HOME_SCORE',
+    'UNDO',
+    'SET_PERIOD',
+  ].includes(type)
 }

--- a/src/lib/gameSyncFingerprint.test.ts
+++ b/src/lib/gameSyncFingerprint.test.ts
@@ -50,6 +50,7 @@ function baseState(over: Partial<GameState> = {}): GameState {
     shotChart: [],
     ...over,
     eventStream: over.eventStream === undefined ? null : over.eventStream,
+    sportGameState: over.sportGameState === undefined ? null : over.sportGameState,
   }
 }
 

--- a/src/lib/gameSyncFingerprint.ts
+++ b/src/lib/gameSyncFingerprint.ts
@@ -28,9 +28,9 @@ export function buildGameSyncFingerprint(state: GameState): string {
   })
 }
 
-/** Event-backed games use the event repository and cannot enter legacy aggregate auto-sync. */
+/** Sport-owned setup/events use their repository and cannot enter legacy aggregate auto-sync. */
 export function isAggregateCloudSyncEligible(state: GameState): boolean {
-  return state.eventStream === null
+  return state.eventStream === null && state.sportGameState === null
 }
 
 /**

--- a/src/lib/gameSyncFingerprint.ts
+++ b/src/lib/gameSyncFingerprint.ts
@@ -1,5 +1,6 @@
 import type { GameState } from '../types'
 import { canonicalGameEventStreamForFingerprint } from './gameEvents/stream'
+import { sportGameStateForFingerprint } from './soccer/state'
 
 /**
  * Canonical snapshot of game fields that are uploaded on cloud sync (excludes sync metadata).
@@ -17,6 +18,7 @@ export function buildGameSyncFingerprint(state: GameState): string {
     teamStatsConfig: state.teamStatsConfig,
     shotChart: state.shotChart,
     eventStream: canonicalGameEventStreamForFingerprint(state.eventStream),
+    sportGameState: sportGameStateForFingerprint(state.sportGameState),
     players: state.players.map(player => ({
       id: player.id,
       name: player.name,
@@ -24,6 +26,11 @@ export function buildGameSyncFingerprint(state: GameState): string {
       stats: player.stats,
     })),
   })
+}
+
+/** Event-backed games use the event repository and cannot enter legacy aggregate auto-sync. */
+export function isAggregateCloudSyncEligible(state: GameState): boolean {
+  return state.eventStream === null
 }
 
 /**

--- a/src/lib/logClientSyncError.test.ts
+++ b/src/lib/logClientSyncError.test.ts
@@ -67,6 +67,7 @@ function state(over: Partial<GameState> = {}): GameState {
     shotChart: [],
     ...over,
     eventStream: over.eventStream === undefined ? null : over.eventStream,
+    sportGameState: over.sportGameState === undefined ? null : over.sportGameState,
   }
 }
 

--- a/src/lib/soccer/events.ts
+++ b/src/lib/soccer/events.ts
@@ -186,7 +186,7 @@ function validateRosterAdded(payload: JsonObject): boolean {
 }
 
 function validateParticipantResolved(payload: JsonObject): boolean {
-  return isId(payload.participantId) && isId(payload.playerId) && isId(payload.displayName) &&
+  return isId(payload.participantId) && isId(payload.playerId) && isNonEmptyString(payload.displayName) &&
     (payload.number === null || typeof payload.number === 'string')
 }
 
@@ -199,6 +199,10 @@ function validateMatchReopened(payload: JsonObject): boolean {
 }
 
 function isId(value: unknown): value is string {
+  return isNonEmptyString(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0
 }
 

--- a/src/lib/soccer/events.ts
+++ b/src/lib/soccer/events.ts
@@ -1,0 +1,215 @@
+import { isPlainObject } from '../gameEvents/envelope'
+import type { GameEvent, GameEventPeriod, JsonObject } from '../gameEvents/types'
+import type { GameEventDefinition } from '../gameEvents/registry'
+import { validateSoccerMatchRules, validateSoccerRole } from './rules'
+import { isSoccerMatchParticipant } from './state'
+import type {
+  SoccerAttackingDirectionChangedPayload,
+  SoccerClockAdjustedPayload,
+  SoccerClockPausedPayload,
+  SoccerClockStartedPayload,
+  SoccerMatchEndedPayload,
+  SoccerMatchEvent,
+  SoccerMatchReopenedPayload,
+  SoccerMatchRosterAddedPayload,
+  SoccerMatchRulesChangedPayload,
+  SoccerOpeningLineupPayload,
+  SoccerParticipantResolvedPayload,
+  SoccerPeriodPayload,
+  SoccerRoleChangedPayload,
+  SoccerSubstitutionWindowPayload,
+} from './types'
+import { SOCCER_EVENT_SCHEMA_VERSION } from './types'
+
+export type SoccerEventPayloadByType = {
+  'soccer.opening_lineup': SoccerOpeningLineupPayload
+  'soccer.period_started': SoccerPeriodPayload
+  'soccer.period_ended': SoccerPeriodPayload
+  'soccer.clock_started': SoccerClockStartedPayload
+  'soccer.clock_paused': SoccerClockPausedPayload
+  'soccer.clock_adjusted': SoccerClockAdjustedPayload
+  'soccer.match_rules_changed': SoccerMatchRulesChangedPayload
+  'soccer.substitution_window': SoccerSubstitutionWindowPayload
+  'soccer.role_changed': SoccerRoleChangedPayload
+  'soccer.attacking_direction_changed': SoccerAttackingDirectionChangedPayload
+  'soccer.match_roster_added': SoccerMatchRosterAddedPayload
+  'soccer.participant_resolved': SoccerParticipantResolvedPayload
+  'soccer.match_ended': SoccerMatchEndedPayload
+  'soccer.match_reopened': SoccerMatchReopenedPayload
+}
+
+export interface CreateSoccerEventInput<TType extends keyof SoccerEventPayloadByType> {
+  id?: string
+  eventType: TType
+  payload: SoccerEventPayloadByType[TType]
+  recorderUserId: string | null
+  sequence: number
+  period: GameEventPeriod
+  elapsedMs: number | null
+  occurredAt: string
+}
+
+export function createSoccerEvent<TType extends keyof SoccerEventPayloadByType>(
+  input: CreateSoccerEventInput<TType>
+): Extract<SoccerMatchEvent, { eventType: TType }> {
+  return {
+    id: input.id ?? createUuid(),
+    sportId: 'soccer',
+    eventType: input.eventType,
+    schemaVersion: SOCCER_EVENT_SCHEMA_VERSION,
+    recorderUserId: input.recorderUserId,
+    sequence: input.sequence,
+    period: input.period,
+    elapsedMs: input.elapsedMs,
+    occurredAt: input.occurredAt,
+    teamSide: 'tracked',
+    location: null,
+    actors: [],
+    payload: input.payload,
+    revision: 1,
+    createdAt: input.occurredAt,
+    updatedAt: input.occurredAt,
+    deletedAt: null,
+  } as unknown as Extract<SoccerMatchEvent, { eventType: TType }>
+}
+
+export function nextSoccerEventSequence(
+  events: unknown[],
+  recorderUserId: string | null
+): number {
+  return events.reduce<number>((highest, value) => {
+    if (!isPlainObject(value) || value.recorderUserId !== recorderUserId) return highest
+    return typeof value.sequence === 'number' && Number.isInteger(value.sequence)
+      ? Math.max(highest, value.sequence)
+      : highest
+  }, -1) + 1
+}
+
+export const soccerEventDefinitions: GameEventDefinition<GameEvent>[] = [
+  definition('soccer.opening_lineup', validateOpeningLineup),
+  definition('soccer.period_started', validatePeriod),
+  definition('soccer.period_ended', validatePeriod),
+  definition('soccer.clock_started', validateClockStarted),
+  definition('soccer.clock_paused', validateClockPaused),
+  definition('soccer.clock_adjusted', validateClockAdjusted),
+  definition('soccer.match_rules_changed', validateRulesChanged),
+  definition('soccer.substitution_window', validateSubstitutionWindow),
+  definition('soccer.role_changed', validateRoleChanged),
+  definition('soccer.attacking_direction_changed', validateDirectionChanged),
+  definition('soccer.match_roster_added', validateRosterAdded),
+  definition('soccer.participant_resolved', validateParticipantResolved),
+  definition('soccer.match_ended', validateMatchEnded),
+  definition('soccer.match_reopened', validateMatchReopened),
+]
+
+function definition(
+  eventType: keyof SoccerEventPayloadByType,
+  validatePayload: (payload: JsonObject) => boolean
+): GameEventDefinition<GameEvent> {
+  return {
+    sportId: 'soccer',
+    eventType,
+    currentSchemaVersion: SOCCER_EVENT_SCHEMA_VERSION,
+    validate: event => {
+      if (
+        event.sportId !== 'soccer' ||
+        event.eventType !== eventType ||
+        event.schemaVersion !== SOCCER_EVENT_SCHEMA_VERSION ||
+        event.teamSide !== 'tracked' ||
+        event.location !== null ||
+        event.actors.length !== 0 ||
+        !validatePayload(event.payload)
+      ) {
+        return { ok: false, message: `${eventType} has an invalid soccer payload.` }
+      }
+      return { ok: true, event }
+    },
+  }
+}
+
+function validateOpeningLineup(payload: JsonObject): boolean {
+  return Array.isArray(payload.starters) && payload.starters.length > 0 && payload.starters.every(
+    entry => isPlainObject(entry) && isId(entry.participantId) && validateSoccerRole(entry.role)
+  )
+}
+
+function validatePeriod(payload: JsonObject): boolean {
+  return isId(payload.periodId)
+}
+
+function validateClockStarted(payload: JsonObject): boolean {
+  return isNonNegativeInteger(payload.anchorElapsedMs)
+}
+
+function validateClockPaused(payload: JsonObject): boolean {
+  return isNonNegativeInteger(payload.elapsedMs)
+}
+
+function validateClockAdjusted(payload: JsonObject): boolean {
+  return isNonNegativeInteger(payload.fromElapsedMs) && isNonNegativeInteger(payload.toElapsedMs)
+}
+
+function validateRulesChanged(payload: JsonObject): boolean {
+  return validateSoccerMatchRules(payload.rules) === null
+}
+
+function validateSubstitutionWindow(payload: JsonObject): boolean {
+  return Boolean(
+    Array.isArray(payload.changes) &&
+      payload.changes.length > 0 &&
+      typeof payload.halftime === 'boolean' &&
+      payload.changes.every(change => {
+        if (!isPlainObject(change)) return false
+        const out = change.playerOutParticipantId
+        const incoming = change.playerInParticipantId
+        if ((out !== null && !isId(out)) || (incoming !== null && !isId(incoming))) return false
+        if (out === null && incoming === null) return false
+        if (out !== null && out === incoming) return false
+        return change.playerInRole === null || validateSoccerRole(change.playerInRole)
+      })
+  )
+}
+
+function validateRoleChanged(payload: JsonObject): boolean {
+  return Array.isArray(payload.changes) && payload.changes.length > 0 && payload.changes.every(
+    change => isPlainObject(change) && isId(change.participantId) && validateSoccerRole(change.role)
+  )
+}
+
+function validateDirectionChanged(payload: JsonObject): boolean {
+  return payload.direction === 'left_to_right' || payload.direction === 'right_to_left'
+}
+
+function validateRosterAdded(payload: JsonObject): boolean {
+  return isSoccerMatchParticipant(payload.participant) &&
+    (payload.destination === 'bench' || payload.destination === 'on_field')
+}
+
+function validateParticipantResolved(payload: JsonObject): boolean {
+  return isId(payload.participantId) && isId(payload.playerId) && isId(payload.displayName) &&
+    (payload.number === null || typeof payload.number === 'string')
+}
+
+function validateMatchEnded(payload: JsonObject): boolean {
+  return payload.reason === 'completed' || payload.reason === 'suspended' || payload.reason === 'abandoned'
+}
+
+function validateMatchReopened(payload: JsonObject): boolean {
+  return payload.reason === null || typeof payload.reason === 'string'
+}
+
+function isId(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) >= 0
+}
+
+function createUuid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  const random = Math.random().toString(16).slice(2).padEnd(12, '0').slice(0, 12)
+  return `00000000-0000-4000-8000-${random}`
+}

--- a/src/lib/soccer/index.ts
+++ b/src/lib/soccer/index.ts
@@ -1,0 +1,5 @@
+export * from './types'
+export * from './rules'
+export * from './state'
+export * from './events'
+export * from './projector'

--- a/src/lib/soccer/projector.ts
+++ b/src/lib/soccer/projector.ts
@@ -1,0 +1,561 @@
+import type { GameState } from '../../types'
+import type {
+  GameEvent,
+  GameEventDiagnostic,
+  GameEventProjection,
+  SportGameEventProjectionResult,
+  SportGameEventProjector,
+} from '../gameEvents/types'
+import { orderedSoccerSegments, validateSoccerMatchRules } from './rules'
+import { createSoccerMatchProjection } from './state'
+import type {
+  SoccerAttackingDirection,
+  SoccerMatchEvent,
+  SoccerMatchProjection,
+  SoccerMatchRules,
+  SoccerProjectedParticipant,
+  SoccerRole,
+  SoccerSportGameState,
+} from './types'
+
+export const soccerGameEventProjector: SportGameEventProjector<GameEvent> = {
+  sportId: 'soccer',
+  project: projectSoccerMatchEvents,
+}
+
+export function projectSoccerMatchEvents(
+  state: GameState,
+  events: GameEvent[]
+): SportGameEventProjectionResult {
+  const sportState = state.sportGameState
+  if (!sportState || sportState.sportId !== 'soccer') {
+    return {
+      projection: emptyProjection(state, state.sportGameState),
+      diagnostics: [diagnostic(null, 'Soccer event projection requires a valid soccer setup.')],
+    }
+  }
+
+  const soccerEvents = [...events]
+    .filter((event): event is SoccerMatchEvent => event.sportId === 'soccer')
+    .sort(compareSoccerCaptureOrder)
+  let projection = createSoccerMatchProjection(sportState.setup)
+  const diagnostics: GameEventDiagnostic[] = []
+  const seenSequences = new Set<string>()
+
+  for (let index = 0; index < soccerEvents.length; index += 1) {
+    const event = soccerEvents[index]
+    const sequenceKey = `${event.recorderUserId ?? 'local'}\u0000${event.sequence}`
+    const next = structuredClone(projection)
+    const error = seenSequences.has(sequenceKey)
+      ? `Capture sequence ${event.sequence} is duplicated for this recorder.`
+      : applySoccerEvent(next, sportState, event, state)
+    if (error) {
+      diagnostics.push(diagnostic(event.id, error))
+      for (const unprojected of soccerEvents.slice(index + 1)) {
+        diagnostics.push({
+          code: 'unprojected_event',
+          message: 'Event was preserved but not projected because earlier match history is invalid.',
+          eventId: unprojected.id,
+        })
+      }
+      break
+    }
+    seenSequences.add(sequenceKey)
+    projection = next
+  }
+
+  const nextSportState: SoccerSportGameState = {
+    ...sportState,
+    projection,
+  }
+  return {
+    projection: buildProjection(state, nextSportState),
+    diagnostics,
+  }
+}
+
+function applySoccerEvent(
+  projection: SoccerMatchProjection,
+  sportState: SoccerSportGameState,
+  event: SoccerMatchEvent,
+  gameState: GameState
+): string | null {
+  if (projection.clock.running && event.elapsedMs !== null && ![
+    'soccer.clock_paused',
+    'soccer.clock_adjusted',
+  ].includes(event.eventType)) {
+    const error = advanceRunningClock(projection, event.elapsedMs, event.occurredAt)
+    if (error) return error
+  }
+
+  switch (event.eventType) {
+    case 'soccer.opening_lineup':
+      return applyOpeningLineup(projection, sportState, event.payload.starters)
+    case 'soccer.period_started':
+      return applyPeriodStarted(projection, event.payload.periodId, event.period.id)
+    case 'soccer.period_ended':
+      return applyPeriodEnded(projection, event.payload.periodId, event.period.id)
+    case 'soccer.clock_started':
+      return applyClockStarted(projection, event.payload.anchorElapsedMs, event.elapsedMs, event.occurredAt)
+    case 'soccer.clock_paused':
+      return applyClockPaused(projection, event.payload.elapsedMs, event.elapsedMs)
+    case 'soccer.clock_adjusted':
+      return applyClockAdjusted(projection, event.payload.fromElapsedMs, event.payload.toElapsedMs, event.elapsedMs, event.occurredAt)
+    case 'soccer.match_rules_changed':
+      return applyRulesChanged(projection, event.payload.rules)
+    case 'soccer.substitution_window':
+      return applySubstitutionWindow(projection, event.payload.changes, event.payload.halftime, event.elapsedMs)
+    case 'soccer.role_changed':
+      return applyRoleChanges(projection, event.payload.changes)
+    case 'soccer.attacking_direction_changed':
+      projection.attackingDirection = event.payload.direction
+      return null
+    case 'soccer.match_roster_added':
+      return applyRosterAddition(projection, event.payload.participant, event.payload.destination, event.elapsedMs)
+    case 'soccer.participant_resolved':
+      return applyParticipantResolution(projection, event.payload, gameState)
+    case 'soccer.match_ended':
+      return applyMatchEnded(projection, event.payload.reason, event.occurredAt)
+    case 'soccer.match_reopened':
+      return applyMatchReopened(projection)
+  }
+}
+
+function applyOpeningLineup(
+  projection: SoccerMatchProjection,
+  sportState: SoccerSportGameState,
+  starters: Array<{ participantId: string; role: SoccerRole }>
+): string | null {
+  if (projection.status !== 'not_started' || projection.openingLineupRecorded) {
+    return 'Opening lineup can only be recorded once before the match starts.'
+  }
+  const expected = sportState.setup.participants
+    .filter(participant => participant.initialStatus === 'starter')
+    .map(participant => participant.id)
+    .sort()
+  const actual = starters.map(starter => starter.participantId).sort()
+  if (new Set(actual).size !== actual.length || JSON.stringify(actual) !== JSON.stringify(expected)) {
+    return 'Opening lineup must exactly match the setup starters.'
+  }
+  if (starters.length > projection.currentRules.maxOnFieldPlayers) {
+    return 'Opening lineup exceeds the configured on-field player maximum.'
+  }
+  for (const starter of starters) {
+    const participant = projection.participants[starter.participantId]
+    if (!participant) return `Opening lineup references unknown participant ${starter.participantId}.`
+    participant.status = 'on_field'
+    participant.role = structuredClone(starter.role)
+    participant.started = true
+    participant.appearances = 1
+  }
+  const goalkeeperError = validateOnFieldGoalkeeper(projection)
+  if (goalkeeperError) return goalkeeperError
+  projection.openingLineupRecorded = true
+  return null
+}
+
+function applyPeriodStarted(
+  projection: SoccerMatchProjection,
+  periodId: string,
+  envelopePeriodId: string
+): string | null {
+  if (!projection.openingLineupRecorded || projection.clock.running || projection.currentPeriodId) {
+    return 'A period cannot start in the current match state.'
+  }
+  if (projection.status !== 'not_started' && projection.status !== 'period_break') {
+    return 'A period can only start before kickoff or during a period break.'
+  }
+  if (periodId !== envelopePeriodId) return 'Period payload and envelope ids must match.'
+  const nextSegment = orderedSoccerSegments(projection.currentRules)
+    .find(segment => !projection.completedPeriodIds.includes(segment.id))
+  if (!nextSegment || nextSegment.id !== periodId) return 'The requested period is not the next available segment.'
+
+  projection.currentPeriodId = periodId
+  projection.status = 'in_progress'
+  projection.attackingDirection = directionForSegment(projection, nextSegment.id)
+  projection.endedAt = null
+  return null
+}
+
+function applyPeriodEnded(
+  projection: SoccerMatchProjection,
+  periodId: string,
+  envelopePeriodId: string
+): string | null {
+  if (projection.status !== 'in_progress' || projection.clock.running) {
+    return 'Pause the clock before ending the active period.'
+  }
+  if (!projection.currentPeriodId || projection.currentPeriodId !== periodId || periodId !== envelopePeriodId) {
+    return 'Only the active period can be ended.'
+  }
+  projection.completedPeriodIds.push(periodId)
+  projection.currentPeriodId = null
+  projection.status = 'period_break'
+  return null
+}
+
+function applyClockStarted(
+  projection: SoccerMatchProjection,
+  anchorElapsedMs: number,
+  eventElapsedMs: number | null,
+  occurredAt: string
+): string | null {
+  if (projection.status !== 'in_progress' || !projection.currentPeriodId || projection.clock.running) {
+    return 'Clock can only start in an active stopped period.'
+  }
+  if (eventElapsedMs !== anchorElapsedMs || anchorElapsedMs !== projection.clock.elapsedMs) {
+    return 'Clock start must use the current canonical elapsed time.'
+  }
+  projection.clock = { running: true, elapsedMs: anchorElapsedMs, anchorOccurredAt: occurredAt }
+  for (const participant of onFieldParticipants(projection)) {
+    participant.activeSinceElapsedMs = anchorElapsedMs
+  }
+  return null
+}
+
+function applyClockPaused(
+  projection: SoccerMatchProjection,
+  elapsedMs: number,
+  eventElapsedMs: number | null
+): string | null {
+  if (!projection.clock.running || eventElapsedMs !== elapsedMs) {
+    return 'Clock pause requires a running clock and matching canonical elapsed time.'
+  }
+  if (elapsedMs < projection.clock.elapsedMs) return 'Clock pause cannot move elapsed time backward.'
+  closeActiveIntervals(projection, elapsedMs)
+  projection.clock = { running: false, elapsedMs, anchorOccurredAt: null }
+  return null
+}
+
+function applyClockAdjusted(
+  projection: SoccerMatchProjection,
+  fromElapsedMs: number,
+  toElapsedMs: number,
+  eventElapsedMs: number | null,
+  occurredAt: string
+): string | null {
+  if (fromElapsedMs !== projection.clock.elapsedMs || eventElapsedMs !== toElapsedMs) {
+    return 'Clock correction must identify the current and corrected canonical times.'
+  }
+  if (projection.clock.running) {
+    for (const participant of onFieldParticipants(projection)) {
+      if (participant.activeSinceElapsedMs !== null && participant.activeSinceElapsedMs > toElapsedMs) {
+        return 'Clock correction would place an active participant before their entry time.'
+      }
+    }
+    projection.clock = { running: true, elapsedMs: toElapsedMs, anchorOccurredAt: occurredAt }
+  } else {
+    projection.clock = { running: false, elapsedMs: toElapsedMs, anchorOccurredAt: null }
+  }
+  return null
+}
+
+function applyRulesChanged(
+  projection: SoccerMatchProjection,
+  rules: SoccerMatchRules
+): string | null {
+  const rulesError = validateSoccerMatchRules(rules)
+  if (rulesError) return rulesError
+  const oldSegments = orderedSoccerSegments(projection.currentRules)
+  const nextSegments = orderedSoccerSegments(rules)
+  for (const periodId of [...projection.completedPeriodIds, projection.currentPeriodId].filter(Boolean)) {
+    const oldSegment = oldSegments.find(segment => segment.id === periodId)
+    const nextSegment = nextSegments.find(segment => segment.id === periodId)
+    if (!oldSegment || !nextSegment || JSON.stringify(oldSegment) !== JSON.stringify(nextSegment)) {
+      return 'Completed and active period definitions cannot be rewritten mid-match.'
+    }
+  }
+  if (onFieldParticipants(projection).length > rules.maxOnFieldPlayers) {
+    return 'The new player maximum is below the current on-field count.'
+  }
+  if (rules.substitutionLimit !== null && rules.substitutionLimit < projection.substitutionCount) {
+    return 'The new substitution limit is below substitutions already used.'
+  }
+  if (rules.substitutionWindowLimit !== null && rules.substitutionWindowLimit < projection.substitutionWindowCount) {
+    return 'The new window limit is below windows already used.'
+  }
+  projection.currentRules = structuredClone(rules)
+  return null
+}
+
+function applySubstitutionWindow(
+  projection: SoccerMatchProjection,
+  changes: Array<{
+    playerOutParticipantId: string | null
+    playerInParticipantId: string | null
+    playerInRole: SoccerRole | null
+  }>,
+  halftime: boolean,
+  elapsedMs: number | null
+): string | null {
+  if (projection.status !== 'in_progress' && projection.status !== 'period_break') {
+    return 'Substitutions require an active match or period break.'
+  }
+  if (projection.status === 'in_progress' && elapsedMs === null) {
+    return 'In-period substitutions require canonical elapsed time.'
+  }
+  if (!projection.clock.running && elapsedMs !== projection.clock.elapsedMs) {
+    return 'A stopped-clock substitution must use the current canonical elapsed time.'
+  }
+  if (halftime && projection.status !== 'period_break') {
+    return 'Halftime substitutions can only be recorded during a period break.'
+  }
+  const ids = changes.flatMap(change => [change.playerOutParticipantId, change.playerInParticipantId]).filter(Boolean)
+  if (new Set(ids).size !== ids.length) return 'A participant can appear only once in a substitution window.'
+  const incomingCount = changes.filter(change => change.playerInParticipantId !== null).length
+  const nextSubstitutionCount = projection.substitutionCount + incomingCount
+  const nextWindowCount = projection.substitutionWindowCount + (halftime ? 0 : 1)
+  if (projection.currentRules.substitutionLimit !== null && nextSubstitutionCount > projection.currentRules.substitutionLimit) {
+    return 'This substitution exceeds the configured match limit.'
+  }
+  if (projection.currentRules.substitutionWindowLimit !== null && nextWindowCount > projection.currentRules.substitutionWindowLimit) {
+    return 'This substitution exceeds the configured window limit.'
+  }
+
+  for (const change of changes) {
+    if (change.playerOutParticipantId) {
+      const outgoing = projection.participants[change.playerOutParticipantId]
+      if (!outgoing || outgoing.status !== 'on_field') return 'Every outgoing participant must be on field.'
+      closeParticipantInterval(outgoing, elapsedMs ?? projection.clock.elapsedMs)
+      outgoing.status = 'left'
+      outgoing.hasExited = true
+    }
+    if (change.playerInParticipantId) {
+      const incoming = projection.participants[change.playerInParticipantId]
+      if (!incoming || incoming.status === 'on_field') return 'Every incoming participant must be off field.'
+      if (incoming.hasExited && !projection.currentRules.allowReturnSubstitutions) {
+        return 'Return substitutions are disabled for this match.'
+      }
+      incoming.status = 'on_field'
+      incoming.role = structuredClone(change.playerInRole ?? incoming.role)
+      incoming.appearances = Math.max(1, incoming.appearances)
+      incoming.activeSinceElapsedMs = projection.clock.running ? elapsedMs : null
+    }
+  }
+  if (onFieldParticipants(projection).length > projection.currentRules.maxOnFieldPlayers) {
+    return 'Substitution leaves too many players on field.'
+  }
+  const goalkeeperError = validateOnFieldGoalkeeper(projection)
+  if (goalkeeperError) return goalkeeperError
+  projection.substitutionCount = nextSubstitutionCount
+  projection.substitutionWindowCount = nextWindowCount
+  return null
+}
+
+function applyRoleChanges(
+  projection: SoccerMatchProjection,
+  changes: Array<{ participantId: string; role: SoccerRole }>
+): string | null {
+  if (projection.status === 'not_started' || projection.status === 'ended') {
+    return 'Roles can only change during an active match.'
+  }
+  if (new Set(changes.map(change => change.participantId)).size !== changes.length) {
+    return 'A role-change event cannot repeat a participant.'
+  }
+  for (const change of changes) {
+    const participant = projection.participants[change.participantId]
+    if (!participant) return `Role change references unknown participant ${change.participantId}.`
+    participant.role = structuredClone(change.role)
+  }
+  return validateOnFieldGoalkeeper(projection)
+}
+
+function applyRosterAddition(
+  projection: SoccerMatchProjection,
+  participant: {
+    id: string
+    kind: 'player' | 'anonymous'
+    playerId: string | null
+    displayName: string
+    number: string | null
+    initialStatus: 'starter' | 'bench'
+    initialRole: SoccerRole
+  },
+  destination: 'bench' | 'on_field',
+  elapsedMs: number | null
+): string | null {
+  if (projection.status === 'not_started' || projection.status === 'ended') {
+    return 'Late roster additions require an active match.'
+  }
+  if (projection.participants[participant.id]) return 'Participant id already exists in this match.'
+  if (participant.playerId && Object.values(projection.participants).some(item => item.playerId === participant.playerId)) {
+    return 'Roster player is already represented in this match.'
+  }
+  if (destination === 'on_field' && projection.status === 'in_progress' && elapsedMs === null) {
+    return 'An in-period entry requires canonical elapsed time.'
+  }
+  projection.participants[participant.id] = {
+    participantId: participant.id,
+    playerId: participant.playerId,
+    displayName: participant.displayName,
+    number: participant.number,
+    status: destination,
+    role: structuredClone(participant.initialRole),
+    started: false,
+    appearances: destination === 'on_field' ? 1 : 0,
+    totalActiveMs: 0,
+    activeSinceElapsedMs: destination === 'on_field' && projection.clock.running ? elapsedMs : null,
+    hasExited: false,
+  }
+  if (onFieldParticipants(projection).length > projection.currentRules.maxOnFieldPlayers) {
+    return 'Roster addition leaves too many players on field.'
+  }
+  return validateOnFieldGoalkeeper(projection)
+}
+
+function applyParticipantResolution(
+  projection: SoccerMatchProjection,
+  payload: { participantId: string; playerId: string; displayName: string; number: string | null },
+  gameState: GameState
+): string | null {
+  const participant = projection.participants[payload.participantId]
+  if (!participant || participant.playerId !== null) {
+    return 'Only an unresolved anonymous participant can be mapped to a player.'
+  }
+  if (!gameState.players.some(player => player.id === payload.playerId)) {
+    return 'Resolved player must exist in the active game roster.'
+  }
+  if (Object.values(projection.participants).some(item => item.playerId === payload.playerId)) {
+    return 'Resolved player is already represented in this match.'
+  }
+  participant.playerId = payload.playerId
+  participant.displayName = payload.displayName
+  participant.number = payload.number
+  return null
+}
+
+function applyMatchEnded(
+  projection: SoccerMatchProjection,
+  reason: 'completed' | 'suspended' | 'abandoned',
+  occurredAt: string
+): string | null {
+  if (projection.status !== 'period_break' && projection.status !== 'in_progress') {
+    return 'Only an active match can be ended.'
+  }
+  if (projection.clock.running) return 'Pause the clock before ending the match.'
+  if (reason === 'completed' && projection.status !== 'period_break') {
+    return 'A completed match must end from a period break.'
+  }
+  if (reason === 'completed') {
+    const regulationIds = projection.currentRules.regulationSegments.map(segment => segment.id)
+    if (!regulationIds.every(periodId => projection.completedPeriodIds.includes(periodId))) {
+      return 'A completed match requires every regulation period to be complete.'
+    }
+    const extraTimeIds = projection.currentRules.extraTimeSegments.map(segment => segment.id)
+    const extraTimeBegan = extraTimeIds.some(periodId => projection.completedPeriodIds.includes(periodId))
+    if (extraTimeBegan && !extraTimeIds.every(periodId => projection.completedPeriodIds.includes(periodId))) {
+      return 'Began extra time must be completed before ending the match as completed.'
+    }
+  }
+  projection.status = 'ended'
+  projection.currentPeriodId = null
+  projection.endedAt = occurredAt
+  return null
+}
+
+function applyMatchReopened(projection: SoccerMatchProjection): string | null {
+  if (projection.status !== 'ended') return 'Only an ended match can be reopened.'
+  projection.status = 'period_break'
+  projection.currentPeriodId = null
+  projection.endedAt = null
+  return null
+}
+
+function advanceRunningClock(
+  projection: SoccerMatchProjection,
+  elapsedMs: number,
+  occurredAt: string
+): string | null {
+  if (elapsedMs < projection.clock.elapsedMs) return 'Event elapsed time predates the running clock anchor.'
+  projection.clock.elapsedMs = elapsedMs
+  projection.clock.anchorOccurredAt = occurredAt
+  return null
+}
+
+function closeActiveIntervals(projection: SoccerMatchProjection, elapsedMs: number): void {
+  for (const participant of onFieldParticipants(projection)) {
+    closeParticipantInterval(participant, elapsedMs)
+  }
+}
+
+function closeParticipantInterval(participant: SoccerProjectedParticipant, elapsedMs: number): void {
+  if (participant.activeSinceElapsedMs === null) return
+  participant.totalActiveMs += Math.max(0, elapsedMs - participant.activeSinceElapsedMs)
+  participant.activeSinceElapsedMs = null
+}
+
+function onFieldParticipants(projection: SoccerMatchProjection): SoccerProjectedParticipant[] {
+  return Object.values(projection.participants).filter(participant => participant.status === 'on_field')
+}
+
+function validateOnFieldGoalkeeper(projection: SoccerMatchProjection): string | null {
+  const onField = onFieldParticipants(projection)
+  const goalkeepers = onField.filter(participant => participant.role.group === 'goalkeeper')
+  return onField.length > 0 && goalkeepers.length !== 1
+    ? 'The on-field lineup must contain exactly one goalkeeper.'
+    : null
+}
+
+function directionForSegment(
+  projection: SoccerMatchProjection,
+  segmentId: string
+): SoccerAttackingDirection {
+  const index = orderedSoccerSegments(projection.currentRules)
+    .findIndex(segment => segment.id === segmentId)
+  const base = projection.firstPeriodAttackingDirection
+  return index % 2 === 0 ? base : oppositeDirection(base)
+}
+
+function oppositeDirection(direction: SoccerAttackingDirection): SoccerAttackingDirection {
+  return direction === 'left_to_right' ? 'right_to_left' : 'left_to_right'
+}
+
+function compareSoccerCaptureOrder(left: SoccerMatchEvent, right: SoccerMatchEvent): number {
+  if (left.sequence !== right.sequence) return left.sequence - right.sequence
+  return left.id.localeCompare(right.id)
+}
+
+function buildProjection(
+  state: GameState,
+  sportGameState: SoccerSportGameState
+): GameEventProjection {
+  const statsByPlayerId: Record<string, Record<string, number>> = Object.fromEntries(
+    state.players.map(player => [player.id, {}])
+  )
+  for (const participant of Object.values(sportGameState.projection.participants)) {
+    if (!participant.playerId || !statsByPlayerId[participant.playerId]) continue
+    const stats = statsByPlayerId[participant.playerId]
+    stats.soc_start = (stats.soc_start ?? 0) + (participant.started ? 1 : 0)
+    stats.soc_app = (stats.soc_app ?? 0) + participant.appearances
+    const activeMs = participant.totalActiveMs + (
+      participant.activeSinceElapsedMs === null
+        ? 0
+        : Math.max(0, sportGameState.projection.clock.elapsedMs - participant.activeSinceElapsedMs)
+    )
+    stats.soc_min_sec = (stats.soc_min_sec ?? 0) + Math.floor(activeMs / 1_000)
+  }
+  return {
+    playerStatsById: statsByPlayerId,
+    opponentScore: 0,
+    homeTeamScore: 0,
+    shotChart: [],
+    sportGameState,
+  }
+}
+
+function emptyProjection(
+  state: GameState,
+  sportGameState: GameState['sportGameState']
+): GameEventProjection {
+  return {
+    playerStatsById: Object.fromEntries(state.players.map(player => [player.id, {}])),
+    opponentScore: 0,
+    homeTeamScore: 0,
+    shotChart: [],
+    sportGameState,
+  }
+}
+
+function diagnostic(eventId: string | null, message: string): GameEventDiagnostic {
+  return { code: 'semantic_validation_failed', message, eventId }
+}

--- a/src/lib/soccer/projector.ts
+++ b/src/lib/soccer/projector.ts
@@ -20,6 +20,7 @@ import type {
 
 export const soccerGameEventProjector: SportGameEventProjector<GameEvent> = {
   sportId: 'soccer',
+  requiresSportGameState: true,
   project: projectSoccerMatchEvents,
 }
 
@@ -108,6 +109,9 @@ function applySoccerEvent(
     case 'soccer.role_changed':
       return applyRoleChanges(projection, event.payload.changes)
     case 'soccer.attacking_direction_changed':
+      if (projection.status !== 'in_progress' && projection.status !== 'period_break') {
+        return 'Attacking direction can only change during an active match.'
+      }
       projection.attackingDirection = event.payload.direction
       return null
     case 'soccer.match_roster_added':
@@ -491,7 +495,7 @@ function onFieldParticipants(projection: SoccerMatchProjection): SoccerProjected
 function validateOnFieldGoalkeeper(projection: SoccerMatchProjection): string | null {
   const onField = onFieldParticipants(projection)
   const goalkeepers = onField.filter(participant => participant.role.group === 'goalkeeper')
-  return onField.length > 0 && goalkeepers.length !== 1
+  return goalkeepers.length !== 1
     ? 'The on-field lineup must contain exactly one goalkeeper.'
     : null
 }

--- a/src/lib/soccer/rules.ts
+++ b/src/lib/soccer/rules.ts
@@ -1,0 +1,141 @@
+import { isPlainObject } from '../gameEvents/envelope'
+import type {
+  SoccerMatchRules,
+  SoccerMatchSegment,
+  SoccerRole,
+} from './types'
+
+const MINUTE_MS = 60_000
+
+export const DEFAULT_SOCCER_MATCH_RULES: SoccerMatchRules = {
+  regulationSegments: [
+    { id: 'regulation-1', label: 'First Half', kind: 'regulation', order: 1, durationMs: 45 * MINUTE_MS },
+    { id: 'regulation-2', label: 'Second Half', kind: 'regulation', order: 2, durationMs: 45 * MINUTE_MS },
+  ],
+  extraTimeSegments: [
+    { id: 'extra-time-1', label: 'Extra Time 1', kind: 'extra_time', order: 3, durationMs: 15 * MINUTE_MS },
+    { id: 'extra-time-2', label: 'Extra Time 2', kind: 'extra_time', order: 4, durationMs: 15 * MINUTE_MS },
+  ],
+  extraTimeAvailable: false,
+  shootoutAvailable: false,
+  clockDirection: 'count_up',
+  clockDisplay: 'continuous',
+  maxOnFieldPlayers: 11,
+  allowReturnSubstitutions: false,
+  substitutionLimit: null,
+  substitutionWindowLimit: null,
+  maxAssistsPerGoal: 2,
+}
+
+export type SoccerMatchRulesOverride = {
+  regulationSegments?: SoccerMatchRules['regulationSegments']
+  extraTimeSegments?: SoccerMatchRules['extraTimeSegments']
+  extraTimeAvailable?: boolean
+  shootoutAvailable?: boolean
+  clockDirection?: SoccerMatchRules['clockDirection']
+  clockDisplay?: SoccerMatchRules['clockDisplay']
+  maxOnFieldPlayers?: number
+  allowReturnSubstitutions?: boolean
+  substitutionLimit?: number | null
+  substitutionWindowLimit?: number | null
+  maxAssistsPerGoal?: number
+}
+
+export interface SoccerRuleLayers {
+  appDefaults?: SoccerMatchRulesOverride | null
+  personalDefaults?: SoccerMatchRulesOverride | null
+  seasonRules?: SoccerMatchRulesOverride | null
+  gameOverrides?: SoccerMatchRulesOverride | null
+}
+
+export function resolveSoccerMatchRules(layers: SoccerRuleLayers = {}): SoccerMatchRules {
+  const resolved = [
+    layers.appDefaults,
+    layers.personalDefaults,
+    layers.seasonRules,
+    layers.gameOverrides,
+  ].reduce<SoccerMatchRules>((rules, layer) => ({ ...rules, ...(layer ?? {}) } as SoccerMatchRules), {
+    ...DEFAULT_SOCCER_MATCH_RULES,
+    regulationSegments: DEFAULT_SOCCER_MATCH_RULES.regulationSegments.map(segment => ({ ...segment })),
+    extraTimeSegments: DEFAULT_SOCCER_MATCH_RULES.extraTimeSegments.map(segment => ({ ...segment })),
+  })
+
+  const error = validateSoccerMatchRules(resolved)
+  if (error) throw new Error(error)
+  return structuredClone(resolved)
+}
+
+export function validateSoccerRole(value: unknown): value is SoccerRole {
+  return Boolean(
+    isPlainObject(value) &&
+      ['goalkeeper', 'defender', 'midfielder', 'forward', 'custom'].includes(String(value.group)) &&
+      (value.label === null || typeof value.label === 'string') &&
+      (value.group !== 'custom' || (typeof value.label === 'string' && value.label.trim().length > 0))
+  )
+}
+
+export function validateSoccerMatchRules(value: unknown): string | null {
+  if (!isPlainObject(value)) return 'Soccer rules must be an object.'
+  if (!Array.isArray(value.regulationSegments) || value.regulationSegments.length === 0) {
+    return 'At least one regulation segment is required.'
+  }
+  if (!Array.isArray(value.extraTimeSegments)) return 'Extra-time segments must be an array.'
+  const segments = [...value.regulationSegments, ...value.extraTimeSegments]
+  if (!segments.every(isMatchSegment)) return 'Every match segment must be valid.'
+  if (new Set(segments.map(segment => segment.id)).size !== segments.length) {
+    return 'Match segment ids must be unique.'
+  }
+  const orders = segments.map(segment => segment.order)
+  if (new Set(orders).size !== orders.length) return 'Match segment order values must be unique.'
+  if (!value.regulationSegments.every(segment => segment.kind === 'regulation')) {
+    return 'Regulation segments must use the regulation kind.'
+  }
+  if (!value.extraTimeSegments.every(segment => segment.kind === 'extra_time')) {
+    return 'Extra-time segments must use the extra-time kind.'
+  }
+  if (typeof value.extraTimeAvailable !== 'boolean' || typeof value.shootoutAvailable !== 'boolean') {
+    return 'Extra-time and shootout availability must be boolean.'
+  }
+  if (value.clockDirection !== 'count_up' && value.clockDirection !== 'count_down') {
+    return 'Clock direction is invalid.'
+  }
+  if (value.clockDisplay !== 'continuous' && value.clockDisplay !== 'per_period') {
+    return 'Clock display mode is invalid.'
+  }
+  if (!isPositiveInteger(value.maxOnFieldPlayers)) return 'Maximum on-field players must be positive.'
+  if (typeof value.allowReturnSubstitutions !== 'boolean') return 'Return substitution policy is invalid.'
+  if (!isNullableNonNegativeInteger(value.substitutionLimit)) return 'Substitution limit is invalid.'
+  if (!isNullableNonNegativeInteger(value.substitutionWindowLimit)) return 'Substitution window limit is invalid.'
+  if (!isNonNegativeInteger(value.maxAssistsPerGoal) || Number(value.maxAssistsPerGoal) > 2) {
+    return 'Maximum assists per goal must be 0, 1, or 2.'
+  }
+  return null
+}
+
+export function orderedSoccerSegments(rules: SoccerMatchRules): SoccerMatchSegment[] {
+  return [...rules.regulationSegments, ...(rules.extraTimeAvailable ? rules.extraTimeSegments : [])]
+    .sort((left, right) => left.order - right.order)
+}
+
+function isMatchSegment(value: unknown): value is SoccerMatchSegment {
+  return Boolean(
+    isPlainObject(value) &&
+      typeof value.id === 'string' && value.id.trim().length > 0 &&
+      typeof value.label === 'string' && value.label.trim().length > 0 &&
+      (value.kind === 'regulation' || value.kind === 'extra_time') &&
+      isNonNegativeInteger(value.order) &&
+      isPositiveInteger(value.durationMs)
+  )
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) > 0
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) >= 0
+}
+
+function isNullableNonNegativeInteger(value: unknown): value is number | null {
+  return value === null || isNonNegativeInteger(value)
+}

--- a/src/lib/soccer/soccer.test.ts
+++ b/src/lib/soccer/soccer.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest'
+import type { GameEvent } from '../gameEvents/types'
+import { addGameEvents, initializeGameEventStream } from '../gameEvents/mutations'
+import { gameEventProjectors, gameEventRegistry } from '../gameEvents/runtime'
+import { createInitialState, gameReducer } from '../gameReducer'
+import type { GameState, SportConfig } from '../../types'
+import { buildGameSyncFingerprint, isAggregateCloudSyncEligible } from '../gameSyncFingerprint'
+import { createSoccerEvent, soccerEventDefinitions } from './events'
+import { DEFAULT_SOCCER_MATCH_RULES, resolveSoccerMatchRules, validateSoccerMatchRules } from './rules'
+import { createSoccerSportGameState, elapsedSoccerClockMs } from './state'
+import type {
+  SoccerEventPayloadByType,
+  SoccerMatchParticipant,
+  SoccerMatchSetup,
+} from './index'
+
+const soccer: SportConfig = {
+  id: 'soccer',
+  name: 'Soccer',
+  icon: 'S',
+  theme: { bg: '', bgLight: '', text: '', border: '', gradient: '' },
+  categories: [],
+  scoreLabel: 'G',
+}
+
+const participants: SoccerMatchParticipant[] = [
+  participant('match-p1', 'p1', 'Keeper', '1', 'starter', 'goalkeeper'),
+  participant('match-p2', 'p2', 'Defender', '2', 'starter', 'defender'),
+  participant('match-p3', 'p3', 'Midfielder', '3', 'bench', 'midfielder'),
+]
+
+function participant(
+  id: string,
+  playerId: string | null,
+  displayName: string,
+  number: string | null,
+  initialStatus: 'starter' | 'bench',
+  role: 'goalkeeper' | 'defender' | 'midfielder' | 'forward'
+): SoccerMatchParticipant {
+  return {
+    id,
+    kind: playerId ? 'player' : 'anonymous',
+    playerId,
+    displayName,
+    number,
+    initialStatus,
+    initialRole: { group: role, label: null },
+  }
+}
+
+function setup(): SoccerMatchSetup {
+  return {
+    version: 1,
+    trackedTeamDesignation: 'home',
+    firstPeriodAttackingDirection: 'left_to_right',
+    sourceTeamId: 'team-1',
+    sourceSeasonId: 'season-1',
+    rulesSnapshot: resolveSoccerMatchRules({
+      gameOverrides: { maxOnFieldPlayers: 2 },
+    }),
+    participants: structuredClone(participants),
+  }
+}
+
+function state(): GameState {
+  return {
+    ...createInitialState(),
+    sport: soccer,
+    gameInfo: {
+      teamName: 'Aces',
+      opponentName: 'Bears',
+      tournamentName: '',
+      tournamentId: null,
+      date: '2026-07-18',
+    },
+    players: [
+      { id: 'p1', name: 'Keeper', number: '1', stats: {} },
+      { id: 'p2', name: 'Defender', number: '2', stats: {} },
+      { id: 'p3', name: 'Midfielder', number: '3', stats: {} },
+      { id: 'p4', name: 'Late Player', number: '4', stats: {} },
+    ],
+    sportGameState: createSoccerSportGameState(setup()),
+  }
+}
+
+function matchEvent<TType extends keyof SoccerEventPayloadByType>(
+  sequence: number,
+  eventType: TType,
+  payload: SoccerEventPayloadByType[TType],
+  elapsedMs: number | null,
+  periodId = 'regulation-1'
+): Extract<GameEvent, { eventType: TType }> {
+  return createSoccerEvent({
+    id: `10000000-0000-4000-8000-${String(sequence + 1).padStart(12, '0')}`,
+    eventType,
+    payload,
+    recorderUserId: 'user-1',
+    sequence,
+    period: { id: periodId, order: periodId === 'regulation-1' ? 1 : 2 },
+    elapsedMs,
+    occurredAt: new Date(Date.parse('2026-07-18T12:00:00.000Z') + sequence * 1_000).toISOString(),
+  }) as Extract<GameEvent, { eventType: TType }>
+}
+
+function initializedState(): GameState {
+  const initialized = initializeGameEventStream(state(), gameEventRegistry, gameEventProjectors)
+  if (!initialized.ok) throw new Error(initialized.error.message)
+  return initialized.state
+}
+
+function kickoffEvents(): GameEvent[] {
+  return [
+    matchEvent(0, 'soccer.opening_lineup', {
+      starters: [
+        { participantId: 'match-p1', role: { group: 'goalkeeper', label: null } },
+        { participantId: 'match-p2', role: { group: 'defender', label: null } },
+      ],
+    }, 0),
+    matchEvent(1, 'soccer.period_started', { periodId: 'regulation-1' }, 0),
+    matchEvent(2, 'soccer.clock_started', { anchorElapsedMs: 0 }, 0),
+  ]
+}
+
+describe('soccer rules and production schemas', () => {
+  it('resolves editable game overrides without mutating app defaults', () => {
+    const rules = resolveSoccerMatchRules({
+      gameOverrides: {
+        maxOnFieldPlayers: 7,
+        clockDirection: 'count_down',
+        regulationSegments: [
+          { id: 'regulation-1', label: 'Quarter 1', kind: 'regulation', order: 1, durationMs: 12 * 60_000 },
+          { id: 'regulation-2', label: 'Quarter 2', kind: 'regulation', order: 2, durationMs: 12 * 60_000 },
+          { id: 'regulation-3', label: 'Quarter 3', kind: 'regulation', order: 3, durationMs: 12 * 60_000 },
+          { id: 'regulation-4', label: 'Quarter 4', kind: 'regulation', order: 4, durationMs: 12 * 60_000 },
+        ],
+        extraTimeSegments: [],
+      },
+    })
+
+    expect(rules.maxOnFieldPlayers).toBe(7)
+    expect(rules.clockDirection).toBe('count_down')
+    expect(rules.regulationSegments).toHaveLength(4)
+    expect(DEFAULT_SOCCER_MATCH_RULES.maxOnFieldPlayers).toBe(11)
+    expect(validateSoccerMatchRules({ ...rules, maxOnFieldPlayers: 0 })).toMatch(/positive/)
+  })
+
+  it('registers all SOC-2 match-state schemas and rejects malformed payloads', () => {
+    expect(soccerEventDefinitions).toHaveLength(14)
+    const malformed = matchEvent(
+      0,
+      'soccer.opening_lineup',
+      { starters: [] },
+      0
+    )
+    expect(gameEventRegistry.inspect(malformed)).toMatchObject({
+      ok: false,
+      diagnostic: { code: 'validation_failed' },
+    })
+  })
+})
+
+describe('soccer match projection', () => {
+  it('projects a complete clock, substitution, correction, and lifecycle history', () => {
+    const rulesWithReturns = resolveSoccerMatchRules({
+      gameOverrides: { maxOnFieldPlayers: 2, allowReturnSubstitutions: true },
+    })
+    const lateAnonymous = participant(
+      'match-late',
+      null,
+      'Late arrival',
+      null,
+      'bench',
+      'forward'
+    )
+    const events: GameEvent[] = [
+      ...kickoffEvents(),
+      matchEvent(3, 'soccer.clock_paused', { elapsedMs: 60_000 }, 60_000),
+      matchEvent(4, 'soccer.substitution_window', {
+        changes: [{
+          playerOutParticipantId: 'match-p2',
+          playerInParticipantId: 'match-p3',
+          playerInRole: { group: 'midfielder', label: null },
+        }],
+        halftime: false,
+      }, 60_000),
+      matchEvent(5, 'soccer.clock_started', { anchorElapsedMs: 60_000 }, 60_000),
+      matchEvent(6, 'soccer.role_changed', {
+        changes: [{ participantId: 'match-p3', role: { group: 'defender', label: null } }],
+      }, 75_000),
+      matchEvent(7, 'soccer.attacking_direction_changed', { direction: 'right_to_left' }, 75_000),
+      matchEvent(8, 'soccer.clock_adjusted', { fromElapsedMs: 75_000, toElapsedMs: 74_000 }, 74_000),
+      matchEvent(9, 'soccer.clock_paused', { elapsedMs: 90_000 }, 90_000),
+      matchEvent(10, 'soccer.match_roster_added', {
+        participant: lateAnonymous,
+        destination: 'bench',
+      }, 90_000),
+      matchEvent(11, 'soccer.participant_resolved', {
+        participantId: 'match-late',
+        playerId: 'p4',
+        displayName: 'Late Player',
+        number: '4',
+      }, 90_000),
+      matchEvent(12, 'soccer.match_rules_changed', { rules: rulesWithReturns }, 90_000),
+      matchEvent(13, 'soccer.period_ended', { periodId: 'regulation-1' }, 90_000),
+      matchEvent(14, 'soccer.period_started', { periodId: 'regulation-2' }, 90_000, 'regulation-2'),
+      matchEvent(15, 'soccer.clock_started', { anchorElapsedMs: 90_000 }, 90_000, 'regulation-2'),
+      matchEvent(16, 'soccer.clock_paused', { elapsedMs: 120_000 }, 120_000, 'regulation-2'),
+      matchEvent(17, 'soccer.period_ended', { periodId: 'regulation-2' }, 120_000, 'regulation-2'),
+      matchEvent(18, 'soccer.match_ended', { reason: 'completed' }, 120_000, 'regulation-2'),
+      matchEvent(19, 'soccer.match_reopened', { reason: 'Correction review' }, 120_000, 'regulation-2'),
+    ]
+
+    const result = addGameEvents(initializedState(), events, gameEventRegistry, gameEventProjectors)
+    if (!result.ok) throw new Error(result.error.message)
+
+    expect(result.inspection.complete).toBe(true)
+    expect(result.state.eventStream?.events).toHaveLength(events.length)
+    const projection = result.state.sportGameState?.projection
+    expect(projection?.status).toBe('period_break')
+    expect(projection?.completedPeriodIds).toEqual(['regulation-1', 'regulation-2'])
+    expect(projection?.attackingDirection).toBe('right_to_left')
+    expect(projection?.substitutionCount).toBe(1)
+    expect(projection?.substitutionWindowCount).toBe(1)
+    expect(projection?.participants['match-late'].playerId).toBe('p4')
+    expect(result.state.players.find(player => player.id === 'p1')?.stats).toMatchObject({
+      soc_start: 1,
+      soc_app: 1,
+      soc_min_sec: 120,
+    })
+    expect(result.state.players.find(player => player.id === 'p2')?.stats.soc_min_sec).toBe(60)
+    expect(result.state.players.find(player => player.id === 'p3')?.stats).toMatchObject({
+      soc_start: 0,
+      soc_app: 1,
+      soc_min_sec: 60,
+    })
+  })
+
+  it('preserves invalid and later events while projecting only through the last valid point', () => {
+    const events: GameEvent[] = [
+      ...kickoffEvents(),
+      matchEvent(3, 'soccer.clock_paused', { elapsedMs: 60_000 }, 60_000),
+      matchEvent(4, 'soccer.substitution_window', {
+        changes: [{
+          playerOutParticipantId: 'match-p1',
+          playerInParticipantId: 'match-p3',
+          playerInRole: { group: 'midfielder', label: null },
+        }],
+        halftime: false,
+      }, 60_000),
+      matchEvent(5, 'soccer.period_ended', { periodId: 'regulation-1' }, 60_000),
+    ]
+
+    const result = addGameEvents(initializedState(), events, gameEventRegistry, gameEventProjectors)
+    if (!result.ok) throw new Error(result.error.message)
+
+    expect(result.state.eventStream?.events).toHaveLength(events.length)
+    expect(result.inspection.complete).toBe(false)
+    expect(result.inspection.diagnostics.map(item => item.code)).toEqual([
+      'semantic_validation_failed',
+      'unprojected_event',
+    ])
+    const projection = result.state.sportGameState?.projection
+    expect(projection?.clock.running).toBe(false)
+    expect(projection?.currentPeriodId).toBe('regulation-1')
+    expect(projection?.participants['match-p1'].status).toBe('on_field')
+    expect(projection?.participants['match-p3'].status).toBe('bench')
+  })
+
+  it('rejects an invalid event batch atomically', () => {
+    const duplicate = kickoffEvents()
+    duplicate[1] = { ...duplicate[1], id: duplicate[0].id }
+    const before = initializedState()
+    const result = addGameEvents(before, duplicate, gameEventRegistry, gameEventProjectors)
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'duplicate_event_id' } })
+    expect(result.state.eventStream?.events).toEqual([])
+  })
+
+  it('derives a running clock from its persisted anchor without mutating state', () => {
+    const result = addGameEvents(
+      initializedState(),
+      kickoffEvents(),
+      gameEventRegistry,
+      gameEventProjectors
+    )
+    if (!result.ok) throw new Error(result.error.message)
+    const projection = result.state.sportGameState?.projection
+    if (!projection?.clock.anchorOccurredAt) throw new Error('clock did not start')
+
+    expect(elapsedSoccerClockMs(projection, Date.parse(projection.clock.anchorOccurredAt) + 12_345)).toBe(12_345)
+    expect(projection.clock.elapsedMs).toBe(0)
+  })
+
+  it('keeps event-backed matches out of legacy aggregate cloud sync', () => {
+    expect(isAggregateCloudSyncEligible(state())).toBe(true)
+    expect(isAggregateCloudSyncEligible(initializedState())).toBe(false)
+  })
+
+  it('blocks legacy aggregate mutations and setup replacement after event capture begins', () => {
+    const result = addGameEvents(
+      initializedState(),
+      kickoffEvents(),
+      gameEventRegistry,
+      gameEventProjectors
+    )
+    if (!result.ok) throw new Error(result.error.message)
+
+    expect(gameReducer(result.state, {
+      type: 'INCREMENT_STAT',
+      playerId: 'p1',
+      statId: 'goal',
+    })).toBe(result.state)
+    expect(gameReducer(result.state, {
+      type: 'SET_SPORT_GAME_STATE',
+      sportGameState: createSoccerSportGameState(setup()),
+    })).toBe(result.state)
+  })
+
+  it('fingerprints authoritative setup but excludes the rebuildable soccer projection', () => {
+    const baseline = state()
+    const changedProjection = structuredClone(baseline)
+    if (!changedProjection.sportGameState) throw new Error('missing soccer state')
+    changedProjection.sportGameState.projection.status = 'ended'
+    changedProjection.sportGameState.projection.clock.elapsedMs = 999_000
+
+    expect(buildGameSyncFingerprint(changedProjection)).toBe(buildGameSyncFingerprint(baseline))
+    changedProjection.sportGameState.setup.trackedTeamDesignation = 'away'
+    expect(buildGameSyncFingerprint(changedProjection)).not.toBe(buildGameSyncFingerprint(baseline))
+  })
+})

--- a/src/lib/soccer/soccer.test.ts
+++ b/src/lib/soccer/soccer.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { GameEvent } from '../gameEvents/types'
-import { addGameEvents, initializeGameEventStream } from '../gameEvents/mutations'
+import {
+  addGameEvent,
+  addGameEvents,
+  initializeGameEventStream,
+  updateGameEvent,
+} from '../gameEvents/mutations'
 import { gameEventProjectors, gameEventRegistry } from '../gameEvents/runtime'
 import { createInitialState, gameReducer } from '../gameReducer'
 import type { GameState, SportConfig } from '../../types'
@@ -235,7 +240,7 @@ describe('soccer match projection', () => {
     })
   })
 
-  it('preserves invalid and later events while projecting only through the last valid point', () => {
+  it('rolls back a semantically invalid event batch', () => {
     const events: GameEvent[] = [
       ...kickoffEvents(),
       matchEvent(3, 'soccer.clock_paused', { elapsedMs: 60_000 }, 60_000),
@@ -250,16 +255,57 @@ describe('soccer match projection', () => {
       matchEvent(5, 'soccer.period_ended', { periodId: 'regulation-1' }, 60_000),
     ]
 
-    const result = addGameEvents(initializedState(), events, gameEventRegistry, gameEventProjectors)
-    if (!result.ok) throw new Error(result.error.message)
+    const before = initializedState()
+    const result = addGameEvents(before, events, gameEventRegistry, gameEventProjectors)
 
-    expect(result.state.eventStream?.events).toHaveLength(events.length)
-    expect(result.inspection.complete).toBe(false)
-    expect(result.inspection.diagnostics.map(item => item.code)).toEqual([
+    expect(result).toMatchObject({ ok: false, error: { code: 'incomplete_projection' } })
+    expect(result.state).toBe(before)
+    expect(result.state.eventStream?.events).toEqual([])
+  })
+
+  it('preserves incomplete history after an existing event is edited', () => {
+    const events: GameEvent[] = [
+      ...kickoffEvents(),
+      matchEvent(3, 'soccer.clock_paused', { elapsedMs: 60_000 }, 60_000),
+      matchEvent(4, 'soccer.substitution_window', {
+        changes: [{
+          playerOutParticipantId: 'match-p2',
+          playerInParticipantId: 'match-p3',
+          playerInRole: { group: 'midfielder', label: null },
+        }],
+        halftime: false,
+      }, 60_000),
+      matchEvent(5, 'soccer.period_ended', { periodId: 'regulation-1' }, 60_000),
+    ]
+    const valid = addGameEvents(initializedState(), events, gameEventRegistry, gameEventProjectors)
+    if (!valid.ok) throw new Error(valid.error.message)
+
+    const edited = updateGameEvent(
+      valid.state,
+      events[4].id,
+      {
+        payload: {
+          changes: [{
+            playerOutParticipantId: 'match-p1',
+            playerInParticipantId: 'match-p3',
+            playerInRole: { group: 'midfielder', label: null },
+          }],
+          halftime: false,
+        },
+      },
+      '2026-07-18T12:10:00.000Z',
+      gameEventRegistry,
+      gameEventProjectors
+    )
+    if (!edited.ok) throw new Error(edited.error.message)
+
+    expect(edited.state.eventStream?.events).toHaveLength(events.length)
+    expect(edited.inspection.complete).toBe(false)
+    expect(edited.inspection.diagnostics.map(item => item.code)).toEqual([
       'semantic_validation_failed',
       'unprojected_event',
     ])
-    const projection = result.state.sportGameState?.projection
+    const projection = edited.state.sportGameState?.projection
     expect(projection?.clock.running).toBe(false)
     expect(projection?.currentPeriodId).toBe('regulation-1')
     expect(projection?.participants['match-p1'].status).toBe('on_field')
@@ -274,6 +320,27 @@ describe('soccer match projection', () => {
 
     expect(result).toMatchObject({ ok: false, error: { code: 'duplicate_event_id' } })
     expect(result.state.eventStream?.events).toEqual([])
+  })
+
+  it('rolls back a semantically invalid single append', () => {
+    const before = initializedState()
+    const result = addGameEvent(
+      before,
+      matchEvent(0, 'soccer.period_started', { periodId: 'regulation-1' }, 0),
+      gameEventRegistry,
+      gameEventProjectors
+    )
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'incomplete_projection' } })
+    expect(result.state).toBe(before)
+  })
+
+  it('requires resolved soccer setup before initializing the authoritative stream', () => {
+    const withoutSetup = { ...state(), sportGameState: null }
+    const result = initializeGameEventStream(withoutSetup, gameEventRegistry, gameEventProjectors)
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'sport_setup_required' } })
+    expect(result.state.eventStream).toBeNull()
   })
 
   it('derives a running clock from its persisted anchor without mutating state', () => {
@@ -291,8 +358,9 @@ describe('soccer match projection', () => {
     expect(projection.clock.elapsedMs).toBe(0)
   })
 
-  it('keeps event-backed matches out of legacy aggregate cloud sync', () => {
-    expect(isAggregateCloudSyncEligible(state())).toBe(true)
+  it('keeps setup-only and event-backed matches out of legacy aggregate cloud sync', () => {
+    expect(isAggregateCloudSyncEligible({ ...state(), sportGameState: null })).toBe(true)
+    expect(isAggregateCloudSyncEligible(state())).toBe(false)
     expect(isAggregateCloudSyncEligible(initializedState())).toBe(false)
   })
 

--- a/src/lib/soccer/state.ts
+++ b/src/lib/soccer/state.ts
@@ -1,0 +1,150 @@
+import { isPlainObject } from '../gameEvents/envelope'
+import { validateSoccerMatchRules, validateSoccerRole } from './rules'
+import type {
+  SoccerAttackingDirection,
+  SoccerMatchParticipant,
+  SoccerMatchProjection,
+  SoccerMatchSetup,
+  SoccerProjectedParticipant,
+  SoccerSportGameState,
+  SportGameState,
+} from './types'
+
+export function createSoccerMatchProjection(setup: SoccerMatchSetup): SoccerMatchProjection {
+  return {
+    status: 'not_started',
+    openingLineupRecorded: false,
+    currentPeriodId: null,
+    completedPeriodIds: [],
+    clock: { running: false, elapsedMs: 0, anchorOccurredAt: null },
+    participants: Object.fromEntries(
+      setup.participants.map(participant => [participant.id, projectedParticipant(participant)])
+    ),
+    currentRules: structuredClone(setup.rulesSnapshot),
+    firstPeriodAttackingDirection: setup.firstPeriodAttackingDirection,
+    attackingDirection: setup.firstPeriodAttackingDirection,
+    substitutionCount: 0,
+    substitutionWindowCount: 0,
+    endedAt: null,
+  }
+}
+
+export function createSoccerSportGameState(setup: SoccerMatchSetup): SoccerSportGameState {
+  const error = validateSoccerMatchSetup(setup)
+  if (error) throw new Error(error)
+  const clonedSetup = structuredClone(setup)
+  return {
+    sportId: 'soccer',
+    version: 1,
+    setup: clonedSetup,
+    projection: createSoccerMatchProjection(clonedSetup),
+  }
+}
+
+export function normalizeSportGameState(value: unknown): SportGameState | null {
+  if (!isPlainObject(value) || value.sportId !== 'soccer' || value.version !== 1) return null
+  if (!isPlainObject(value.setup)) return null
+  const setup = value.setup as unknown as SoccerMatchSetup
+  if (validateSoccerMatchSetup(setup)) return null
+  return createSoccerSportGameState(setup)
+}
+
+export function sportGameStateForFingerprint(value: SportGameState | null): unknown {
+  if (!value) return null
+  return {
+    sportId: value.sportId,
+    version: value.version,
+    setup: value.setup,
+  }
+}
+
+export function validateSoccerMatchSetup(value: unknown): string | null {
+  if (!isPlainObject(value) || value.version !== 1) return 'Soccer setup version is invalid.'
+  if (!['home', 'away', 'neutral'].includes(String(value.trackedTeamDesignation))) {
+    return 'Tracked-team designation is invalid.'
+  }
+  if (!isDirection(value.firstPeriodAttackingDirection)) return 'First-period direction is invalid.'
+  if (value.sourceTeamId !== null && typeof value.sourceTeamId !== 'string') {
+    return 'Source team id is invalid.'
+  }
+  if (value.sourceSeasonId !== null && typeof value.sourceSeasonId !== 'string') {
+    return 'Source season id is invalid.'
+  }
+  const rulesError = validateSoccerMatchRules(value.rulesSnapshot)
+  if (rulesError) return rulesError
+  if (!Array.isArray(value.participants) || !value.participants.every(validateParticipant)) {
+    return 'Every soccer match participant must be valid.'
+  }
+  const ids = value.participants.map(participant => participant.id)
+  if (new Set(ids).size !== ids.length) return 'Soccer participant ids must be unique.'
+  const playerIds = value.participants
+    .map(participant => participant.playerId)
+    .filter((playerId): playerId is string => playerId !== null)
+  if (new Set(playerIds).size !== playerIds.length) {
+    return 'A roster player cannot appear more than once in the match roster.'
+  }
+  return null
+}
+
+export function isSoccerMatchParticipant(value: unknown): value is SoccerMatchParticipant {
+  return validateParticipant(value)
+}
+
+export function elapsedSoccerClockMs(
+  projection: SoccerMatchProjection,
+  nowMs = Date.now()
+): number {
+  if (!projection.clock.running || !projection.clock.anchorOccurredAt) {
+    return projection.clock.elapsedMs
+  }
+  const anchorMs = Date.parse(projection.clock.anchorOccurredAt)
+  if (!Number.isFinite(anchorMs)) return projection.clock.elapsedMs
+  return projection.clock.elapsedMs + Math.max(0, nowMs - anchorMs)
+}
+
+export function participantActiveMs(
+  participant: SoccerProjectedParticipant,
+  projection: SoccerMatchProjection,
+  nowMs = Date.now()
+): number {
+  if (participant.activeSinceElapsedMs === null) return participant.totalActiveMs
+  return participant.totalActiveMs + Math.max(
+    0,
+    elapsedSoccerClockMs(projection, nowMs) - participant.activeSinceElapsedMs
+  )
+}
+
+function projectedParticipant(participant: SoccerMatchParticipant): SoccerProjectedParticipant {
+  return {
+    participantId: participant.id,
+    playerId: participant.playerId,
+    displayName: participant.displayName,
+    number: participant.number,
+    status: 'bench',
+    role: structuredClone(participant.initialRole),
+    started: false,
+    appearances: 0,
+    totalActiveMs: 0,
+    activeSinceElapsedMs: null,
+    hasExited: false,
+  }
+}
+
+function validateParticipant(value: unknown): value is SoccerMatchParticipant {
+  if (!isPlainObject(value)) return false
+  if (typeof value.id !== 'string' || value.id.trim().length === 0) return false
+  if (value.kind !== 'player' && value.kind !== 'anonymous') return false
+  if (value.playerId !== null && (typeof value.playerId !== 'string' || value.playerId.trim().length === 0)) {
+    return false
+  }
+  if (value.kind === 'player' && value.playerId === null) return false
+  if (value.kind === 'anonymous' && value.playerId !== null) return false
+  if (typeof value.displayName !== 'string' || value.displayName.trim().length === 0) return false
+  if (value.number !== null && typeof value.number !== 'string') return false
+  if (value.initialStatus !== 'starter' && value.initialStatus !== 'bench') return false
+  return validateSoccerRole(value.initialRole)
+}
+
+function isDirection(value: unknown): value is SoccerAttackingDirection {
+  return value === 'left_to_right' || value === 'right_to_left'
+}

--- a/src/lib/soccer/types.ts
+++ b/src/lib/soccer/types.ts
@@ -1,0 +1,212 @@
+import type { GameEvent, JsonObject } from '../gameEvents/types'
+
+export const SOCCER_GAME_STATE_VERSION = 1
+export const SOCCER_EVENT_SCHEMA_VERSION = 1
+
+export type SoccerTrackedTeamDesignation = 'home' | 'away' | 'neutral'
+export type SoccerAttackingDirection = 'left_to_right' | 'right_to_left'
+export type SoccerClockDirection = 'count_up' | 'count_down'
+export type SoccerClockDisplay = 'continuous' | 'per_period'
+export type SoccerParticipantKind = 'player' | 'anonymous'
+export type SoccerRosterStatus = 'starter' | 'bench'
+export type SoccerRoleGroup = 'goalkeeper' | 'defender' | 'midfielder' | 'forward' | 'custom'
+export type SoccerSegmentKind = 'regulation' | 'extra_time'
+
+export interface SoccerRole extends JsonObject {
+  group: SoccerRoleGroup
+  label: string | null
+}
+
+export interface SoccerMatchSegment extends JsonObject {
+  id: string
+  label: string
+  kind: SoccerSegmentKind
+  order: number
+  durationMs: number
+}
+
+export interface SoccerMatchRules extends JsonObject {
+  regulationSegments: SoccerMatchSegment[]
+  extraTimeSegments: SoccerMatchSegment[]
+  extraTimeAvailable: boolean
+  shootoutAvailable: boolean
+  clockDirection: SoccerClockDirection
+  clockDisplay: SoccerClockDisplay
+  maxOnFieldPlayers: number
+  allowReturnSubstitutions: boolean
+  substitutionLimit: number | null
+  substitutionWindowLimit: number | null
+  maxAssistsPerGoal: number
+}
+
+export interface SoccerMatchParticipant extends JsonObject {
+  id: string
+  kind: SoccerParticipantKind
+  playerId: string | null
+  displayName: string
+  number: string | null
+  initialStatus: SoccerRosterStatus
+  initialRole: SoccerRole
+}
+
+export interface SoccerMatchSetup {
+  version: 1
+  trackedTeamDesignation: SoccerTrackedTeamDesignation
+  firstPeriodAttackingDirection: SoccerAttackingDirection
+  sourceTeamId: string | null
+  sourceSeasonId: string | null
+  rulesSnapshot: SoccerMatchRules
+  participants: SoccerMatchParticipant[]
+}
+
+export type SoccerMatchStatus = 'not_started' | 'in_progress' | 'period_break' | 'ended'
+export type SoccerParticipantStatus = 'bench' | 'on_field' | 'left'
+
+export interface SoccerProjectedParticipant {
+  participantId: string
+  playerId: string | null
+  displayName: string
+  number: string | null
+  status: SoccerParticipantStatus
+  role: SoccerRole
+  started: boolean
+  appearances: number
+  totalActiveMs: number
+  activeSinceElapsedMs: number | null
+  hasExited: boolean
+}
+
+export interface SoccerProjectedClock {
+  running: boolean
+  elapsedMs: number
+  anchorOccurredAt: string | null
+}
+
+export interface SoccerMatchProjection {
+  status: SoccerMatchStatus
+  openingLineupRecorded: boolean
+  currentPeriodId: string | null
+  completedPeriodIds: string[]
+  clock: SoccerProjectedClock
+  participants: Record<string, SoccerProjectedParticipant>
+  currentRules: SoccerMatchRules
+  firstPeriodAttackingDirection: SoccerAttackingDirection
+  attackingDirection: SoccerAttackingDirection
+  substitutionCount: number
+  substitutionWindowCount: number
+  endedAt: string | null
+}
+
+export interface SoccerSportGameState {
+  sportId: 'soccer'
+  version: 1
+  setup: SoccerMatchSetup
+  projection: SoccerMatchProjection
+}
+
+export type SportGameState = SoccerSportGameState
+
+export interface SoccerLineupEntry extends JsonObject {
+  participantId: string
+  role: SoccerRole
+}
+
+export interface SoccerOpeningLineupPayload extends JsonObject {
+  starters: SoccerLineupEntry[]
+}
+
+export interface SoccerPeriodPayload extends JsonObject {
+  periodId: string
+}
+
+export interface SoccerClockStartedPayload extends JsonObject {
+  anchorElapsedMs: number
+}
+
+export interface SoccerClockPausedPayload extends JsonObject {
+  elapsedMs: number
+}
+
+export interface SoccerClockAdjustedPayload extends JsonObject {
+  fromElapsedMs: number
+  toElapsedMs: number
+}
+
+export interface SoccerMatchRulesChangedPayload extends JsonObject {
+  rules: SoccerMatchRules
+}
+
+export interface SoccerSubstitutionChange extends JsonObject {
+  playerOutParticipantId: string | null
+  playerInParticipantId: string | null
+  playerInRole: SoccerRole | null
+}
+
+export interface SoccerSubstitutionWindowPayload extends JsonObject {
+  changes: SoccerSubstitutionChange[]
+  halftime: boolean
+}
+
+export interface SoccerRoleChange extends JsonObject {
+  participantId: string
+  role: SoccerRole
+}
+
+export interface SoccerRoleChangedPayload extends JsonObject {
+  changes: SoccerRoleChange[]
+}
+
+export interface SoccerAttackingDirectionChangedPayload extends JsonObject {
+  direction: SoccerAttackingDirection
+}
+
+export interface SoccerMatchRosterAddedPayload extends JsonObject {
+  participant: SoccerMatchParticipant
+  destination: 'bench' | 'on_field'
+}
+
+export interface SoccerParticipantResolvedPayload extends JsonObject {
+  participantId: string
+  playerId: string
+  displayName: string
+  number: string | null
+}
+
+export interface SoccerMatchEndedPayload extends JsonObject {
+  reason: 'completed' | 'suspended' | 'abandoned'
+}
+
+export interface SoccerMatchReopenedPayload extends JsonObject {
+  reason: string | null
+}
+
+export type SoccerOpeningLineupEvent = GameEvent<SoccerOpeningLineupPayload, 'soccer.opening_lineup', 'soccer'>
+export type SoccerPeriodStartedEvent = GameEvent<SoccerPeriodPayload, 'soccer.period_started', 'soccer'>
+export type SoccerPeriodEndedEvent = GameEvent<SoccerPeriodPayload, 'soccer.period_ended', 'soccer'>
+export type SoccerClockStartedEvent = GameEvent<SoccerClockStartedPayload, 'soccer.clock_started', 'soccer'>
+export type SoccerClockPausedEvent = GameEvent<SoccerClockPausedPayload, 'soccer.clock_paused', 'soccer'>
+export type SoccerClockAdjustedEvent = GameEvent<SoccerClockAdjustedPayload, 'soccer.clock_adjusted', 'soccer'>
+export type SoccerMatchRulesChangedEvent = GameEvent<SoccerMatchRulesChangedPayload, 'soccer.match_rules_changed', 'soccer'>
+export type SoccerSubstitutionWindowEvent = GameEvent<SoccerSubstitutionWindowPayload, 'soccer.substitution_window', 'soccer'>
+export type SoccerRoleChangedEvent = GameEvent<SoccerRoleChangedPayload, 'soccer.role_changed', 'soccer'>
+export type SoccerAttackingDirectionChangedEvent = GameEvent<SoccerAttackingDirectionChangedPayload, 'soccer.attacking_direction_changed', 'soccer'>
+export type SoccerMatchRosterAddedEvent = GameEvent<SoccerMatchRosterAddedPayload, 'soccer.match_roster_added', 'soccer'>
+export type SoccerParticipantResolvedEvent = GameEvent<SoccerParticipantResolvedPayload, 'soccer.participant_resolved', 'soccer'>
+export type SoccerMatchEndedEvent = GameEvent<SoccerMatchEndedPayload, 'soccer.match_ended', 'soccer'>
+export type SoccerMatchReopenedEvent = GameEvent<SoccerMatchReopenedPayload, 'soccer.match_reopened', 'soccer'>
+
+export type SoccerMatchEvent =
+  | SoccerOpeningLineupEvent
+  | SoccerPeriodStartedEvent
+  | SoccerPeriodEndedEvent
+  | SoccerClockStartedEvent
+  | SoccerClockPausedEvent
+  | SoccerClockAdjustedEvent
+  | SoccerMatchRulesChangedEvent
+  | SoccerSubstitutionWindowEvent
+  | SoccerRoleChangedEvent
+  | SoccerAttackingDirectionChangedEvent
+  | SoccerMatchRosterAddedEvent
+  | SoccerParticipantResolvedEvent
+  | SoccerMatchEndedEvent
+  | SoccerMatchReopenedEvent

--- a/src/pages/CareerStats.tsx
+++ b/src/pages/CareerStats.tsx
@@ -292,7 +292,8 @@ export default function CareerStats() {
         teamStatsConfig: cloudGame.teamStatsConfig ?? null,
         actionLog: [],
         shotChart: cloudGame.shotChart ?? [],
-        eventStream: null,
+            eventStream: null,
+            sportGameState: null,
         cloudSync: {
           seasonId: cloudGame.seasonId ?? null,
           teamId: cloudGame.teamId,

--- a/src/pages/CareerStats.tsx
+++ b/src/pages/CareerStats.tsx
@@ -292,8 +292,8 @@ export default function CareerStats() {
         teamStatsConfig: cloudGame.teamStatsConfig ?? null,
         actionLog: [],
         shotChart: cloudGame.shotChart ?? [],
-            eventStream: null,
-            sportGameState: null,
+        eventStream: null,
+        sportGameState: null,
         cloudSync: {
           seasonId: cloudGame.seasonId ?? null,
           teamId: cloudGame.teamId,

--- a/src/pages/GameInfo.tsx
+++ b/src/pages/GameInfo.tsx
@@ -332,7 +332,8 @@ export default function GameInfo() {
       teamStatsConfig: cloudGame.teamStatsConfig ?? null,
       actionLog: [],
       shotChart: cloudGame.shotChart ?? [],
-      eventStream: null,
+          eventStream: null,
+          sportGameState: null,
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,
         teamId: cloudGame.teamId,

--- a/src/pages/GameInfo.tsx
+++ b/src/pages/GameInfo.tsx
@@ -332,8 +332,8 @@ export default function GameInfo() {
       teamStatsConfig: cloudGame.teamStatsConfig ?? null,
       actionLog: [],
       shotChart: cloudGame.shotChart ?? [],
-          eventStream: null,
-          sportGameState: null,
+      eventStream: null,
+      sportGameState: null,
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,
         teamId: cloudGame.teamId,

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -347,7 +347,8 @@ export default function Games() {
       teamStatsConfig: cloudGame.teamStatsConfig ?? null,
       actionLog: [],
       shotChart: cloudGame.shotChart ?? [],
-      eventStream: null,
+          eventStream: null,
+          sportGameState: null,
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,
         teamId: cloudGame.teamId,

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -347,8 +347,8 @@ export default function Games() {
       teamStatsConfig: cloudGame.teamStatsConfig ?? null,
       actionLog: [],
       shotChart: cloudGame.shotChart ?? [],
-          eventStream: null,
-          sportGameState: null,
+      eventStream: null,
+      sportGameState: null,
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,
         teamId: cloudGame.teamId,

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -292,7 +292,8 @@ export default function PlayerProfile() {
       teamStatsConfig: cloudGame.teamStatsConfig ?? null,
       actionLog: [],
       shotChart: cloudGame.shotChart ?? [],
-      eventStream: null,
+          eventStream: null,
+          sportGameState: null,
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,
         teamId: cloudGame.teamId,

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -292,8 +292,8 @@ export default function PlayerProfile() {
       teamStatsConfig: cloudGame.teamStatsConfig ?? null,
       actionLog: [],
       shotChart: cloudGame.shotChart ?? [],
-          eventStream: null,
-          sportGameState: null,
+      eventStream: null,
+      sportGameState: null,
       cloudSync: {
         seasonId: cloudGame.seasonId ?? null,
         teamId: cloudGame.teamId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type {
   GameEventEditableFields,
   GameEventStream,
 } from './lib/gameEvents/types'
+import type { SportGameState } from './lib/soccer/types'
 
 export type ShotZone = 'restricted' | 'paint' | 'mid_range' | 'three'
 
@@ -166,6 +167,8 @@ export interface GameState {
   shotChart: ShotRecord[]
   /** Null for legacy aggregate-only games; present when events are authoritative. */
   eventStream: GameEventStream | null
+  /** Sport-owned immutable setup plus rebuildable runtime projection. */
+  sportGameState: SportGameState | null
 }
 
 export type CloudSyncStatus =
@@ -225,6 +228,8 @@ export type GameAction =
   | { type: 'SET_TEAM_STATS_CONFIG'; config: Record<string, unknown> | null }
   | { type: 'INITIALIZE_EVENT_STREAM' }
   | { type: 'ADD_GAME_EVENT'; event: GameEvent }
+  | { type: 'ADD_GAME_EVENTS'; events: GameEvent[] }
+  | { type: 'SET_SPORT_GAME_STATE'; sportGameState: SportGameState | null }
   | {
       type: 'UPDATE_GAME_EVENT'
       eventId: string


### PR DESCRIPTION
## Summary
- record the complete SOC-2 match rules, lineup, clock, and three-PR delivery plan
- add typed soccer rules, setup, participants, roles, 14 production event schemas, and semantic projection through the last coherent event
- add atomic event batches, exact participation projection, persistence/fingerprint support, and guards against legacy aggregate mutation or sync
- keep soccer UI disabled; SOC-2B owns setup, roster, lineup, and kickoff UI

## Verification
- pnpm test (54 files, 335 tests)
- pnpm lint (0 errors; 3 existing Fast Refresh warnings)
- pnpm build

## Deployment
- No Supabase migration or manual deployment step is required.