### PR TITLE
docs: plan SOC-6 summary and release

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ docs/
 ├── PLAN_SOC_5C_INDEPENDENT_RECORDERS_AND_PRIMARY.md # SOC-5C recorder presence and primary resolution
 ├── PLAN_SOC_5D_FINALIZATION_AND_RECOVERY.md # SOC-5D canonical publication and audited reopen
 ├── PLAN_SOC_6_SUMMARY_AND_RELEASE.md # Reviewed SOC-6 summary, aggregates, settings, and release roadmap
+├── PLAN_SOC_6A_SUMMARY_FOUNDATION.md # Reviewed SOC-6A summary source and Overview implementation plan
 ├── PLAN_BASKETBALL_EVENT_MODEL_ROADMAP.md # Required post-SOC basketball event migration
 ├── PLAN_MULTI_GAME_PARKING.md # Roadmap: local parking + sync queue + cloud ordering hardening shipped
 ├── ACCESS_MATRIX.md       # Approved role/action contract and current security audit

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ docs/
 ├── PLAN_SOC_5B_OFFLINE_RECOVERY_AND_CONFLICTS.md # SOC-5B cloud resume and same-recorder conflicts
 ├── PLAN_SOC_5C_INDEPENDENT_RECORDERS_AND_PRIMARY.md # SOC-5C recorder presence and primary resolution
 ├── PLAN_SOC_5D_FINALIZATION_AND_RECOVERY.md # SOC-5D canonical publication and audited reopen
+├── PLAN_SOC_6_SUMMARY_AND_RELEASE.md # Reviewed SOC-6 summary, aggregates, settings, and release roadmap
 ├── PLAN_BASKETBALL_EVENT_MODEL_ROADMAP.md # Required post-SOC basketball event migration
 ├── PLAN_MULTI_GAME_PARKING.md # Roadmap: local parking + sync queue + cloud ordering hardening shipped
 ├── ACCESS_MATRIX.md       # Approved role/action contract and current security audit
@@ -415,7 +416,7 @@ See [`docs/INTEGRATION_PLAN.md`](docs/INTEGRATION_PLAN.md) for the full architec
 
 ### What's Next
 
-- [ ] **Soccer SOC-6** - complete summaries, field maps, settings, aggregates, regression QA, and production release ([SOC-5 plan](docs/PLAN_SOC_5_CLOUD_SYNC_AND_FINALIZATION.md), [roadmap](docs/PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md))
+- [ ] **Soccer SOC-6** - complete summaries, field maps, settings, aggregates, regression QA, and production release ([SOC-6 plan](docs/PLAN_SOC_6_SUMMARY_AND_RELEASE.md), [roadmap](docs/PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md))
 - [ ] **Basketball event-model migration (BKE-0 through BKE-4)** — required post-foundation redesign that unifies counters, action log, shot records, linked assists/rebounds, editing, and F13 on the shared event platform while preserving historical games ([roadmap](docs/PLAN_BASKETBALL_EVENT_MODEL_ROADMAP.md))
 - [ ] **Audit event-family follow-ups** — expand the SEC-6 trail to guardian changes, stat corrections, primary-recorder reassignment, and game lifecycle/finalization events ([plan](docs/PLAN_SEC_6_AUDIT_TRAIL.md))
 - [ ] **Multi-game storage/ops follow-ups** — optional historical orphan cleanup tooling, full transactional/idempotent cloud sync, IndexedDB storage, import conflict UI, and richer quota recovery UX ([plan](docs/PLAN_MULTI_GAME_PARKING.md))

--- a/docs/AGENT_CODEBASE_OVERVIEW.md
+++ b/docs/AGENT_CODEBASE_OVERVIEW.md
@@ -311,6 +311,7 @@ flowchart LR
 | [`ACCESS_MATRIX.md`](ACCESS_MATRIX.md) / [`PLAN_ADMIN_SECURITY_ROADMAP.md`](PLAN_ADMIN_SECURITY_ROADMAP.md) | SEC-0 through SEC-6 complete; later audit event-family expansion is documented in SEC-6 |
 | [`PLAN_MULTI_GAME_PARKING.md`](PLAN_MULTI_GAME_PARKING.md) | P0–P3b shipped (incl. discard/hydrate race guards); IndexedDB + orphan ops follow-ups remain |
 | [`PLAN_SOC_5_CLOUD_SYNC_AND_FINALIZATION.md`](PLAN_SOC_5_CLOUD_SYNC_AND_FINALIZATION.md) / [`PLAN_SOC_5D_FINALIZATION_AND_RECOVERY.md`](PLAN_SOC_5D_FINALIZATION_AND_RECOVERY.md) | SOC-5 decisions and phases; SOC-5A-D transport through canonical finalization implemented |
+| [`PLAN_SOC_6_SUMMARY_AND_RELEASE.md`](PLAN_SOC_6_SUMMARY_AND_RELEASE.md) / [`PLAN_SOC_6A_SUMMARY_FOUNDATION.md`](PLAN_SOC_6A_SUMMARY_FOUNDATION.md) | Reviewed next work: five SOC-6 slices; 6A summary source and Overview plan is ready for implementation |
 | [`PLAN_BASKETBALL_EVENT_MODEL_ROADMAP.md`](PLAN_BASKETBALL_EVENT_MODEL_ROADMAP.md) | Required follow-up: BKE-0 planning after SOC-1; no BKE-1+ implementation before SOC-5 |
 
 ### Held / waiting for feedback

--- a/docs/PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md
+++ b/docs/PLAN_SOC_0_SOCCER_PRODUCT_MODEL.md
@@ -547,7 +547,7 @@ migration and conflict strategy belong in SOC-1 and SOC-5 plans.
 | SOC-3 | Full field, shot/goal/chance flows, goalkeeper links, score events, and editable timeline | Core attacking game can be tracked locally end-to-end with consistent derived totals |
 | SOC-4 | Defense, discipline/staff cards, corners, offsides, shootouts, and structured outcomes ([execution plan](PLAN_SOC_4_MATCH_EVENT_CATALOG.md)) | Core soccer event catalog is usable and editable locally |
 | SOC-5 | Cloud sync, independent recorder streams, primary resolution, finalization, and resume hardening ([detailed plan](PLAN_SOC_5_CLOUD_SYNC_AND_FINALIZATION.md)) | Complete: SOC-5A-D implement transport, recovery, recorder resolution, canonical finalization, and audited reopen |
-| SOC-6 | Soccer summaries, field maps, season aggregates, settings modules, regression hardening, and enablement | Soccer can be enabled as a supported sport without regressing basketball or parking |
+| SOC-6 | Soccer summaries, field maps, season aggregates, settings modules, regression hardening, and enablement ([execution roadmap](PLAN_SOC_6_SUMMARY_AND_RELEASE.md)) | Soccer can be enabled as a supported sport without regressing basketball or parking |
 
 Each phase receives a separate plan and one-question-at-a-time Q&A before implementation.
 Recommended names:

--- a/docs/PLAN_SOC_5_CLOUD_SYNC_AND_FINALIZATION.md
+++ b/docs/PLAN_SOC_5_CLOUD_SYNC_AND_FINALIZATION.md
@@ -11,7 +11,8 @@ revisions, records verified checkpoints, and later supports explicit conflict re
 primary-recorder selection, finalization, and audited reopen.
 
 SOC-5 does not enable Soccer in production. Summary, aggregates, settings consolidation,
-release QA, and production enablement remain SOC-6.
+release QA, and production enablement remain SOC-6; see
+[PLAN_SOC_6_SUMMARY_AND_RELEASE.md](PLAN_SOC_6_SUMMARY_AND_RELEASE.md).
 
 ## 2. Delivery Slices
 
@@ -147,5 +148,6 @@ Implemented by migration 046, `src/lib/soccer/finalization.ts`, and
 
 - Live collaborative co-editing of one stream.
 - Automatic merging of different recorders into one projection.
-- Production soccer enablement and complete summary/season UI (SOC-6).
+- Production soccer enablement and complete summary/season UI
+  ([SOC-6 roadmap](PLAN_SOC_6_SUMMARY_AND_RELEASE.md)).
 - Basketball migration to the shared event model (BKE roadmap).

--- a/docs/PLAN_SOC_6A_SUMMARY_FOUNDATION.md
+++ b/docs/PLAN_SOC_6A_SUMMARY_FOUNDATION.md
@@ -1,0 +1,342 @@
+# Plan: SOC-6A Summary Foundation
+
+Status: Product and implementation direction reviewed. Implementation is not started.
+
+Parent roadmap: [PLAN_SOC_6_SUMMARY_AND_RELEASE.md](PLAN_SOC_6_SUMMARY_AND_RELEASE.md)
+
+## 1. Goal
+
+Replace soccer's minimal development-only cloud review with one truthful summary foundation for:
+
+- the current local match;
+- a non-final selected cloud primary;
+- a finalized canonical publication.
+
+SOC-6A ships the shared route, source-authority loader, responsive shell, and complete Overview.
+Players, Timeline, Field, and Shootout become visible only when their complete implementations ship
+in SOC-6B.
+
+SOC-6A does not remove production soccer gates, publish aggregates, or add soccer settings.
+
+## 2. Reviewed Product Contract
+
+### Route and source authority
+
+- `/summary` without `gameId` reads the current local soccer `GameState`.
+- `/summary?gameId=<uuid>` reads cloud state without hydrating `GameContext`, activating a parked
+  record, or disturbing another active game.
+- A non-final cloud request reads the selected primary recorder stream.
+- A final cloud request requires a healthy active canonical publication.
+- A final game with no healthy active publication fails closed with recovery guidance. It never
+  falls back to a live recorder or a stored score-only view.
+- Legacy `/soccer/review` preserves relevant query parameters and redirects to `/summary`.
+- Tab state uses `?tab=...`; 6A accepts/defaults to `overview` and safely falls back from future
+  tab values until 6B ships them.
+
+### Overview
+
+- Keep the header compact with team names, score, match state/result, and a source-status label:
+  `Local`, `Synced Primary`, or `Canonical Final`.
+- Put date, competition, rule profile/format, primary recorder, and publication details in the
+  Overview or a compact details sheet.
+- Use explicit result context:
+  - Win, Draw, or Loss for completed normal results;
+  - AET when extra time decides the result;
+  - Pens when a shootout decides the result;
+  - Abandoned without assigning Win/Loss.
+- Compare tracked and opponent sides in compact Attack, Defense, and Discipline sections.
+- Always show key rows such as shots, shots on target, corners, fouls, and cards.
+- Hide an optional comparison row only when both sides are zero.
+- Show nonzero leaders for goals, assists, shots on target, saves, and defensive actions.
+- Preserve tied leaders and hide empty leader categories.
+- If projection diagnostics exist, show last coherent match context and diagnostics but suppress
+  potentially partial comparison totals, leaders, and finalization controls.
+
+### Navigation and actions
+
+- Cloud Games and Game Info open `/summary?gameId=...` directly.
+- Ending a local match keeps the user in Tracker.
+- The ended tracker makes `View Summary` the primary action and local `Reopen Match` secondary
+  until cloud finalization locks the game.
+- Carry a small `from` context for Tracker, Games, Game Info, or Team.
+- Use the Soccer dashboard as the safe back-navigation fallback.
+- Keep compact source/cloud status visible in the header.
+- Full Finalize/Reopen controls appear on Overview only.
+- Finalization refreshes the current Summary in place into canonical authority.
+- Reopen refreshes in place into non-final primary authority, then offers Resume/Open Tracker when
+  the user owns an editable stream.
+
+### Loading and freshness
+
+- Use stable skeleton dimensions so the score/header layout does not jump.
+- Errors identify the failed authority source and offer explicit retry.
+- Never retain a stale primary after a transition to canonical final.
+- Refresh non-final cloud summaries:
+  - on focus;
+  - through manual retry/refresh;
+  - every 30 seconds while the page remains active.
+- Canonical finals are static except for explicit refresh after Finalize/Reopen or manual retry.
+- Do not add realtime subscriptions in SOC-6A.
+
+## 3. Summary Source Model
+
+Introduce one discriminated source result consumed by presentation components:
+
+```ts
+type SoccerSummarySource =
+  | {
+      kind: 'local'
+      state: GameState
+      recorder: null
+      publication: null
+      editable: true
+    }
+  | {
+      kind: 'cloud_primary'
+      state: GameState
+      recorder: SoccerRecorderSummary
+      publication: null
+      editable: false
+    }
+  | {
+      kind: 'canonical'
+      state: GameState
+      recorder: SoccerRecorderSummary
+      publication: SoccerCanonicalPublication
+      editable: false
+    }
+```
+
+Exact naming may follow local conventions, but the source kind, authority, and editing capability
+must remain explicit. Components must not infer authority from a mixture of `gameStatus`,
+`eventStream`, and route shape.
+
+### Local source
+
+- Require current `state.sport.id === 'soccer'`.
+- Reuse the current projected state and inspection without writing or cloning it into parking.
+- Keep local completion visibly distinct from canonical finalization.
+- Do not expose Finalize until the game is cloud-bound and normal readiness checks pass.
+
+### Cloud source
+
+- Build on the SOC-5 recorder/canonical loaders.
+- Read cloud game status before choosing primary versus canonical authority.
+- For `final`, require an active canonical publication and successful deterministic rebuild.
+- For non-final, load only the selected primary into the main model.
+- Other-recorder presence remains available through the existing recorder control but never enters
+  Overview totals.
+- Do not call `openGameSnapshot`, `resumeParkedGame`, or aggregate cloud hydration.
+
+### Diagnostics
+
+- Preserve raw inspection diagnostics and last coherent projected match context.
+- Mark the summary unhealthy.
+- Suppress team comparison, leaders, and Finalize.
+- Keep retry and recorder/recovery paths reachable.
+- Never silently use partial projection totals as official-looking output.
+
+## 4. Overview Read Model
+
+Create pure helpers that turn one healthy soccer projection into display-ready values.
+
+### Result
+
+The result helper owns:
+
+- score line;
+- tracked result label;
+- regulation/extra-time/shootout decision label;
+- abandoned and suspended wording;
+- shootout score when present.
+
+It must not infer match outcome from `games.home_team_score` when canonical events are available.
+
+### Team comparison
+
+Start with event-derived core rows:
+
+| Section | Rows |
+|---|---|
+| Attack | Shots, shots on target, corners, offsides, penalty attempts/goals where present |
+| Defense | Saves, tackles won, interceptions, clearances, recoveries, blocked shots |
+| Discipline | Fouls, yellow cards, red cards, penalties won/conceded, staff cards where present |
+
+Goals remain represented by the primary score rather than duplicated as the first comparison row.
+Key rows stay visible at zero. Optional rows use the reviewed both-sides-zero suppression rule.
+
+### Leaders
+
+Leader helpers:
+
+- use tracked match participants only;
+- include every tied participant at the maximum nonzero value;
+- preserve stable match participant identity;
+- format unresolved local participants normally within the game;
+- derive assists from primary plus secondary assist totals for the combined leader;
+- define defensive leader value from the reviewed core defensive actions rather than a generic
+  weighted player score;
+- hide categories with no positive value.
+
+SOC-6A leaders are game context only and do not change `SportConfig` or aggregate stat ids.
+
+## 5. UI Structure
+
+Recommended component boundary:
+
+```text
+src/pages/SoccerSummary.tsx
+src/components/soccer-summary/
+  SoccerSummaryHeader.tsx
+  SoccerSummaryTabs.tsx
+  SoccerOverview.tsx
+  SoccerTeamComparison.tsx
+  SoccerMatchLeaders.tsx
+  SoccerMatchDetails.tsx
+src/lib/soccer/
+  summary.ts
+  summarySource.ts
+```
+
+Names may be adjusted to established local conventions. Keep data loading in the page/source
+module, pure derivation in `src/lib/soccer`, and rendering in focused components.
+
+### Responsive behavior
+
+- Use the existing narrow soccer workspace width and current shell language.
+- Keep score columns stable across long team names.
+- Tabs use stable dimensions but only Overview is visible in 6A.
+- Team comparison uses aligned tracked/opponent columns without horizontal scrolling.
+- Leader rows wrap safely for long participant names and tied leaders.
+- Do not add nested cards or a marketing-style header.
+
+## 6. Routing and Integration
+
+### `src/App.tsx`
+
+- Route active soccer `/summary` to `SoccerSummary` in development until SOC-6E removes the final
+  production gate.
+- Preserve existing basketball `GameSummary`.
+- Replace the development-only `SoccerCloudReview` route with a compatibility redirect that keeps
+  `gameId`, `tab`, `from`, and team context.
+
+### Tracker
+
+- Add `View Summary` after a match ends.
+- Navigate to `/summary?tab=overview&from=tracker`.
+- Keep local Reopen available as the secondary command when not cloud-final.
+- Do not auto-navigate when `soccer.match_ended` is appended.
+
+### Cloud Games and Game Info
+
+- Soccer final and read-only review actions navigate directly to the summary path.
+- Do not hydrate the cloud final into active local state.
+- Non-final tracking actions continue using SOC-5 resume/open behavior.
+- Read-only non-final actions use direct summary authority.
+
+### Back path
+
+Use a helper rather than scattered string construction. It should:
+
+- serialize `gameId`, `tab`, and a constrained `from` value;
+- retain `teamId` when returning to Game Info or Team;
+- reject unknown `from` values;
+- fall back to `/sport/soccer`.
+
+## 7. Finalization and Reopen
+
+Reuse `SoccerFinalizationPanel` and SOC-5 server contracts.
+
+- Show the full panel only for a healthy Overview source with a cloud game binding.
+- Continue flushing the matching primary queue before finalization.
+- After success, reload cloud authority and require canonical source before rendering the final.
+- Do not navigate away or hydrate the final into `GameContext`.
+- Reopen updates matching parked bindings through the existing GameContext helper.
+- Reload as `cloud_primary` in place.
+- Offer Resume/Open Tracker only when the role and owned-stream state permit it.
+- A manager viewing another recorder's primary remains read-only after reopen.
+
+## 8. Implementation Sequence
+
+1. Add summary path/query helpers and pure tests.
+2. Add the discriminated source loader with local, non-final primary, canonical, invalid-final,
+   and diagnostic tests.
+3. Add pure Overview result, comparison, and leader helpers with edge-case fixtures.
+4. Build the responsive Summary header and Overview components.
+5. Wire `/summary`, legacy redirect, Tracker, Cloud Games, and Game Info.
+6. Integrate Finalize/Reopen in-place refresh and non-final polling.
+7. Extend regression documentation and codebase orientation docs.
+8. Run focused tests, full tests, lint, build, and mobile/desktop screenshot checks.
+
+No Supabase migration is expected for SOC-6A. If implementation discovers a missing read contract,
+stop and amend the plan rather than widening migration 046 or adding an ad hoc direct-table query.
+
+## 9. Automated Verification
+
+Add focused coverage for:
+
+- summary query parsing and safe back-path fallback;
+- local route source with no cloud read;
+- direct non-final cloud primary source;
+- direct canonical-final source;
+- final game without active publication failing closed;
+- canonical rebuild/projection diagnostics propagating as unhealthy;
+- no cloud summary path activating or replacing a parked game;
+- result labels for regulation, extra time, shootout, suspended, and abandoned states;
+- key comparison rows staying visible at zero;
+- optional both-zero comparison rows hiding;
+- tied/nonzero leader selection and empty-category suppression;
+- source-status labels and Finalize visibility;
+- post-finalize source switching from primary to canonical;
+- post-reopen source switching from canonical to non-final primary;
+- future/invalid `tab` values safely resolving to Overview during 6A;
+- basketball `/summary` routing remaining unchanged.
+
+## 10. Manual Regression
+
+Add an SOC-6A section to `docs/REGRESSION_TESTING.md` covering:
+
+1. End a local-only match, remain in Tracker, and open editable local Summary.
+2. Reopen locally and verify Summary returns to non-final match context.
+3. Open a non-final selected primary as viewer without activating a parked game.
+4. Open a cloud final from Games while another basketball or soccer game is active.
+5. Verify the active/parked game remains unchanged.
+6. Finalize from Overview and observe in-place canonical transition.
+7. Reopen from Overview and observe in-place non-final transition.
+8. Exercise owner/admin/scorer/viewer visibility and actions.
+9. Force a missing/invalid canonical publication and verify fail-closed recovery.
+10. Force projection diagnostics and verify totals/leaders/finalization are suppressed.
+11. Verify focus/manual/30-second refresh for non-final review.
+12. Verify long names, ties, zero totals, abandoned results, extra time, and shootouts on narrow
+    mobile and desktop widths.
+13. Re-run basketball local and cloud summary entry paths.
+
+## 11. Deferred to Later SOC-6 Slices
+
+- Visible Players, Timeline, Field, and Shootout tabs: SOC-6B.
+- Summary event editing and detailed player/role views: SOC-6B.
+- Field-map normalization and filters: SOC-6B.
+- `soc_*` `SportConfig` migration and canonical aggregate RPCs: SOC-6C.
+- Account/season soccer defaults: SOC-6D.
+- Production route availability, backend capability gate, and final release matrix: SOC-6E.
+
+## 12. Reviewed Decisions
+
+The SOC-6A Q&A selected the recommended option for all 16 questions:
+
+- direct cloud summary never activates local state;
+- query-backed tab state;
+- fail-closed missing canonical final;
+- diagnostics retain context but suppress partial official totals/actions;
+- compact categorized team comparison;
+- tied nonzero leaders;
+- explicit regulation/extra-time/shootout/abandoned result labels;
+- compact global status with Overview-only finalization controls;
+- direct Games/Game Info summary entry;
+- Summary-primary ended-tracker action;
+- deterministic source-aware back navigation;
+- compact header with secondary match metadata;
+- no visible incomplete tabs in 6A;
+- stable skeletons, retries, and authority-specific errors;
+- in-place reopen transition;
+- focus/manual/30-second non-final refresh without realtime.

--- a/docs/PLAN_SOC_6A_SUMMARY_FOUNDATION.md
+++ b/docs/PLAN_SOC_6A_SUMMARY_FOUNDATION.md
@@ -23,9 +23,12 @@ SOC-6A does not remove production soccer gates, publish aggregates, or add socce
 ### Route and source authority
 
 - `/summary` without `gameId` reads the current local soccer `GameState`.
+- If that local state is bound to a cloud-final game, its `gameId` becomes the canonical lookup;
+  the retained local copy is never editable summary authority.
 - `/summary?gameId=<uuid>` reads cloud state without hydrating `GameContext`, activating a parked
   record, or disturbing another active game.
-- A non-final cloud request reads the selected primary recorder stream.
+- A non-final cloud request reads the SOC-5C effective primary recorder stream: explicit manager
+  selection when present, otherwise the existing creator-preferring provisional default.
 - A final cloud request requires a healthy active canonical publication.
 - A final game with no healthy active publication fails closed with recovery guidance. It never
   falls back to a live recorder or a stored score-only view.
@@ -89,7 +92,7 @@ type SoccerSummarySource =
       state: GameState
       recorder: null
       publication: null
-      editable: true
+      editable: boolean
     }
   | {
       kind: 'cloud_primary'
@@ -116,6 +119,10 @@ must remain explicit. Components must not infer authority from a mixture of `gam
 - Require current `state.sport.id === 'soccer'`.
 - Reuse the current projected state and inspection without writing or cloning it into parking.
 - Keep local completion visibly distinct from canonical finalization.
+- Set `editable` only while `state.cloudSync.gameStatus !== 'final'`.
+- When a bound local state is cloud-final, load canonical authority through its `gameId`. If that
+  canonical load fails, show the fail-closed final error with `editable: false`; never expose
+  local event edits or local Reopen.
 - Do not expose Finalize until the game is cloud-bound and normal readiness checks pass.
 
 ### Cloud source
@@ -123,7 +130,10 @@ must remain explicit. Components must not infer authority from a mixture of `gam
 - Build on the SOC-5 recorder/canonical loaders.
 - Read cloud game status before choosing primary versus canonical authority.
 - For `final`, require an active canonical publication and successful deterministic rebuild.
-- For non-final, load only the selected primary into the main model.
+- For non-final, resolve `effective_soccer_primary_recorder` through the existing SOC-5C contract
+  and load only that effective primary into the main model. A recorder-dialog selection may
+  change the effective primary through its authorized RPC, but an arbitrary UI stream pick never
+  feeds Overview totals.
 - Other-recorder presence remains available through the existing recorder control but never enters
   Overview totals.
 - Do not call `openGameSnapshot`, `resumeParkedGame`, or aggregate cloud hydration.
@@ -248,6 +258,9 @@ Use a helper rather than scattered string construction. It should:
 Reuse `SoccerFinalizationPanel` and SOC-5 server contracts.
 
 - Show the full panel only for a healthy Overview source with a cloud game binding.
+- A non-final source may expose Finalize through normal readiness checks. A canonical cloud-final
+  source may expose only the authorized server Reopen action; it never exposes local Reopen or
+  event mutation.
 - Continue flushing the matching primary queue before finalization.
 - After success, reload cloud authority and require canonical source before rendering the final.
 - Do not navigate away or hydrate the final into `GameContext`.
@@ -277,6 +290,7 @@ Add focused coverage for:
 
 - summary query parsing and safe back-path fallback;
 - local route source with no cloud read;
+- bound cloud-final local route resolving canonical authority and remaining read-only;
 - direct non-final cloud primary source;
 - direct canonical-final source;
 - final game without active publication failing closed;
@@ -298,18 +312,20 @@ Add an SOC-6A section to `docs/REGRESSION_TESTING.md` covering:
 
 1. End a local-only match, remain in Tracker, and open editable local Summary.
 2. Reopen locally and verify Summary returns to non-final match context.
-3. Open a non-final selected primary as viewer without activating a parked game.
-4. Open a cloud final from Games while another basketball or soccer game is active.
-5. Verify the active/parked game remains unchanged.
-6. Finalize from Overview and observe in-place canonical transition.
-7. Reopen from Overview and observe in-place non-final transition.
-8. Exercise owner/admin/scorer/viewer visibility and actions.
-9. Force a missing/invalid canonical publication and verify fail-closed recovery.
-10. Force projection diagnostics and verify totals/leaders/finalization are suppressed.
-11. Verify focus/manual/30-second refresh for non-final review.
-12. Verify long names, ties, zero totals, abandoned results, extra time, and shootouts on narrow
+3. Retain a local cloud-final binding and verify `/summary` loads canonical authority without
+   local edit/Reopen controls.
+4. Open a non-final effective primary as viewer without activating a parked game.
+5. Open a cloud final from Games while another basketball or soccer game is active.
+6. Verify the active/parked game remains unchanged.
+7. Finalize from Overview and observe in-place canonical transition.
+8. Reopen from Overview and observe in-place non-final transition.
+9. Exercise owner/admin/scorer/viewer visibility and actions.
+10. Force a missing/invalid canonical publication and verify fail-closed recovery.
+11. Force projection diagnostics and verify totals/leaders/finalization are suppressed.
+12. Verify focus/manual/30-second refresh for non-final review.
+13. Verify long names, ties, zero totals, abandoned results, extra time, and shootouts on narrow
     mobile and desktop widths.
-13. Re-run basketball local and cloud summary entry paths.
+14. Re-run basketball local and cloud summary entry paths.
 
 ## 11. Deferred to Later SOC-6 Slices
 

--- a/docs/PLAN_SOC_6_SUMMARY_AND_RELEASE.md
+++ b/docs/PLAN_SOC_6_SUMMARY_AND_RELEASE.md
@@ -1,0 +1,280 @@
+# Plan: SOC-6 Summary and Release
+
+Status: Product direction reviewed. Implementation is not started.
+
+## 1. Goal
+
+Turn the development-only soccer workspace into an opt-in supported sport with complete match
+review, player aggregates, account-backed defaults, and a release-grade regression boundary.
+
+SOC-6 must preserve the event model established in SOC-1 through SOC-5:
+
+- raw soccer events and locked match setup remain the source of truth;
+- finalized cloud review uses the active canonical publication;
+- independent recorder streams never blend automatically;
+- finalized corrections require audited reopen and republish;
+- basketball aggregate sync, summaries, and historical games remain unchanged;
+- local-only soccer remains usable without Supabase.
+
+The broader application reskin is not part of SOC-6.
+
+## 2. Current Baseline
+
+SOC-1 through SOC-5D are implemented. The codebase already has:
+
+- deterministic soccer projection for match state, score, player totals, side totals, minutes,
+  lineup/role intervals, discipline, and shootouts;
+- local parking plus recorder-owned cloud event transport;
+- canonical publication, final score derivation, manager finalization, and audited reopen;
+- a development-only live tracker and minimal cloud primary review;
+- generic basketball-era summary, season, team, player, career, and tournament routes.
+
+Important implementation drift to resolve:
+
+- `src/config/sports.ts` still exposes the old limited soccer stat ids such as `s_goal`;
+- the event projector emits the richer canonical `soc_*` stat family;
+- generic aggregate RPCs read `game_stats`, while soccer authority lives in canonical event
+  publications;
+- `/summary` redirects soccer back to the tracker and `/soccer/review` is development-only;
+- soccer settings do not yet exist and current app settings are device-local;
+- production route and sport-availability gates still reject soccer.
+
+SOC-6 must reconcile these surfaces without copying event-derived totals into an unverified
+client-authored authority table.
+
+## 3. Delivery Slices
+
+### SOC-6A: Summary foundation and overview
+
+Detailed plan:
+[PLAN_SOC_6A_SUMMARY_FOUNDATION.md](PLAN_SOC_6A_SUMMARY_FOUNDATION.md)
+
+Build the shared soccer summary read model and first production-quality summary surface.
+
+- Add one `SoccerSummary` experience at `/summary`.
+- Support current local state and direct cloud loading through `?gameId=`.
+- Redirect legacy `/soccer/review` links to the shared summary.
+- Resolve authority explicitly:
+  - current local recorder state for local/non-final owned work;
+  - selected cloud primary for non-final read-only review;
+  - active canonical publication for a finalized game.
+- Add the summary shell with `Overview`, `Players`, `Timeline`, and `Field` tabs.
+- Add a conditional `Shootout` tab only when a shootout exists.
+- Ship Overview with score/result, regulation or extra-time decision context, conditional
+  shootout result, side-by-side team totals, and compact leaders.
+- Keep the user in the tracker after match end and add an explicit Summary action.
+- Keep finalization/reopen access available from the appropriate summary state.
+
+Exit condition: a local ended match, a non-final cloud primary, and a canonical final all open
+the same truthful summary shell with correct edit/read-only behavior.
+
+### SOC-6B: Detailed match review
+
+Complete player, Timeline, field-map, and shootout review.
+
+- Player table keeps identity, lineup status, role, and minutes fixed while category tabs switch
+  Attack, Defense, Discipline, and Goalkeeping columns.
+- Include every match participant; unused substitutes display `DNP`.
+- Player detail exposes full match totals and role/on-field intervals.
+- Derive rates at read time:
+  - shot accuracy;
+  - goal conversion;
+  - tackle win rate;
+  - goalkeeper save percentage.
+- Derive team and goalkeeper clean-sheet context. Every goalkeeper who played and conceded no
+  goal during their own on-field interval receives credit; multiple qualifying keepers are
+  labeled as a shared clean sheet.
+- Timeline defaults oldest-first with period headings and family filters.
+- Local/current-recorder non-final review reuses revision editing.
+- Remote-primary and canonical-final review stay read-only and offer Resume or Reopen actions
+  when authorized.
+- Field maps show all located event families using side colors and event-specific shapes.
+- Filter maps by side, participant, family, and period.
+- Normalize attacking direction by default and provide original match orientation as a toggle.
+- Keep unlocated events in totals and Timeline, display an unknown-location count, and omit only
+  their field marker.
+- Keep shootout presentation separate from normal score and player goal totals.
+
+Exit condition: the complete four-view summary plus conditional shootout review works on mobile
+for local, primary-cloud, and canonical-final sources.
+
+### SOC-6C: Canonical aggregate projection
+
+Feed existing stat destinations from canonical soccer sources without introducing a second
+unverified authority.
+
+- Make `soc_*` the canonical soccer stat-id family in `SportConfig`.
+- Add only a narrow compatibility map for pre-release development data using old soccer ids.
+- Add RLS-scoped, paginated RPCs that return the active canonical source needed for authorized
+  season/team/player/career/tournament projection.
+- Run the existing deterministic TypeScript projector over canonical setup/events and aggregate
+  the resulting totals in the client.
+- Do not write client-supplied canonical soccer totals into `game_stats`.
+- Reuse existing Season, Team, Player, Career, and Tournament route shells with soccer-specific
+  categories, sorting, formatting, and empty states.
+- Include only completed active canonical publications in aggregates.
+- Exclude abandoned matches from first-release aggregates while retaining their summaries.
+- Include only participants resolved to stable cloud players in cross-game player totals.
+- Surface unresolved-participant exclusion counts to managers.
+- Keep shootout statistics game-scoped in the first release.
+- Sum raw numerators/denominators before deriving aggregate percentages.
+- Defer per-90 and per-standard-match rates.
+- Treat an invalidated publication as immediately absent; a replacement publication becomes the
+  only aggregate source.
+
+Exit condition: finalized completed soccer matches contribute deterministic player totals to all
+existing aggregate destinations, while abandoned, invalidated, unresolved, and shootout data
+follow the reviewed exclusion rules.
+
+### SOC-6D: Soccer settings and default hierarchy
+
+Add grouped soccer configuration without turning every stat into a toggle.
+
+- Add account-synced soccer defaults for authenticated users.
+- Keep a local cache and full local-only fallback when Supabase is unavailable.
+- Resolve defaults in this order:
+  1. personal account defaults;
+  2. season/team soccer configuration;
+  3. per-match overrides.
+- Snapshot the resolved setup at kickoff. Later settings changes never rewrite existing games.
+- Configure core rule/display defaults:
+  - count-up or countdown display;
+  - period count and duration;
+  - on-field player count;
+  - return substitutions;
+  - extra-time and shootout defaults;
+  - useful field-orientation preference.
+- Keep every implemented core event family available.
+- Add optional module toggles only when those advanced modules actually ship.
+- Soccer is disabled by default for normal discovery.
+- Disabling Soccer blocks new games and removes it from normal sport selection, but existing
+  games, summaries, teams, and statistics remain accessible.
+
+Exit condition: account defaults follow a signed-in user across devices, local-only defaults still
+work, season/game overrides resolve predictably, and setup snapshots remain immutable.
+
+### SOC-6E: Release hardening and enablement
+
+Remove development gates only after the complete release boundary passes.
+
+- Replace `import.meta.env.DEV` soccer routing with normal sport availability checks.
+- Make Soccer opt-in under App settings rather than globally enabled.
+- For authenticated cloud creation, verify required soccer backend capabilities before starting a
+  new cloud game.
+- Continue allowing local-only soccer when Supabase is absent.
+- Keep existing historical access when Soccer is disabled.
+- Consolidate the full soccer release matrix in `docs/REGRESSION_TESTING.md`.
+- Cover mobile layout, local-only play, offline parking, reconnect, multiple simultaneous sports,
+  independent recorders, viewer/scorer/manager permissions, conflicts, finalization/reopen,
+  summary sources, field maps, settings hierarchy, aggregates, and migration failure states.
+- Re-run basketball setup, tracker, court capture, parking, cloud finalization, summary,
+  corrections, and aggregate regression paths.
+- Deliver responsive functional polish consistent with the current application shell. Do not
+  block release on the future application-wide reskin.
+
+Exit condition: CI and the complete manual release matrix pass against an environment with all
+required migrations, and production builds expose opt-in Soccer without weakening other sports.
+
+## 4. Authority and Editing Matrix
+
+| Summary source | Display authority | Editing |
+|---|---|---|
+| Local-only current match | Current healthy local event stream | Current recorder may revise |
+| Bound current recorder | Current healthy local stream until synced/finalized | Current recorder may revise |
+| Non-final remote cloud game | Selected primary cloud stream | Read-only; resume owned stream to edit |
+| Final cloud game | Active canonical setup/events | Read-only; manager must reopen |
+| Reopened cloud game | Live selected primary after publication invalidation | Recorder revision flow resumes |
+
+Local match completion is not canonical finalization. It receives a clearly labeled local summary
+and remains editable. If it later binds to cloud, normal sync and canonical finalization are
+required before it can enter cloud aggregates.
+
+## 5. Summary Product Contract
+
+- Tabs are `Overview`, `Players`, `Timeline`, and `Field`.
+- `Shootout` appears only when applicable.
+- Staff/team discipline appears in team comparison and Timeline, never in player statistics.
+- Opponent team totals appear when derivable even when individual opponent players are unknown.
+- Unknown-location events remain statistically authoritative.
+- Rates never display when their denominator is zero.
+- Minutes retain second precision in the model and use an appropriate `MM:SS` or
+  hours/minutes display for the surface.
+- Finalized canonical corrections always require reasoned reopen and a new publication.
+
+## 6. Aggregate Safety Contract
+
+- Active canonical setup/events, not `game_stats`, are soccer aggregate authority.
+- RPCs enforce existing game/team read access and expose only active authorized publications.
+- Client projection uses the same versioned registry/projector as game review.
+- Projection diagnostics exclude that publication from aggregate totals and surface an error;
+  they never silently publish partial totals.
+- Name or jersey similarity never merges unresolved participants across games.
+- Aggregate percentage formulas use combined totals, not averages of per-game percentages.
+- Caching is an optimization only and cannot become an independent source of truth.
+
+## 7. Settings and Availability Contract
+
+- Account-backed defaults use a versioned schema and deep-merge missing keys.
+- Local settings remain usable offline and without authentication.
+- Server state wins after authenticated reconciliation; unsynced local changes require a
+  deterministic last-write/version rule defined in SOC-6D.
+- Season/team configuration is manager-owned.
+- Per-match overrides are explicit at setup and become part of the immutable match snapshot.
+- Disabling Soccer never hides or corrupts historical data.
+- A missing backend capability blocks new cloud soccer creation with a useful error, not the
+  local workspace or historical read-only access.
+
+## 8. Reviewed Decisions
+
+The SOC-6 Q&A selected the recommended option for all 32 high-level questions:
+
+- five focused implementation slices;
+- player aggregates in first release, with standings deferred;
+- reopen-before-correction for canonical finals;
+- opt-in production availability;
+- one local/cloud summary route and four core tabs;
+- explicit post-match Summary navigation;
+- compact overview with team comparison and leaders;
+- category-based player tables including `DNP`;
+- read-time rates and shared goalkeeper clean-sheet credit;
+- all-family field maps with normalized direction and unknown-location accounting;
+- oldest-first review Timeline with authority-aware editing;
+- canonical source projection rather than client-authored aggregate rows;
+- stable-player-only cross-game totals and canonical `soc_*` ids;
+- account-backed defaults with season/game override hierarchy;
+- core event families always available;
+- historical access after disabling Soccer;
+- completed-only first-release aggregates, no shootout season totals, and no per-90 rates;
+- selected-primary non-final review with optional other streams;
+- truthful editable local summaries before cloud finalization;
+- backend capability checks for cloud creation;
+- functional polish without a broad reskin;
+- automated plus complete manual regression before production enablement.
+
+## 9. Deferred Beyond SOC-6
+
+- Team standings, configurable points, and competition tiebreakers.
+- Per-90 and per-standard-match rates.
+- Season shootout leaderboards.
+- Automatic aggregation of unresolved participants by name or jersey.
+- Advanced capture modules listed in SOC-0.
+- Collaborative editing of one recorder stream.
+- Server/materialized aggregate caches unless measured performance requires them.
+- Broader application reskin.
+- Basketball migration to the shared event model; see the BKE roadmap.
+
+## 10. Planning Handoff
+
+Each slice receives its own implementation plan and focused Q&A before code changes:
+
+```text
+docs/PLAN_SOC_6A_SUMMARY_FOUNDATION.md
+docs/PLAN_SOC_6B_DETAILED_MATCH_REVIEW.md
+docs/PLAN_SOC_6C_CANONICAL_AGGREGATES.md
+docs/PLAN_SOC_6D_SOCCER_SETTINGS.md
+docs/PLAN_SOC_6E_RELEASE_HARDENING.md
+```
+
+Phase planning should settle component boundaries, exact stat tables, RPC payload/pagination,
+settings reconciliation, migration numbering, and test fixtures without reopening the reviewed
+high-level product decisions.

--- a/docs/PLAN_SOC_6_SUMMARY_AND_RELEASE.md
+++ b/docs/PLAN_SOC_6_SUMMARY_AND_RELEASE.md
@@ -55,18 +55,19 @@ Build the shared soccer summary read model and first production-quality summary 
 - Support current local state and direct cloud loading through `?gameId=`.
 - Redirect legacy `/soccer/review` links to the shared summary.
 - Resolve authority explicitly:
-  - current local recorder state for local/non-final owned work;
-  - selected cloud primary for non-final read-only review;
+  - current local recorder state for local/non-final owned work, never a cloud-final local copy;
+  - the SOC-5C effective primary for non-final read-only review;
   - active canonical publication for a finalized game.
-- Add the summary shell with `Overview`, `Players`, `Timeline`, and `Field` tabs.
-- Add a conditional `Shootout` tab only when a shootout exists.
+- Ship an Overview-only shell in 6A while reserving query-safe future tab ids internally.
+- Do not show disabled or incomplete Players, Timeline, Field, or Shootout tabs; 6B adds them only
+  when their complete views ship.
 - Ship Overview with score/result, regulation or extra-time decision context, conditional
   shootout result, side-by-side team totals, and compact leaders.
 - Keep the user in the tracker after match end and add an explicit Summary action.
 - Keep finalization/reopen access available from the appropriate summary state.
 
-Exit condition: a local ended match, a non-final cloud primary, and a canonical final all open
-the same truthful summary shell with correct edit/read-only behavior.
+Exit condition: a local ended match, the non-final SOC-5C effective primary, and a canonical final
+all open the same truthful Overview with correct edit/read-only behavior and no incomplete tabs.
 
 ### SOC-6B: Detailed match review
 
@@ -84,6 +85,8 @@ Complete player, Timeline, field-map, and shootout review.
 - Derive team and goalkeeper clean-sheet context. Every goalkeeper who played and conceded no
   goal during their own on-field interval receives credit; multiple qualifying keepers are
   labeled as a shared clean sheet.
+- The 6B phase Q&A must settle interval boundaries, own-goal treatment, and shootout exclusion
+  before clean-sheet derivation is implemented.
 - Timeline defaults oldest-first with period headings and family filters.
 - Local/current-recorder non-final review reuses revision editing.
 - Remote-primary and canonical-final review stay read-only and offer Resume or Reopen actions
@@ -107,6 +110,8 @@ unverified authority.
 - Add only a narrow compatibility map for pre-release development data using old soccer ids.
 - Add RLS-scoped, paginated RPCs that return the active canonical source needed for authorized
   season/team/player/career/tournament projection.
+- Instrument publication count, event count, payload bytes, and projection time during 6C; measure
+  the paginated client path before proposing any materialized cache.
 - Run the existing deterministic TypeScript projector over canonical setup/events and aggregate
   the resulting totals in the client.
 - Do not write client-supplied canonical soccer totals into `game_stats`.
@@ -180,8 +185,9 @@ required migrations, and production builds expose opt-in Soccer without weakenin
 | Summary source | Display authority | Editing |
 |---|---|---|
 | Local-only current match | Current healthy local event stream | Current recorder may revise |
-| Bound current recorder | Current healthy local stream until synced/finalized | Current recorder may revise |
-| Non-final remote cloud game | Selected primary cloud stream | Read-only; resume owned stream to edit |
+| Bound non-final current recorder | Current healthy local stream | Current recorder may revise |
+| Locally retained cloud-final binding | Active canonical setup/events via its cloud game id | Read-only; never offer local reopen |
+| Non-final remote cloud game | SOC-5C effective primary cloud stream | Read-only; resume owned stream to edit |
 | Final cloud game | Active canonical setup/events | Read-only; manager must reopen |
 | Reopened cloud game | Live selected primary after publication invalidation | Recorder revision flow resumes |
 


### PR DESCRIPTION
## Summary

- add the reviewed five-slice SOC-6 roadmap covering summary, detailed match review, canonical aggregate projection, soccer settings, and production release
- add the detailed SOC-6A summary foundation plan from the 16-question phase Q&A
- document source authority, editing rules, Overview behavior, routing, finalization transitions, implementation boundaries, and regression coverage
- link the new plans from README, SOC-0, and the agent codebase overview

## Validation

- `git diff --check`
- verified all relative links in the new planning documents resolve

## Scope

Documentation only. No application or migration behavior changes.